### PR TITLE
Remove depth confidence threshold

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "4311773fde2eab53793380420f88c7ac6b46fbcb")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "f0c2d772db713daa8c55db9850669091edc0a78f")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/host_pipeline_config.hpp
+++ b/include/depthai/pipeline/host_pipeline_config.hpp
@@ -26,7 +26,6 @@ struct HostPipelineConfig
         std::string type;
         float       padding_factor = 0.3f;
         float       depth_limit_m = 10.0f;
-        float       confidence_threshold = 0.5f;
         uint8_t     median_kernel_size = 7;
         bool        lr_check = false;
         struct WarpRectify {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -867,7 +867,6 @@ std::shared_ptr<CNNHostPipeline> Device::create_pipeline(
         };
         json_config_obj["depth"]["padding_factor"] = config.depth.padding_factor;
         json_config_obj["depth"]["depth_limit_mm"] = (int)(config.depth.depth_limit_m * 1000);
-        json_config_obj["depth"]["confidence_threshold"] = config.depth.confidence_threshold;
         json_config_obj["depth"]["median_kernel_size"] = config.depth.median_kernel_size;
         json_config_obj["depth"]["lr_check"] = config.depth.lr_check;
         json_config_obj["depth"]["warp_rectify"] = {

--- a/src/pipeline/host_pipeline_config.cpp
+++ b/src/pipeline/host_pipeline_config.cpp
@@ -105,6 +105,11 @@ bool HostPipelineConfig::initWithJSON(const nlohmann::json &json_obj)
                 depth.depth_limit_m = depth_obj.at("depth_limit_m").get<float>();
             }
 
+            if (depth_obj.contains("confidence_threshold"))
+            {
+                throw std::runtime_error("Field \"confidence_threshold\" for depth has been moved to network config. See https://docs.luxonis.com/api/#creating-blob-configuration-file");
+            }
+
             if (depth_obj.contains("median_kernel_size"))
             {
                 depth.median_kernel_size = depth_obj.at("median_kernel_size").get<uint8_t>();

--- a/src/pipeline/host_pipeline_config.cpp
+++ b/src/pipeline/host_pipeline_config.cpp
@@ -105,17 +105,6 @@ bool HostPipelineConfig::initWithJSON(const nlohmann::json &json_obj)
                 depth.depth_limit_m = depth_obj.at("depth_limit_m").get<float>();
             }
 
-            if (depth_obj.contains("confidence_threshold"))
-            {
-                depth.confidence_threshold = depth_obj.at("confidence_threshold").get<float>();
-
-                if (depth.confidence_threshold < 0.f || depth.confidence_threshold > 1.f)
-                {
-                    std::cerr << WARNING "confidence_threshold should be in the range [0 .. 1]\n" ENDC;
-                    break;
-                }
-            }
-
             if (depth_obj.contains("median_kernel_size"))
             {
                 depth.median_kernel_size = depth_obj.at("median_kernel_size").get<uint8_t>();


### PR DESCRIPTION
Removed `depth_confidence_threshold` since there is no reason to have both for decoding and depth.