### PR TITLE
Rename depth_raw to depth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "depthai-cpp/shared/depthai-shared"]
 	path = shared/depthai-shared
-	url = https://github.com/luxonis/depthai-shared.git
+	url = ../depthai-shared.git

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "6aff98a0227f54985d2bb7468693b8b6f63bcdbb")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "2f9c918bc823a0fbeb4ce54696966045ca7cb13c")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -947,7 +947,7 @@ std::shared_ptr<CNNHostPipeline> Device::create_pipeline(
                 if (!stream.data_type.empty()) { obj["data_type"] = stream.data_type; };
                 if (0.f != stream.max_fps)     { obj["max_fps"]   = stream.max_fps;   };
 
-                if (stream.name == "depth_raw"){obj["data_type"] = "uint16"; }
+                if (stream.name == "depth"){obj["data_type"] = "uint16"; }
 
                 json_config_obj["_pipeline"]["_streams"].push_back(obj);
                 pipeline_device_streams.push_back(stream.name);

--- a/src/disparity_stream_post_processor.cpp
+++ b/src/disparity_stream_post_processor.cpp
@@ -48,7 +48,7 @@ void DisparityStreamPostProcessor::prepareDepthColorAndNotifyObservers(
         depth[j+1] = c_disp_to_color[disp][1];
         depth[j+2] = c_disp_to_color[disp][2];
     }
-    FrameMetadata *m = (FrameMetadata *)(depth_raw.data() + depth_raw.size() - sizeof(FrameMetadata));
+    FrameMetadata *m = (FrameMetadata *)(depth.data() + depth.size() - sizeof(FrameMetadata));
     memcpy(m, disp_uc + data.size - sizeof(FrameMetadata), sizeof(FrameMetadata));
     m->frameSize = 3 * (data.size - sizeof(FrameMetadata));
 

--- a/src/disparity_stream_post_processor.cpp
+++ b/src/disparity_stream_post_processor.cpp
@@ -38,15 +38,15 @@ void DisparityStreamPostProcessor::prepareDepthColorAndNotifyObservers(
             data_info.dimensions[0] * data_info.dimensions[1] * 3 + sizeof(FrameMetadata),
             {data_info.dimensions[0], data_info.dimensions[1], 3});
 
-    std::vector<unsigned char> depth_raw(depth_si.size);
+    std::vector<unsigned char> depth(depth_si.size);
     const unsigned char* disp_uc = (const unsigned char*) data.data;
 
     for (int i = 0, j = 0; i < data.size - sizeof(FrameMetadata); ++i, j+=3)
     {
         const unsigned char &disp = *(disp_uc + i);
-        depth_raw[j  ] = c_disp_to_color[disp][0];
-        depth_raw[j+1] = c_disp_to_color[disp][1];
-        depth_raw[j+2] = c_disp_to_color[disp][2];
+        depth[j  ] = c_disp_to_color[disp][0];
+        depth[j+1] = c_disp_to_color[disp][1];
+        depth[j+2] = c_disp_to_color[disp][2];
     }
     FrameMetadata *m = (FrameMetadata *)(depth_raw.data() + depth_raw.size() - sizeof(FrameMetadata));
     memcpy(m, disp_uc + data.size - sizeof(FrameMetadata), sizeof(FrameMetadata));
@@ -54,8 +54,8 @@ void DisparityStreamPostProcessor::prepareDepthColorAndNotifyObservers(
 
     StreamData depth_d;
     depth_d.packet_number = data.packet_number;
-    depth_d.data = depth_raw.data();
-    depth_d.size = depth_raw.size();
+    depth_d.data = depth.data();
+    depth_d.size = depth.size();
 
     notifyObservers(depth_si, depth_d);
 }


### PR DESCRIPTION
Stream `depth_raw` has been renamed to `depth` to match naming convention with other streams.

Git submodule path was changed to relative to inherit root repo's SSH/HTTPS url.

`git submodule sync --recursive`
is suggested.