### PR TITLE
Gen1 updates: FrameMetadata all streams, sync seqNo, IMX477 RPi HQcam

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "cc7b6c4296bd31e30dae65e4d5f1552947750dba")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "f9df8e9f3115e796682ff3499068b04f782f888f")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "2f49dc5f43e668af0c70fe683367b390fc5a6abb")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "cc7b6c4296bd31e30dae65e4d5f1552947750dba")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -13,9 +13,9 @@ hunter_config(
 
 hunter_config(
     XLink
-    VERSION "luxonis-2020.2"
-    URL "https://github.com/luxonis/XLink/archive/3f8c17eef960d0a76fcb8f78581407d74dade2c7.tar.gz"
-    SHA1 "00494618711aa285282af1c9937e39f42e568680"
+    VERSION "luxonis-2020.2-fix_boot_multiple_512-0"
+    URL "https://github.com/luxonis/XLink/archive/17bf859bc95589b2ee616d2ec32e97a239ac3210.zip"
+    SHA1 "cfbfdde1cdd9eedb1941ddc91c7465f4abfd7235"
     CMAKE_ARGS
         CMAKE_POSITION_INDEPENDENT_CODE=ON
 )

--- a/include/depthai/pipeline/host_pipeline_config.hpp
+++ b/include/depthai/pipeline/host_pipeline_config.hpp
@@ -88,6 +88,7 @@ struct HostPipelineConfig
     {
         bool sync_video_meta_streams = false;
         bool sync_sequence_numbers = false;
+        uint32_t usb_chunk_KiB = 64; // Increase to improve throughput, 0 to disable chunking
     } app_config;
 
     bool initWithJSON(const nlohmann::json &json_obj);

--- a/include/depthai/pipeline/host_pipeline_config.hpp
+++ b/include/depthai/pipeline/host_pipeline_config.hpp
@@ -87,6 +87,7 @@ struct HostPipelineConfig
     struct AppConfig
     {
         bool sync_video_meta_streams = false;
+        bool sync_sequence_numbers = false;
     } app_config;
 
     bool initWithJSON(const nlohmann::json &json_obj);

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -920,6 +920,7 @@ std::shared_ptr<CNNHostPipeline> Device::create_pipeline(
         json_config_obj["ot"]["confidence_threshold"] = config.ot.confidence_threshold;
 
         json_config_obj["app"]["sync_video_meta_streams"] = config.app_config.sync_video_meta_streams;
+        json_config_obj["app"]["sync_sequence_numbers"] = config.app_config.sync_sequence_numbers;
 
         bool add_disparity_post_processing_color = false;
         bool temp_measurement = false;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -921,6 +921,7 @@ std::shared_ptr<CNNHostPipeline> Device::create_pipeline(
 
         json_config_obj["app"]["sync_video_meta_streams"] = config.app_config.sync_video_meta_streams;
         json_config_obj["app"]["sync_sequence_numbers"] = config.app_config.sync_sequence_numbers;
+        json_config_obj["app"]["usb_chunk_KiB"] = config.app_config.usb_chunk_KiB;
 
         bool add_disparity_post_processing_color = false;
         bool temp_measurement = false;

--- a/src/disparity_stream_post_processor.cpp
+++ b/src/disparity_stream_post_processor.cpp
@@ -51,6 +51,7 @@ void DisparityStreamPostProcessor::prepareDepthColorAndNotifyObservers(
     FrameMetadata *m = (FrameMetadata *)(depth.data() + depth.size() - sizeof(FrameMetadata));
     memcpy(m, disp_uc + data.size - sizeof(FrameMetadata), sizeof(FrameMetadata));
     m->frameSize = 3 * (data.size - sizeof(FrameMetadata));
+    m->spec.bytesPP = 3;
 
     StreamData depth_d;
     depth_d.packet_number = data.packet_number;

--- a/src/pipeline/host_pipeline_config.cpp
+++ b/src/pipeline/host_pipeline_config.cpp
@@ -388,6 +388,11 @@ bool HostPipelineConfig::initWithJSON(const nlohmann::json &json_obj)
             {
                 app_config.sync_video_meta_streams = app_conf_obj.at("sync_video_meta_streams").get<bool>();
             }
+
+            if (app_conf_obj.contains("sync_sequence_numbers"))
+            {
+                app_config.sync_sequence_numbers = app_conf_obj.at("sync_sequence_numbers").get<bool>();
+            }
         }
 
 

--- a/src/pipeline/host_pipeline_config.cpp
+++ b/src/pipeline/host_pipeline_config.cpp
@@ -393,6 +393,11 @@ bool HostPipelineConfig::initWithJSON(const nlohmann::json &json_obj)
             {
                 app_config.sync_sequence_numbers = app_conf_obj.at("sync_sequence_numbers").get<bool>();
             }
+
+            if (app_conf_obj.contains("usb_chunk_KiB"))
+            {
+                app_config.usb_chunk_KiB = app_conf_obj.at("usb_chunk_KiB").get<uint32_t>();
+            }
         }
 
 


### PR DESCRIPTION
Add an experimental option to synchronize the sequence numbers of RGB and Mono cameras MIPI source, and thus all packets should have `seqNo` in sync. RGB camera starts first and will stream frames. After several frames when the Mono camera start too, their `seqNo` will not begin with zero, but start from the current RGB `seqNo`.

Other device side changes:
- FrameMetadata is being populated and sent out for all streams. Previously it was missing for `jpegout, video, object_tracker`. The metadata for the new and existing streams should have all fields properly initialized.
- Fix device crash in some scenarios when too many streams were enabled.
- Add support for IMX477 RPi HQ camera. Allow operation with missing EEPROM / VCM ICs for the RGB cameras modules (IMX378 or IMX477).

Related PR: https://github.com/luxonis/depthai-shared/pull/8