### PR TITLE
Fix libarchive build with CMake version < 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ project(${TARGET_NAME} VERSION "0.0.2" LANGUAGES CXX C)
 
 # Set policies
 # CMP0074 dictates that find_package searches environment variable "[packageName]_ROOT" along with regular variable [packageName]_ROOT
-cmake_policy(SET CMP0074 NEW)
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW) # Only introduced in 3.12
+endif()
 
 # Set to export compile commands for tools like clang-tidy and format
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -30,9 +30,9 @@ hunter_config(
 # libarchive, luxonis fork
 hunter_config(
     libarchive
-    VERSION "3.4.2-p1"
-    URL "https://github.com/luxonis/libarchive/archive/28db49513446c442fb9a97776c71f97456052eaa.tar.gz"
-    SHA1 "eeabd2153101698e63387e4537d88bcb4e1a44eb"
+    VERSION "3.4.2-p2"
+    URL "https://github.com/luxonis/libarchive/archive/cf2caf0588fc5e2af22cae37027d3ff6902e096f.tar.gz"
+    SHA1 "e99477d32ce14292fe652dc5f4f460d3af8fbc93"
     CMAKE_ARGS
         ENABLE_ACL=OFF                                           
         ENABLE_BZip2=OFF                                          

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -30,9 +30,9 @@ hunter_config(
 # libarchive, luxonis fork
 hunter_config(
     libarchive
-    VERSION "3.4.2-p0"    
-    URL "https://github.com/luxonis/libarchive/archive/e6c4150eb4f08e98e2629aa51f52d2d0c5b0f8d4.tar.gz"
-    SHA1 "AEA3E76511A7BECD2173B14AC1322626E23A1B9B"
+    VERSION "3.4.2-p1"
+    URL "https://github.com/luxonis/libarchive/archive/28db49513446c442fb9a97776c71f97456052eaa.tar.gz"
+    SHA1 "eeabd2153101698e63387e4537d88bcb4e1a44eb"
     CMAKE_ARGS
         ENABLE_ACL=OFF                                           
         ENABLE_BZip2=OFF                                          


### PR DESCRIPTION
Ubuntu18.04 ships with CMake 3.10.
`libarchive` version changed here: https://github.com/luxonis/libarchive/commit/28db49513446c442fb9a97776c71f97456052eaa