### PR TITLE
Change to relative submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "shared/depthai-shared"]
 	path = shared/depthai-shared
-	url = https://github.com/luxonis/depthai-shared.git
+	url = ../depthai-shared.git
 [submodule "shared/depthai-bootloader-shared"]
 	path = shared/depthai-bootloader-shared
-	url = https://github.com/luxonis/depthai-bootloader-shared.git
+	url = ../depthai-bootloader-shared.git


### PR DESCRIPTION
After switching from `develop` to `gen2` I got the following error : 
`fatal: not a git repository: shared/depthai-shared/../../../.git/modules/depthai-core/modules/shared/depthai-shared`

Deleting `shared` folder + switching to relative submodule path and running `git submodule sync` resolved the issue.
