### PR TITLE
Option to run NN on stereo rectified streams

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "7860565c090169995160ad19b69f36c34667e21b")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "1bd254499ebd4d54cfd247aa6f15b8379d458aa4")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Device side changelog:
- `["ai"]["camera_input"]` in `config_h2d` supports 3 new options: `rectified_left`, `rectified_right`, `rectified_left_right`
- fixed an artifact potentially shown on the first line of the frame, left side for `previewout-left`, `previewout-right`, `rectified_left`, `rectified_right`.
- fill metadata field instanceNum (camera index: rgb/left/right) for `rectified_left`, `rectified_right`, `disparity`, `depth`.