### PR TITLE
Fix crash on 2nd device object delete

### DIFF
--- a/include/depthai/device.hpp
+++ b/include/depthai/device.hpp
@@ -106,7 +106,7 @@ private:
     uint8_t* binary_backup;
     long binary_size_backup;
 
-    int wdog_thread_alive = 1;
+    int wdog_thread_alive = 0;
 
     std::thread wd_thread;
     std::chrono::milliseconds wd_timeout = std::chrono::milliseconds(5000);

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -150,12 +150,10 @@ void Device::wdog_thread(std::chrono::milliseconds& wd_timeout)
 
 int Device::wdog_start(void)
 {
-    static int once = 1;
-    if(once)
+    if(!wdog_thread_alive)
     {
         wdog_thread_alive = 1;
         wd_thread = std::thread(&Device::wdog_thread, this, std::ref(wd_timeout)); 
-        once = 0;
     }
     return 0;
 }


### PR DESCRIPTION
... due to watchdog thread not recreated.
Now running create+delete in a loop should work fine.

Should fix issue https://github.com/luxonis/depthai/issues/259