### PR TITLE
ImageManip: rotated/arbitrary cropping, add camera controls

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "cc6f54c05d5448c8de5c082608a2f80ca6474b13")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "c1d766103180bf0e8893b07314ec3382e054f6e8")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "891b6a4f202251d14fc3d9f01383633c17fc91d6")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a10606cda3fbb2a76043228d3cc96eec8b19ab54")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "bb7bda62770e68d9e6de69ce2801ab87d9fa1047")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "0f8760df31f4d37efcd8d6fc210f1a4215221de3")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "ed1af895b62201d19882c406e673dc9c8ffa0e28")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "891b6a4f202251d14fc3d9f01383633c17fc91d6")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "94cbb11f942f7979a76ced55edc4758868509ee2")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "eb4029fe94fd956e30c7f66f31925d39bf92190d")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "c1d766103180bf0e8893b07314ec3382e054f6e8")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "bb7bda62770e68d9e6de69ce2801ab87d9fa1047")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "eb4029fe94fd956e30c7f66f31925d39bf92190d")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "cc6f54c05d5448c8de5c082608a2f80ca6474b13")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "8ea0e4fa6edbf415b6736da38eb43a99b42d2326")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "ed1af895b62201d19882c406e673dc9c8ffa0e28")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a10606cda3fbb2a76043228d3cc96eec8b19ab54")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "94cbb11f942f7979a76ced55edc4758868509ee2")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "0f8760df31f4d37efcd8d6fc210f1a4215221de3")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "d49ac887074adf18024c21e33ce071ea48b0c014")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "d55d55a15e273298bb94006c6b7bc1a4b31a10a2")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "cb9cbd8426cb0caab4f3200311a0afb6df4a2125")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -71,8 +71,9 @@ dai_add_example(mjpeg_encoding src/mjpeg_encoding_example.cpp)
 # StereoDepth example
 dai_add_example(stereo src/stereo_example.cpp)
 
-# Image Manip node example
+# Image Manip node examples
 dai_add_example(image_manip src/image_manip_example.cpp)
+dai_add_example(image_manip_warp src/image_manip_warp_example.cpp)
 
 # Color Camera config example
 dai_add_example(color_camera_control src/color_camera_control_example.cpp)

--- a/examples/src/color_camera_control_example.cpp
+++ b/examples/src/color_camera_control_example.cpp
@@ -1,5 +1,15 @@
-// This example shows usage of Camera Control message as well as ColorCamera configInput to change crop x and y
-
+/**
+ * This example shows usage of Camera Control message as well as ColorCamera configInput to change crop x and y
+ * Uses 'WASD' controls to move the crop window, 'C' to capture a still image, 'T' to trigger autofocus, 'IOKL,.'
+ * for manual exposure/focus:
+ *   Control:      key[dec/inc]  min..max
+ *   exposure time:     I   O      1..33000 [us]
+ *   sensitivity iso:   K   L    100..1600
+ *   focus:             ,   .      0..255 [far..near]
+ * To go back to auto controls:
+ *   'E' - autoexposure
+ *   'F' - autofocus (continuous)
+ */
 #include <iostream>
 #include <cstdio>
 
@@ -11,6 +21,15 @@
 
 // Step size ('W','A','S','D' controls)
 static constexpr int STEP_SIZE = 16;
+
+// Manual exposure/focus set step
+static constexpr int EXP_STEP = 500;  // us
+static constexpr int ISO_STEP = 50;
+static constexpr int LENS_STEP = 3;
+
+static int clamp(int num, int v0, int v1) {
+    return std::max(v0, std::min(num, v1));
+}
 
 int main(){
 
@@ -67,8 +86,18 @@ int main(){
     float crop_x = 0;
     float crop_y = 0;
 
-    float prev_crop_x = crop_x;
-    float prev_crop_y = crop_y;
+    // Defaults and limits for manual focus/exposure controls
+    int lens_pos = 150;
+    int lens_min = 0;
+    int lens_max = 255;
+
+    int exp_time = 20000;
+    int exp_min = 1;
+    int exp_max = 33000;
+
+    int sens_iso = 800;
+    int sens_min = 100;
+    int sens_max = 1600;
 
     while(true){
 
@@ -105,33 +134,62 @@ int main(){
             dai::CameraControl ctrl;
             ctrl.setCaptureStill(true);
             controlQueue->send(ctrl);
-        } else if(key == 'a'){
-            crop_x -= (max_crop_x / colorCam->getResolutionWidth()) * STEP_SIZE;
-            if (crop_x < 0) crop_x = max_crop_x;
-        } else if(key == 'd'){
-            crop_x += (max_crop_x / colorCam->getResolutionWidth()) * STEP_SIZE;
-            if (crop_x > max_crop_x) crop_x = 0.0f;
-        } else if(key == 'w'){
-            crop_y -= (max_crop_y / colorCam->getResolutionHeight()) * STEP_SIZE;
-            if (crop_y < 0) crop_y = max_crop_y;
-        } else if(key == 's'){
-            crop_y += (max_crop_y / colorCam->getResolutionHeight()) * STEP_SIZE;
-            if (crop_y > max_crop_y) crop_y = 0.0f;
-        }
+        } else if (key == 't') {
+            printf("Autofocus trigger (and disable continuous)\n");
+            dai::CameraControl ctrl;
+            ctrl.setAutoFocusMode(dai::CameraControl::AutoFocusMode::AUTO);
+            ctrl.setAutoFocusTrigger();
+            controlQueue->send(ctrl);
+        } else if (key == 'f') {
+            printf("Autofocus enable, continuous\n");
+            dai::CameraControl ctrl;
+            ctrl.setAutoFocusMode(dai::CameraControl::AutoFocusMode::CONTINUOUS_VIDEO);
+            controlQueue->send(ctrl);
+        } else if (key == 'e') {
+            printf("Autoexposure enable\n");
+            dai::CameraControl ctrl;
+            ctrl.setAutoExposureEnable();
+            controlQueue->send(ctrl);
+        } else if (key == ',' || key == '.') {
+            if (key == ',') lens_pos -= LENS_STEP;
+            if (key == '.') lens_pos += LENS_STEP;
+            lens_pos = clamp(lens_pos, lens_min, lens_max);
+            printf("Setting manual focus, lens position: %d\n", lens_pos);
+            dai::CameraControl ctrl;
+            ctrl.setManualFocus(lens_pos);
+            controlQueue->send(ctrl);
+        } else if (key == 'i' || key == 'o' || key == 'k' || key == 'l') {
+            if (key == 'i') exp_time -= EXP_STEP;
+            if (key == 'o') exp_time += EXP_STEP;
+            if (key == 'k') sens_iso -= ISO_STEP;
+            if (key == 'l') sens_iso += ISO_STEP;
+            exp_time = clamp(exp_time, exp_min, exp_max);
+            sens_iso = clamp(sens_iso, sens_min, sens_max);
+            printf("Setting manual exposure, time %d us, iso %d\n", exp_time, sens_iso);
+            dai::CameraControl ctrl;
+            ctrl.setManualExposure(exp_time, sens_iso);
+            controlQueue->send(ctrl);
+        } else if (key == 'w' || key == 'a' || key == 's' || key == 'd') {
+            if(key == 'a'){
+                crop_x -= (max_crop_x / colorCam->getResolutionWidth()) * STEP_SIZE;
+                if (crop_x < 0) crop_x = max_crop_x;
+            } else if(key == 'd'){
+                crop_x += (max_crop_x / colorCam->getResolutionWidth()) * STEP_SIZE;
+                if (crop_x > max_crop_x) crop_x = 0.0f;
+            } else if(key == 'w'){
+                crop_y -= (max_crop_y / colorCam->getResolutionHeight()) * STEP_SIZE;
+                if (crop_y < 0) crop_y = max_crop_y;
+            } else if(key == 's'){
+                crop_y += (max_crop_y / colorCam->getResolutionHeight()) * STEP_SIZE;
+                if (crop_y > max_crop_y) crop_y = 0.0f;
+            }
 
-
-        // if crop changed
-        if(prev_crop_x != crop_x || prev_crop_y != crop_y){
             // Send new cfg to camera
             dai::ImageManipConfig cfg;
             cfg.setCropRect(crop_x, crop_y, 0, 0);
             configQueue->send(cfg);
             printf("Sending new crop - x: %f, y: %f\n", crop_x, crop_y);
         }
-        
-        // set prev crop
-        prev_crop_x = crop_x;
-        prev_crop_y = crop_y;
 
     }
 

--- a/examples/src/image_manip_example.cpp
+++ b/examples/src/image_manip_example.cpp
@@ -33,11 +33,11 @@ int main(){
     colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
 
     // Create a center crop image manipulation
-    imageManip->setCenterCrop(0.7f);
-    imageManip->setResizeThumbnail(300, 400);
+    imageManip->initialConfig.setCenterCrop(0.7f);
+    imageManip->initialConfig.setResizeThumbnail(300, 400);
     
     // Second image manipulator - Create a off center crop
-    imageManip2->setCropRect(0.1, 0.1, 0.3, 0.3);
+    imageManip2->initialConfig.setCropRect(0.1, 0.1, 0.3, 0.3);
     imageManip2->setWaitForConfigInput(true);
 
 

--- a/examples/src/image_manip_warp_example.cpp
+++ b/examples/src/image_manip_warp_example.cpp
@@ -1,0 +1,170 @@
+#include <iostream>
+#include <cstdio>
+
+#include "utility.hpp"
+
+#include "depthai/depthai.hpp"
+
+struct warpFourPointTest {
+    std::vector<dai::RawImageManipConfig::Point2f> points;
+    bool normalizedCoords;
+    const char *description;
+};
+
+#define ROTATE_RATE_MAX 5.0
+#define ROTATE_RATE_INC 0.1
+#define KEY_ROTATE_DECR 'z'
+#define KEY_ROTATE_INCR 'x'
+
+#define RESIZE_MAX_W 800
+#define RESIZE_MAX_H 600
+#define RESIZE_FACTOR_MAX 5
+#define KEY_RESIZE_INC   'v'
+
+/* The crop points are specified in clockwise order,
+ * with first point mapped to output top-left, as:
+ *   P0  ->  P1
+ *    ^       v
+ *   P3  <-  P2
+ */
+#define P0 {0, 0}  // top-left
+#define P1 {1, 0}  // top-right
+#define P2 {1, 1}  // bottom-right
+#define P3 {0, 1}  // bottom-left
+std::vector<warpFourPointTest> warpList = {
+  //{{{  0,  0},{  1,  0},{  1,  1},{  0,  1}}, true, "passthrough"},
+  //{{{  0,  0},{639,  0},{639,479},{  0,479}}, false,"passthrough (pixels)"},
+    {{P0, P1, P2, P3}, true, "1.passthrough"},
+    {{P3, P0, P1, P2}, true, "2.rotate 90"},
+    {{P2, P3, P0, P1}, true, "3.rotate 180"},
+    {{P1, P2, P3, P0}, true, "4.rotate 270"},
+    {{P1, P0, P3, P2}, true, "5.horizontal mirror"},
+    {{P3, P2, P1, P0}, true, "6.vertical flip"},
+    {{{-0.1,-0.1},{1.1,-0.1},{1.1,1.1},{-0.1,1.1}}, true, "7.add black borders"},
+    {{{-0.3, 0},{1, 0},{1.3, 1},{0, 1}}, true, "8.parallelogram transform"},
+    {{{-0.2, 0},{1.8, 0},{1, 1},{0, 1}}, true, "9.trapezoid transform"},
+};
+#define KEY_WARP_TEST_CYCLE 'c'
+
+void printControls() {
+    printf("\n=== Controls:\n");
+    printf(" %c -rotated rectangle crop, decrease rate\n", KEY_ROTATE_DECR);
+    printf(" %c -rotated rectangle crop, increase rate\n", KEY_ROTATE_INCR);
+    printf(" %c -warp 4-point transform, cycle through modes\n", KEY_WARP_TEST_CYCLE);
+    printf(" %c -resize cropped region, or disable resize\n", KEY_RESIZE_INC);
+    printf(" h -print controls (help)\n");
+}
+
+int main(){
+    dai::Pipeline pipeline;
+
+    auto colorCam = pipeline.create<dai::node::ColorCamera>();
+    auto camOut = pipeline.create<dai::node::XLinkOut>();
+    auto manip = pipeline.create<dai::node::ImageManip>();
+    auto manipCfg = pipeline.create<dai::node::XLinkIn>();
+    auto manipOut = pipeline.create<dai::node::XLinkOut>();
+
+    camOut->setStreamName("preview");
+    manipOut->setStreamName("manip");
+    manipCfg->setStreamName("manipCfg");
+
+    colorCam->setPreviewSize(640, 480);
+    colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+    colorCam->setInterleaved(false);
+    colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
+    manip->setMaxOutputFrameSize(2000*1500*3);
+
+    /* Link nodes: CAM --> XLINK(preview)
+     *                \--> manip -> XLINK(manipOut)
+     *        manipCfg ---/
+     */
+    colorCam->preview.link(camOut->input);
+    colorCam->preview.link(manip->inputImage);
+    manip->out.link(manipOut->input);
+    manipCfg->out.link(manip->inputConfig);
+
+    // Connect to device and start pipeline
+    dai::Device device(pipeline);
+    device.startPipeline();
+
+    // Create input & output queues
+    auto previewQueue = device.getOutputQueue("preview", 8, false);
+    auto manipQueue = device.getOutputQueue("manip", 8, false);
+    auto manipInQueue = device.getInputQueue("manipCfg");
+
+    std::vector<decltype(previewQueue)> frameQueues {previewQueue, manipQueue};
+
+    // keep processing data
+    int key = -1;
+    float angleDeg = 0;
+    float rotateRate = 1.0;
+    int resizeFactor = 0, resizeX, resizeY;
+    bool testFourPt = false;
+    int warpIdx = -1;
+
+    printControls();
+
+    while (key != 'q') {
+        if (key >= 0) {
+            printf("Pressed: %c | ", key);
+            if (key == KEY_ROTATE_DECR || key == KEY_ROTATE_INCR) {
+                if (key == KEY_ROTATE_DECR) {
+                    if (rotateRate > -ROTATE_RATE_MAX)
+                        rotateRate -= ROTATE_RATE_INC;
+                } else if (key == KEY_ROTATE_INCR) {
+                    if (rotateRate <  ROTATE_RATE_MAX)
+                        rotateRate += ROTATE_RATE_INC;
+                }
+                testFourPt = false;
+                printf("Crop rotated rectangle, rate: %g degrees", rotateRate);
+            } else if (key == KEY_RESIZE_INC) {
+                resizeFactor++;
+                if (resizeFactor > RESIZE_FACTOR_MAX) {
+                    resizeFactor = 0;
+                    printf("Crop region not resized");
+                } else {
+                    resizeX = RESIZE_MAX_W / resizeFactor;
+                    resizeY = RESIZE_MAX_H / resizeFactor;
+                    printf("Crop region resized to: %d x %d", resizeX, resizeY);
+                }
+            } else if (key == KEY_WARP_TEST_CYCLE) {
+                resizeFactor = 0; // Disable resizing initially
+                warpIdx = (warpIdx + 1) % warpList.size();
+                printf("Warp 4-point transform, %s", warpList[warpIdx].description);
+                testFourPt = true;
+            } else if (key == 'h') {
+                printControls();
+            }
+            printf("\n");
+        }
+
+        // Send an updated config with continuous rotate, or after a key press
+        if (key >= 0 || (!testFourPt && std::abs(rotateRate) > 0.0001)) {
+            dai::ImageManipConfig cfg;
+            if (testFourPt) {
+                cfg.setWarpTransformFourPoints(warpList[warpIdx].points,
+                                               warpList[warpIdx].normalizedCoords);
+            } else {
+                angleDeg += rotateRate;
+                dai::RawImageManipConfig::RotatedRect rr = {
+                        {320, 240}, // center
+                        {640, 480}, //{400, 400}, // size
+                        angleDeg
+                };
+                bool normalized = false;
+                cfg.setCropRotatedRect(rr, normalized);
+            }
+            if (resizeFactor > 0) {
+                cfg.setResize(resizeX, resizeY);
+            }
+            manipInQueue->send(cfg);
+        }
+
+        for (const auto& q : frameQueues) {
+            auto img = q->get<dai::ImgFrame>();
+            auto mat = toMat(img->getData(), img->getWidth(), img->getHeight(), 3, 1);
+            cv::imshow(q->getName(), mat);
+        }
+        key = cv::waitKey(1);
+    }
+}

--- a/examples/src/image_manip_warp_example.cpp
+++ b/examples/src/image_manip_warp_example.cpp
@@ -6,7 +6,7 @@
 #include "depthai/depthai.hpp"
 
 struct warpFourPointTest {
-    std::vector<dai::RawImageManipConfig::Point2f> points;
+    std::vector<dai::Point2f> points;
     bool normalizedCoords;
     const char *description;
 };
@@ -146,7 +146,7 @@ int main(){
                                                warpList[warpIdx].normalizedCoords);
             } else {
                 angleDeg += rotateRate;
-                dai::RawImageManipConfig::RotatedRect rr = {
+                dai::RotatedRect rr = {
                         {320, 240}, // center
                         {640, 480}, //{400, 400}, // size
                         angleDeg
@@ -157,6 +157,8 @@ int main(){
             if (resizeFactor > 0) {
                 cfg.setResize(resizeX, resizeY);
             }
+            //cfg.setWarpBorderFillColor(255, 0, 0);
+            //cfg.setWarpBorderReplicatePixels();
             manipInQueue->send(cfg);
         }
 

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -13,6 +13,12 @@ class CameraControl : public Buffer {
     std::shared_ptr<RawBuffer> serialize() const override;
     RawCameraControl& cfg;
 
+    using AutoFocusMode = RawCameraControl::AutoFocusMode;
+    using AntiBandingMode = RawCameraControl::AntiBandingMode;
+    using AutoWhiteBalanceMode = RawCameraControl::AutoWhiteBalanceMode;
+    using SceneMode = RawCameraControl::SceneMode;
+    using EffectMode = RawCameraControl::EffectMode;
+
    public:
     CameraControl();
     explicit CameraControl(std::shared_ptr<RawCameraControl> ptr);
@@ -25,7 +31,7 @@ class CameraControl : public Buffer {
     void setStopStreaming();
 
     // Focus
-    void setAutoFocusMode(RawCameraControl::AutoFocusMode mode);
+    void setAutoFocusMode(AutoFocusMode mode);
     void setAutoFocusTrigger();
     void setAutoFocusRegion(uint16_t startX, uint16_t startY, uint16_t width, uint16_t height);
     void setManualFocus(uint8_t lensPosition);
@@ -35,11 +41,11 @@ class CameraControl : public Buffer {
     void setAutoExposureLock(bool lock);
     void setAutoExposureRegion(uint16_t startX, uint16_t startY, uint16_t width, uint16_t height);
     void setAutoExposureCompensation(int8_t compensation);
-    void setAntiBandingMode(RawCameraControl::AntiBandingMode mode);
+    void setAntiBandingMode(AntiBandingMode mode);
     void setManualExposure(uint32_t exposureTimeUs, uint32_t sensitivityIso);
 
     // White Balance
-    void setAutoWhiteBalanceMode(RawCameraControl::AutoWhiteBalanceMode mode);
+    void setAutoWhiteBalanceMode(AutoWhiteBalanceMode mode);
     void setAutoWhiteBalanceLock(bool lock);
 
     // Other image controls
@@ -50,8 +56,8 @@ class CameraControl : public Buffer {
     void setNoiseReductionStrength(uint16_t value);
     void setLumaDenoise(uint16_t value);
     void setChromaDenoise(uint16_t value);
-    void setSceneMode(RawCameraControl::SceneMode mode);
-    void setEffectMode(RawCameraControl::EffectMode mode);
+    void setSceneMode(SceneMode mode);
+    void setEffectMode(EffectMode mode);
 
     // Functions to retrieve properties
     bool getCaptureStill() const;

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -21,6 +21,38 @@ class CameraControl : public Buffer {
     // Functions to set properties
     void setCaptureStill(bool capture);
 
+    void setStartStreaming();
+    void setStopStreaming();
+
+    // Focus
+    void setAutoFocusMode(RawCameraControl::AutoFocusMode mode);
+    void setAutoFocusTrigger();
+    void setAutoFocusRegion(uint16_t startX, uint16_t startY, uint16_t width, uint16_t height);
+    void setManualFocus(uint8_t lensPosition);
+
+    // Exposure
+    void setAutoExposureEnable();
+    void setAutoExposureLock(bool lock);
+    void setAutoExposureRegion(uint16_t startX, uint16_t startY, uint16_t width, uint16_t height);
+    void setAutoExposureCompensation(int8_t compensation);
+    void setAntiBandingMode(RawCameraControl::AntiBandingMode mode);
+    void setManualExposure(uint32_t exposureTimeUs, uint32_t sensitivityIso);
+
+    // White Balance
+    void setAutoWhiteBalanceMode(RawCameraControl::AutoWhiteBalanceMode mode);
+    void setAutoWhiteBalanceLock(bool lock);
+
+    // Other image controls
+    void setBrightness(uint16_t value); // TODO move to AE?
+    void setContrast(uint16_t value);
+    void setSaturation(uint16_t value);
+    void setSharpness(uint16_t value);
+    void setNoiseReductionStrength(uint16_t value);
+    void setLumaDenoise(uint16_t value);
+    void setChromaDenoise(uint16_t value);
+    void setSceneMode(RawCameraControl::SceneMode mode);
+    void setEffectMode(RawCameraControl::EffectMode mode);
+
     // Functions to retrieve properties
     bool getCaptureStill() const;
 };

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -43,7 +43,7 @@ class CameraControl : public Buffer {
     void setAutoWhiteBalanceLock(bool lock);
 
     // Other image controls
-    void setBrightness(uint16_t value); // TODO move to AE?
+    void setBrightness(uint16_t value);  // TODO move to AE?
     void setContrast(uint16_t value);
     void setSaturation(uint16_t value);
     void setSharpness(uint16_t value);

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -13,13 +13,13 @@ class CameraControl : public Buffer {
     std::shared_ptr<RawBuffer> serialize() const override;
     RawCameraControl& cfg;
 
+   public:
     using AutoFocusMode = RawCameraControl::AutoFocusMode;
     using AntiBandingMode = RawCameraControl::AntiBandingMode;
     using AutoWhiteBalanceMode = RawCameraControl::AutoWhiteBalanceMode;
     using SceneMode = RawCameraControl::SceneMode;
     using EffectMode = RawCameraControl::EffectMode;
 
-   public:
     CameraControl();
     explicit CameraControl(std::shared_ptr<RawCameraControl> ptr);
     virtual ~CameraControl() = default;

--- a/include/depthai/pipeline/datatype/ImageManipConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfig.hpp
@@ -20,9 +20,9 @@ class ImageManipConfig : public Buffer {
 
     // Functions to set properties
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
-    void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
+    void setCropRotatedRect(RotatedRect rr, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
-    void setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords);
+    void setWarpTransformFourPoints(std::vector<Point2f> pt, bool normalizedCoords);
     void setWarpTransformMatrix3x3(std::vector<float> mat);
     void setRotationDegrees(float deg);
     void setRotationRadians(float rad);

--- a/include/depthai/pipeline/datatype/ImageManipConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfig.hpp
@@ -21,7 +21,7 @@ class ImageManipConfig : public Buffer {
     // Functions to set properties
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
     void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
-    void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, RawImageManipConfig::Size2f outSize, bool normalizedCoords = true);
+    void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
     void setResize(int w, int h);
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);

--- a/include/depthai/pipeline/datatype/ImageManipConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfig.hpp
@@ -27,6 +27,7 @@ class ImageManipConfig : public Buffer {
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);
     void setFrameType(dai::RawImgFrame::Type name);
     void setHorizontalFlip(bool flip);
+    void setReusePreviousImage(bool reuse);
 
     // Functions to retrieve properties
     float getCropXMin() const;

--- a/include/depthai/pipeline/datatype/ImageManipConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfig.hpp
@@ -24,6 +24,8 @@ class ImageManipConfig : public Buffer {
     void setCenterCrop(float ratio, float whRatio = 1.0f);
     void setWarpTransformFourPoints(std::vector<Point2f> pt, bool normalizedCoords);
     void setWarpTransformMatrix3x3(std::vector<float> mat);
+    void setWarpBorderReplicatePixels();
+    void setWarpBorderFillColor(int red, int green, int blue);
     void setRotationDegrees(float deg);
     void setRotationRadians(float rad);
     void setResize(int w, int h);

--- a/include/depthai/pipeline/datatype/ImageManipConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfig.hpp
@@ -20,6 +20,8 @@ class ImageManipConfig : public Buffer {
 
     // Functions to set properties
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
+    void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
+    void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, RawImageManipConfig::Size2f outSize, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
     void setResize(int w, int h);
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);

--- a/include/depthai/pipeline/datatype/ImageManipConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfig.hpp
@@ -21,13 +21,17 @@ class ImageManipConfig : public Buffer {
     // Functions to set properties
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
     void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
-    void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
+    void setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords);
+    void setWarpTransformMatrix3x3(std::vector<float> mat);
+    void setRotationDegrees(float deg);
+    void setRotationRadians(float rad);
     void setResize(int w, int h);
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);
     void setFrameType(dai::RawImgFrame::Type name);
     void setHorizontalFlip(bool flip);
     void setReusePreviousImage(bool reuse);
+    void setSkipCurrentImage(bool skip);
 
     // Functions to retrieve properties
     float getCropXMin() const;

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -112,6 +112,9 @@ class ColorCamera : public Node {
 
     void setPreviewKeepAspectRatio(bool keep);
     bool getPreviewKeepAspectRatio();
+
+    // Camera Controls
+    void setAutoFocusMode(RawCameraControl::AutoFocusMode mode);
 };
 
 }  // namespace node

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "depthai/pipeline/Node.hpp"
 #include <depthai/pipeline/datatype/CameraControl.hpp>
+
+#include "depthai/pipeline/Node.hpp"
 
 // shared
 #include <depthai-shared/properties/ColorCameraProperties.hpp>
@@ -117,7 +118,6 @@ class ColorCamera : public Node {
 
     void setPreviewKeepAspectRatio(bool keep);
     bool getPreviewKeepAspectRatio();
-
 };
 
 }  // namespace node

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -115,6 +115,7 @@ class ColorCamera : public Node {
 
     // Camera Controls
     void setAutoFocusMode(RawCameraControl::AutoFocusMode mode);
+    void setInitialLensPosition(uint8_t position);
 };
 
 }  // namespace node

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "depthai/pipeline/Node.hpp"
+#include <depthai/pipeline/datatype/CameraControl.hpp>
 
 // shared
 #include <depthai-shared/properties/ColorCameraProperties.hpp>
@@ -16,8 +17,12 @@ class ColorCamera : public Node {
     nlohmann::json getProperties() override;
     std::shared_ptr<Node> clone() override;
 
+    std::shared_ptr<RawCameraControl> rawControl;
+
    public:
     ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
+
+    CameraControl initialControl;
 
     Input inputConfig{*this, "inputConfig", Input::Type::SReceiver, {{DatatypeEnum::ImageManipConfig, false}}};
     Input inputControl{*this, "inputControl", Input::Type::SReceiver, {{DatatypeEnum::CameraControl, false}}};
@@ -113,9 +118,6 @@ class ColorCamera : public Node {
     void setPreviewKeepAspectRatio(bool keep);
     bool getPreviewKeepAspectRatio();
 
-    // Camera Controls
-    void setAutoFocusMode(RawCameraControl::AutoFocusMode mode);
-    void setInitialLensPosition(uint8_t position);
 };
 
 }  // namespace node

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -31,18 +31,12 @@ class ImageManip : public Node {
     Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::ImgFrame, true}}};
 
     // Functions to set ImageManipConfig - deprecated
-    [[deprecated("Use 'initialConfig.setCropRect()' instead")]]
-    void setCropRect(float xmin, float ymin, float xmax, float ymax);
-    [[deprecated("Use 'initialConfig.setCenterCrop()' instead")]]
-    void setCenterCrop(float ratio, float whRatio = 1.0f);
-    [[deprecated("Use 'initialConfig.setResize()' instead")]]
-    void setResize(int w, int h);
-    [[deprecated("Use 'initialConfig.setResizeThumbnail()' instead")]]
-    void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);
-    [[deprecated("Use 'initialConfig.setFrameType()' instead")]]
-    void setFrameType(dai::RawImgFrame::Type name);
-    [[deprecated("Use 'initialConfig.setHorizontalFlip()' instead")]]
-    void setHorizontalFlip(bool flip);
+    [[deprecated("Use 'initialConfig.setCropRect()' instead")]] void setCropRect(float xmin, float ymin, float xmax, float ymax);
+    [[deprecated("Use 'initialConfig.setCenterCrop()' instead")]] void setCenterCrop(float ratio, float whRatio = 1.0f);
+    [[deprecated("Use 'initialConfig.setResize()' instead")]] void setResize(int w, int h);
+    [[deprecated("Use 'initialConfig.setResizeThumbnail()' instead")]] void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);
+    [[deprecated("Use 'initialConfig.setFrameType()' instead")]] void setFrameType(dai::RawImgFrame::Type name);
+    [[deprecated("Use 'initialConfig.setHorizontalFlip()' instead")]] void setHorizontalFlip(bool flip);
 
     // Functions to set properties
     void setWaitForConfigInput(bool wait);

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -19,26 +19,30 @@ class ImageManip : public Node {
     std::shared_ptr<Node> clone() override;
 
     std::shared_ptr<RawImageManipConfig> rawConfig;
-    ImageManipConfig config;
 
    public:
     ImageManip(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
+
+    ImageManipConfig initialConfig;
 
     Input inputConfig{*this, "inputConfig", Input::Type::SReceiver, {{DatatypeEnum::ImageManipConfig, true}}};
     Input inputImage{*this, "inputImage", Input::Type::SReceiver, {{DatatypeEnum::ImgFrame, true}}};
 
     Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::ImgFrame, true}}};
 
-    // Functions to set ImageManipConfig
-    // TODO deprecate these in favor of?
+    // Functions to set ImageManipConfig - deprecated
+    [[deprecated("Use 'initialConfig.setCropRect()' instead")]]
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
+    [[deprecated("Use 'initialConfig.setCenterCrop()' instead")]]
     void setCenterCrop(float ratio, float whRatio = 1.0f);
+    [[deprecated("Use 'initialConfig.setResize()' instead")]]
     void setResize(int w, int h);
+    [[deprecated("Use 'initialConfig.setResizeThumbnail()' instead")]]
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);
+    [[deprecated("Use 'initialConfig.setFrameType()' instead")]]
     void setFrameType(dai::RawImgFrame::Type name);
+    [[deprecated("Use 'initialConfig.setHorizontalFlip()' instead")]]
     void setHorizontalFlip(bool flip);
-
-    // TODO add API to set/get an initial config
 
     // Functions to set properties
     void setWaitForConfigInput(bool wait);

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -32,7 +32,6 @@ class ImageManip : public Node {
     // Functions to set ImageManipConfig
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
     void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
-    void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
     void setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords);
     void setWarpTransformMatrix3x3(std::vector<float> mat);

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -31,6 +31,8 @@ class ImageManip : public Node {
 
     // Functions to set ImageManipConfig
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
+    void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
+    void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, RawImageManipConfig::Size2f outSize, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
     void setResize(int w, int h);
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -32,7 +32,7 @@ class ImageManip : public Node {
     // Functions to set ImageManipConfig
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
     void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
-    void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, RawImageManipConfig::Size2f outSize, bool normalizedCoords = true);
+    void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
     void setResize(int w, int h);
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -30,17 +30,15 @@ class ImageManip : public Node {
     Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::ImgFrame, true}}};
 
     // Functions to set ImageManipConfig
+    // TODO deprecate these in favor of?
     void setCropRect(float xmin, float ymin, float xmax, float ymax);
-    void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
-    void setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords);
-    void setWarpTransformMatrix3x3(std::vector<float> mat);
-    void setRotationDegrees(float deg);
-    void setRotationRadians(float rad);
     void setResize(int w, int h);
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);
     void setFrameType(dai::RawImgFrame::Type name);
     void setHorizontalFlip(bool flip);
+
+    // TODO add API to set/get an initial config
 
     // Functions to set properties
     void setWaitForConfigInput(bool wait);

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -34,6 +34,10 @@ class ImageManip : public Node {
     void setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords = true);
     void setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords = true);
     void setCenterCrop(float ratio, float whRatio = 1.0f);
+    void setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords);
+    void setWarpTransformMatrix3x3(std::vector<float> mat);
+    void setRotationDegrees(float deg);
+    void setRotationRadians(float rad);
     void setResize(int w, int h);
     void setResizeThumbnail(int w, int h, int bgRed = 0, int bgGreen = 0, int bgBlue = 0);
     void setFrameType(dai::RawImgFrame::Type name);

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -20,6 +20,8 @@ class MonoCamera : public Node {
    public:
     MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 
+    Input inputControl{*this, "inputControl", Input::Type::SReceiver, {{DatatypeEnum::CameraControl, false}}};
+
     Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};
 
     // Set which board socket to use

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "depthai/pipeline/Node.hpp"
 #include <depthai/pipeline/datatype/CameraControl.hpp>
+
+#include "depthai/pipeline/Node.hpp"
 
 // shared
 #include <depthai-shared/common/CameraBoardSocket.hpp>

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "depthai/pipeline/Node.hpp"
+#include <depthai/pipeline/datatype/CameraControl.hpp>
 
 // shared
 #include <depthai-shared/common/CameraBoardSocket.hpp>
@@ -17,8 +18,12 @@ class MonoCamera : public Node {
     nlohmann::json getProperties() override;
     std::shared_ptr<Node> clone() override;
 
+    std::shared_ptr<RawCameraControl> rawControl;
+
    public:
     MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
+
+    CameraControl initialControl;
 
     Input inputControl{*this, "inputControl", Input::Type::SReceiver, {{DatatypeEnum::CameraControl, false}}};
 

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -42,6 +42,7 @@ class NeuralNetwork : public Node {
     // Specify local filesystem path to load the blob (which gets loaded at loadAssets)
     void setBlobPath(const std::string& path);
     void setNumPoolFrames(int numFrames);
+    void setNumInferenceThreads(int numThreads);
 };
 
 }  // namespace node

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -43,6 +43,9 @@ class NeuralNetwork : public Node {
     void setBlobPath(const std::string& path);
     void setNumPoolFrames(int numFrames);
     void setNumInferenceThreads(int numThreads);
+    // Zero means AUTO. TODO add AUTO in NeuralNetworkProperties
+    int getNumInferenceThreads();
+    // TODO add getters for other API
 };
 
 }  // namespace node

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -24,7 +24,7 @@ void CameraControl::setStopStreaming() {
 }
 
 // Focus
-void CameraControl::setAutoFocusMode(RawCameraControl::AutoFocusMode mode) {
+void CameraControl::setAutoFocusMode(AutoFocusMode mode) {
     cfg.setCommand(RawCameraControl::Command::AF_MODE);
     cfg.autoFocusMode = mode;
 }
@@ -65,7 +65,7 @@ void CameraControl::setAutoExposureCompensation(int8_t compensation) {
     cfg.setCommand(RawCameraControl::Command::EXPOSURE_COMPENSATION);
     cfg.expCompensation = compensation;
 }
-void CameraControl::setAntiBandingMode(RawCameraControl::AntiBandingMode mode) {
+void CameraControl::setAntiBandingMode(AntiBandingMode mode) {
     cfg.setCommand(RawCameraControl::Command::ANTIBANDING_MODE);
     cfg.antiBandingMode = mode;
 }
@@ -77,7 +77,7 @@ void CameraControl::setManualExposure(uint32_t exposureTimeUs, uint32_t sensitiv
 }
 
 // White Balance
-void CameraControl::setAutoWhiteBalanceMode(RawCameraControl::AutoWhiteBalanceMode mode) {
+void CameraControl::setAutoWhiteBalanceMode(AutoWhiteBalanceMode mode) {
     cfg.setCommand(RawCameraControl::Command::AWB_MODE);
     cfg.awbMode = mode;
 }
@@ -115,11 +115,11 @@ void CameraControl::setChromaDenoise(uint16_t value) {
     cfg.setCommand(RawCameraControl::Command::CHROMA_DENOISE);
     cfg.chromaDenoise = value;
 }
-void CameraControl::setSceneMode(RawCameraControl::SceneMode mode) {
+void CameraControl::setSceneMode(SceneMode mode) {
     cfg.setCommand(RawCameraControl::Command::SCENE_MODE);
     cfg.sceneMode = mode;
 }
-void CameraControl::setEffectMode(RawCameraControl::EffectMode mode) {
+void CameraControl::setEffectMode(EffectMode mode) {
     cfg.setCommand(RawCameraControl::Command::EFFECT_MODE);
     cfg.effectMode = mode;
 }

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -16,7 +16,6 @@ void CameraControl::setCaptureStill(bool capture) {
     cfg.setCommand(RawCameraControl::Command::STILL_CAPTURE, capture);
 }
 
-
 void CameraControl::setStartStreaming() {
     cfg.setCommand(RawCameraControl::Command::START_STREAM);
 }
@@ -38,7 +37,7 @@ void CameraControl::setAutoFocusRegion(uint16_t startX, uint16_t startY, uint16_
     cfg.afRegion.y = startY;
     cfg.afRegion.width = width;
     cfg.afRegion.height = height;
-    cfg.afRegion.priority = 1; // TODO
+    cfg.afRegion.priority = 1;  // TODO
 }
 void CameraControl::setManualFocus(uint8_t lensPosition) {
     cfg.setCommand(RawCameraControl::Command::MOVE_LENS);
@@ -59,7 +58,7 @@ void CameraControl::setAutoExposureRegion(uint16_t startX, uint16_t startY, uint
     cfg.aeRegion.y = startY;
     cfg.aeRegion.width = width;
     cfg.aeRegion.height = height;
-    cfg.aeRegion.priority = 1; // TODO
+    cfg.aeRegion.priority = 1;  // TODO
 }
 void CameraControl::setAutoExposureCompensation(int8_t compensation) {
     cfg.setCommand(RawCameraControl::Command::EXPOSURE_COMPENSATION);
@@ -73,7 +72,7 @@ void CameraControl::setManualExposure(uint32_t exposureTimeUs, uint32_t sensitiv
     cfg.setCommand(RawCameraControl::Command::AE_MANUAL);
     cfg.expManual.exposureTimeUs = exposureTimeUs;
     cfg.expManual.sensitivityIso = sensitivityIso;
-    cfg.expManual.frameDurationUs = 0; // TODO
+    cfg.expManual.frameDurationUs = 0;  // TODO
 }
 
 // White Balance
@@ -123,7 +122,6 @@ void CameraControl::setEffectMode(RawCameraControl::EffectMode mode) {
     cfg.setCommand(RawCameraControl::Command::EFFECT_MODE);
     cfg.effectMode = mode;
 }
-
 
 bool CameraControl::getCaptureStill() const {
     return cfg.getCommand(RawCameraControl::Command::STILL_CAPTURE);

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -42,6 +42,7 @@ void CameraControl::setAutoFocusRegion(uint16_t startX, uint16_t startY, uint16_
 void CameraControl::setManualFocus(uint8_t lensPosition) {
     cfg.setCommand(RawCameraControl::Command::MOVE_LENS);
     cfg.lensPosition = lensPosition;
+    setAutoFocusMode(AutoFocusMode::OFF); // TODO added for initialConfig case
 }
 
 // Exposure

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -13,11 +13,120 @@ CameraControl::CameraControl(std::shared_ptr<RawCameraControl> ptr) : Buffer(std
 // Functions to set properties
 void CameraControl::setCaptureStill(bool capture) {
     // Enable capture
-    cfg.captureStill = capture;
+    cfg.setCommand(RawCameraControl::Command::STILL_CAPTURE, capture);
 }
 
+
+void CameraControl::setStartStreaming() {
+    cfg.setCommand(RawCameraControl::Command::START_STREAM);
+}
+void CameraControl::setStopStreaming() {
+    cfg.setCommand(RawCameraControl::Command::STOP_STREAM);
+}
+
+// Focus
+void CameraControl::setAutoFocusMode(RawCameraControl::AutoFocusMode mode) {
+    cfg.setCommand(RawCameraControl::Command::AF_MODE);
+    cfg.autoFocusMode = mode;
+}
+void CameraControl::setAutoFocusTrigger() {
+    cfg.setCommand(RawCameraControl::Command::AF_TRIGGER);
+}
+void CameraControl::setAutoFocusRegion(uint16_t startX, uint16_t startY, uint16_t width, uint16_t height) {
+    cfg.setCommand(RawCameraControl::Command::AF_REGION);
+    cfg.afRegion.x = startX;
+    cfg.afRegion.y = startY;
+    cfg.afRegion.width = width;
+    cfg.afRegion.height = height;
+    cfg.afRegion.priority = 1; // TODO
+}
+void CameraControl::setManualFocus(uint8_t lensPosition) {
+    cfg.setCommand(RawCameraControl::Command::MOVE_LENS);
+    cfg.lensPosition = lensPosition;
+}
+
+// Exposure
+void CameraControl::setAutoExposureEnable() {
+    cfg.setCommand(RawCameraControl::Command::AE_AUTO);
+}
+void CameraControl::setAutoExposureLock(bool lock) {
+    cfg.setCommand(RawCameraControl::Command::AE_LOCK);
+    cfg.aeLockMode = lock;
+}
+void CameraControl::setAutoExposureRegion(uint16_t startX, uint16_t startY, uint16_t width, uint16_t height) {
+    cfg.setCommand(RawCameraControl::Command::AE_REGION);
+    cfg.aeRegion.x = startX;
+    cfg.aeRegion.y = startY;
+    cfg.aeRegion.width = width;
+    cfg.aeRegion.height = height;
+    cfg.aeRegion.priority = 1; // TODO
+}
+void CameraControl::setAutoExposureCompensation(int8_t compensation) {
+    cfg.setCommand(RawCameraControl::Command::EXPOSURE_COMPENSATION);
+    cfg.expCompensation = compensation;
+}
+void CameraControl::setAntiBandingMode(RawCameraControl::AntiBandingMode mode) {
+    cfg.setCommand(RawCameraControl::Command::ANTIBANDING_MODE);
+    cfg.antiBandingMode = mode;
+}
+void CameraControl::setManualExposure(uint32_t exposureTimeUs, uint32_t sensitivityIso) {
+    cfg.setCommand(RawCameraControl::Command::AE_MANUAL);
+    cfg.expManual.exposureTimeUs = exposureTimeUs;
+    cfg.expManual.sensitivityIso = sensitivityIso;
+    cfg.expManual.frameDurationUs = 0; // TODO
+}
+
+// White Balance
+void CameraControl::setAutoWhiteBalanceMode(RawCameraControl::AutoWhiteBalanceMode mode) {
+    cfg.setCommand(RawCameraControl::Command::AWB_MODE);
+    cfg.awbMode = mode;
+}
+void CameraControl::setAutoWhiteBalanceLock(bool lock) {
+    cfg.setCommand(RawCameraControl::Command::AWB_LOCK);
+    cfg.awbLockMode = lock;
+}
+
+// Other image controls
+void CameraControl::setBrightness(uint16_t value) {
+    cfg.setCommand(RawCameraControl::Command::BRIGHTNESS);
+    cfg.brightness = value;
+}
+void CameraControl::setContrast(uint16_t value) {
+    cfg.setCommand(RawCameraControl::Command::CONTRAST);
+    cfg.contrast = value;
+}
+void CameraControl::setSaturation(uint16_t value) {
+    cfg.setCommand(RawCameraControl::Command::SATURATION);
+    cfg.saturation = value;
+}
+void CameraControl::setSharpness(uint16_t value) {
+    cfg.setCommand(RawCameraControl::Command::SHARPNESS);
+    cfg.sharpness = value;
+}
+void CameraControl::setNoiseReductionStrength(uint16_t value) {
+    cfg.setCommand(RawCameraControl::Command::NOISE_REDUCTION_STRENGTH);
+    cfg.noiseReductionStrength = value;
+}
+void CameraControl::setLumaDenoise(uint16_t value) {
+    cfg.setCommand(RawCameraControl::Command::LUMA_DENOISE);
+    cfg.lumaDenoise = value;
+}
+void CameraControl::setChromaDenoise(uint16_t value) {
+    cfg.setCommand(RawCameraControl::Command::CHROMA_DENOISE);
+    cfg.chromaDenoise = value;
+}
+void CameraControl::setSceneMode(RawCameraControl::SceneMode mode) {
+    cfg.setCommand(RawCameraControl::Command::SCENE_MODE);
+    cfg.sceneMode = mode;
+}
+void CameraControl::setEffectMode(RawCameraControl::EffectMode mode) {
+    cfg.setCommand(RawCameraControl::Command::EFFECT_MODE);
+    cfg.effectMode = mode;
+}
+
+
 bool CameraControl::getCaptureStill() const {
-    return cfg.captureStill;
+    return cfg.getCommand(RawCameraControl::Command::STILL_CAPTURE);
 }
 
 }  // namespace dai

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -42,7 +42,7 @@ void CameraControl::setAutoFocusRegion(uint16_t startX, uint16_t startY, uint16_
 void CameraControl::setManualFocus(uint8_t lensPosition) {
     cfg.setCommand(RawCameraControl::Command::MOVE_LENS);
     cfg.lensPosition = lensPosition;
-    setAutoFocusMode(AutoFocusMode::OFF); // TODO added for initialConfig case
+    setAutoFocusMode(AutoFocusMode::OFF);  // TODO added for initialConfig case
 }
 
 // Exposure

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -101,6 +101,10 @@ void ImageManipConfig::setHorizontalFlip(bool flip) {
     cfg.formatConfig.flipHorizontal = flip;
 }
 
+void ImageManipConfig::setReusePreviousImage(bool reuse) {
+    cfg.reusePreviousImage = reuse;
+}
+
 // Functions to retrieve properties
 float ImageManipConfig::getCropXMin() const {
     return cfg.cropConfig.cropRect.xmin;

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -34,13 +34,19 @@ void ImageManipConfig::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, b
     cfg.cropConfig.normalizedCoords = normalizedCoords;
 }
 
-void ImageManipConfig::setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords) {
-    // Enable crop stage and extended flags
-    cfg.enableCrop = true;
-    cfg.cropConfig.enableCropQuadrilateral = true;
+void ImageManipConfig::setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords) {
+    // Enable resize stage and extended flags
+    cfg.enableResize = true;
+    cfg.resizeConfig.enableWarp4pt = true;
+    cfg.resizeConfig.warpFourPoints = pt;
+    cfg.resizeConfig.normalizedCoords = normalizedCoords;
+}
 
-    cfg.cropConfig.cropQuadrilateral.pt = pt;
-    cfg.cropConfig.normalizedCoords = normalizedCoords;
+void ImageManipConfig::setWarpTransformMatrix3x3(std::vector<float> mat) {
+    // Enable resize stage and extended flags
+    cfg.enableResize = true;
+    cfg.resizeConfig.enableWarpMatrix = true;
+    cfg.resizeConfig.warpMatrix3x3 = mat;
 }
 
 void ImageManipConfig::setCenterCrop(float ratio, float whRatio) {
@@ -53,6 +59,20 @@ void ImageManipConfig::setCenterCrop(float ratio, float whRatio) {
     // Set crop center crop config
     cfg.cropConfig.cropRatio = ratio;
     cfg.cropConfig.widthHeightAspectRatio = whRatio;
+}
+
+void ImageManipConfig::setRotationDegrees(float deg) {
+    cfg.enableResize = true;
+    cfg.resizeConfig.rotationAngle = deg;
+    cfg.resizeConfig.angleInRadians = false;
+    cfg.resizeConfig.enableRotation = true;
+}
+
+void ImageManipConfig::setRotationRadians(float rad) {
+    cfg.enableResize = true;
+    cfg.resizeConfig.rotationAngle = rad;
+    cfg.resizeConfig.angleInRadians = true;
+    cfg.resizeConfig.enableRotation = true;
 }
 
 void ImageManipConfig::setResize(int w, int h) {
@@ -102,6 +122,10 @@ void ImageManipConfig::setHorizontalFlip(bool flip) {
 
 void ImageManipConfig::setReusePreviousImage(bool reuse) {
     cfg.reusePreviousImage = reuse;
+}
+
+void ImageManipConfig::setSkipCurrentImage(bool skip) {
+    cfg.skipCurrentImage = skip;
 }
 
 // Functions to retrieve properties

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -25,6 +25,25 @@ void ImageManipConfig::setCropRect(float xmin, float ymin, float xmax, float yma
     cfg.cropConfig.cropRect.ymax = ymax;
 }
 
+void ImageManipConfig::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords) {
+    // Enable crop stage and extended flags
+    cfg.enableCrop = true;
+    cfg.cropConfig.enableRotatedRect = true;
+
+    cfg.cropConfig.cropRotatedRect = rr;
+    cfg.cropConfig.normalizedCoords = normalizedCoords;
+}
+
+void ImageManipConfig::setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, RawImageManipConfig::Size2f outSize, bool normalizedCoords) {
+    // Enable crop stage and extended flags
+    cfg.enableCrop = true;
+    cfg.cropConfig.enableCropQuadrilateral = true;
+
+    cfg.cropConfig.cropQuadrilateral.pt = pt;
+    cfg.cropConfig.cropQuadrilateral.outSize = outSize;
+    cfg.cropConfig.normalizedCoords = normalizedCoords;
+}
+
 void ImageManipConfig::setCenterCrop(float ratio, float whRatio) {
     // Enable crop stage
     cfg.enableCrop = true;

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -34,13 +34,12 @@ void ImageManipConfig::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, b
     cfg.cropConfig.normalizedCoords = normalizedCoords;
 }
 
-void ImageManipConfig::setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, RawImageManipConfig::Size2f outSize, bool normalizedCoords) {
+void ImageManipConfig::setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords) {
     // Enable crop stage and extended flags
     cfg.enableCrop = true;
     cfg.cropConfig.enableCropQuadrilateral = true;
 
     cfg.cropConfig.cropQuadrilateral.pt = pt;
-    cfg.cropConfig.cropQuadrilateral.outSize = outSize;
     cfg.cropConfig.normalizedCoords = normalizedCoords;
 }
 

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -1,8 +1,8 @@
 // First, as other headers may include <cmath>
 #define _USE_MATH_DEFINES
-#include <cmath>
-
 #include "depthai/pipeline/datatype/ImageManipConfig.hpp"
+
+#include <cmath>
 
 namespace dai {
 

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -25,7 +25,7 @@ void ImageManipConfig::setCropRect(float xmin, float ymin, float xmax, float yma
     cfg.cropConfig.cropRect.ymax = ymax;
 }
 
-void ImageManipConfig::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords) {
+void ImageManipConfig::setCropRotatedRect(RotatedRect rr, bool normalizedCoords) {
     // Enable crop stage and extended flags
     cfg.enableCrop = true;
     cfg.cropConfig.enableRotatedRect = true;
@@ -34,7 +34,7 @@ void ImageManipConfig::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, b
     cfg.cropConfig.normalizedCoords = normalizedCoords;
 }
 
-void ImageManipConfig::setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords) {
+void ImageManipConfig::setWarpTransformFourPoints(std::vector<Point2f> pt, bool normalizedCoords) {
     // Enable resize stage and extended flags
     cfg.enableResize = true;
     cfg.resizeConfig.enableWarp4pt = true;
@@ -63,16 +63,13 @@ void ImageManipConfig::setCenterCrop(float ratio, float whRatio) {
 
 void ImageManipConfig::setRotationDegrees(float deg) {
     cfg.enableResize = true;
-    cfg.resizeConfig.rotationAngle = deg;
-    cfg.resizeConfig.angleInRadians = false;
+    cfg.resizeConfig.rotationAngleDeg = deg;
     cfg.resizeConfig.enableRotation = true;
 }
 
 void ImageManipConfig::setRotationRadians(float rad) {
-    cfg.enableResize = true;
-    cfg.resizeConfig.rotationAngle = rad;
-    cfg.resizeConfig.angleInRadians = true;
-    cfg.resizeConfig.enableRotation = true;
+    static constexpr float rad2degFactor = 180 / M_PI;
+    setRotationDegrees(rad * rad2degFactor);
 }
 
 void ImageManipConfig::setResize(int w, int h) {

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -1,3 +1,7 @@
+// First, as other headers may include <cmath>
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include "depthai/pipeline/datatype/ImageManipConfig.hpp"
 
 namespace dai {
@@ -47,6 +51,21 @@ void ImageManipConfig::setWarpTransformMatrix3x3(std::vector<float> mat) {
     cfg.enableResize = true;
     cfg.resizeConfig.enableWarpMatrix = true;
     cfg.resizeConfig.warpMatrix3x3 = mat;
+}
+
+void ImageManipConfig::setWarpBorderReplicatePixels() {
+    // Enable resize stage and extended flags
+    cfg.enableResize = true;
+    cfg.resizeConfig.warpBorderReplicate = true;
+}
+
+void ImageManipConfig::setWarpBorderFillColor(int red, int green, int blue) {
+    // Enable resize stage and extended flags
+    cfg.enableResize = true;
+    cfg.resizeConfig.warpBorderReplicate = false;
+    cfg.resizeConfig.bgRed = red;
+    cfg.resizeConfig.bgGreen = green;
+    cfg.resizeConfig.bgBlue = blue;
 }
 
 void ImageManipConfig::setCenterCrop(float ratio, float whRatio) {

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -303,6 +303,9 @@ bool ColorCamera::getPreviewKeepAspectRatio() {
 void ColorCamera::setAutoFocusMode(RawCameraControl::AutoFocusMode mode) {
     properties.initialConfig.autoFocusMode = mode;
 }
+void ColorCamera::setInitialLensPosition(uint8_t position) {
+    properties.initialConfig.lensPosition = position;
+}
 
 }  // namespace node
 }  // namespace dai

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -6,7 +6,7 @@ namespace dai {
 namespace node {
 
 ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-        : Node(par, nodeId), rawControl(std::make_shared<RawCameraControl>()), initialControl(rawControl) {
+    : Node(par, nodeId), rawControl(std::make_shared<RawCameraControl>()), initialControl(rawControl) {
     properties.boardSocket = CameraBoardSocket::AUTO;
     properties.imageOrientation = CameraImageOrientation::AUTO;
     properties.colorOrder = ColorCameraProperties::ColorOrder::BGR;
@@ -300,7 +300,6 @@ void ColorCamera::setPreviewKeepAspectRatio(bool keep) {
 bool ColorCamera::getPreviewKeepAspectRatio() {
     return properties.previewKeepAspectRatio;
 }
-
 
 }  // namespace node
 }  // namespace dai

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -299,5 +299,10 @@ bool ColorCamera::getPreviewKeepAspectRatio() {
     return properties.previewKeepAspectRatio;
 }
 
+// Camera Controls
+void ColorCamera::setAutoFocusMode(RawCameraControl::AutoFocusMode mode) {
+    properties.initialConfig.autoFocusMode = mode;
+}
+
 }  // namespace node
 }  // namespace dai

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -5,7 +5,8 @@
 namespace dai {
 namespace node {
 
-ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : Node(par, nodeId) {
+ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+        : Node(par, nodeId), rawControl(std::make_shared<RawCameraControl>()), initialControl(rawControl) {
     properties.boardSocket = CameraBoardSocket::AUTO;
     properties.imageOrientation = CameraImageOrientation::AUTO;
     properties.colorOrder = ColorCameraProperties::ColorOrder::BGR;
@@ -31,6 +32,7 @@ std::vector<Node::Input> ColorCamera::getInputs() {
 
 nlohmann::json ColorCamera::getProperties() {
     nlohmann::json j;
+    properties.initialControl = *rawControl;
     nlohmann::to_json(j, properties);
     return j;
 }
@@ -299,13 +301,6 @@ bool ColorCamera::getPreviewKeepAspectRatio() {
     return properties.previewKeepAspectRatio;
 }
 
-// Camera Controls
-void ColorCamera::setAutoFocusMode(RawCameraControl::AutoFocusMode mode) {
-    properties.initialConfig.autoFocusMode = mode;
-}
-void ColorCamera::setInitialLensPosition(uint8_t position) {
-    properties.initialConfig.lensPosition = position;
-}
 
 }  // namespace node
 }  // namespace dai

--- a/src/pipeline/node/ImageManip.cpp
+++ b/src/pipeline/node/ImageManip.cpp
@@ -33,6 +33,16 @@ void ImageManip::setCropRect(float xmin, float ymin, float xmax, float ymax) {
     properties.initialConfig = *rawConfig;
 }
 
+void ImageManip::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords) {
+    config.setCropRotatedRect(rr, normalizedCoords);
+    properties.initialConfig = *rawConfig;
+}
+
+void ImageManip::setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, RawImageManipConfig::Size2f outSize, bool normalizedCoords) {
+    config.setCropQuadrilateral(pt, outSize, normalizedCoords);
+    properties.initialConfig = *rawConfig;
+}
+
 void ImageManip::setCenterCrop(float ratio, float whRatio) {
     config.setCenterCrop(ratio, whRatio);
     properties.initialConfig = *rawConfig;

--- a/src/pipeline/node/ImageManip.cpp
+++ b/src/pipeline/node/ImageManip.cpp
@@ -33,33 +33,8 @@ void ImageManip::setCropRect(float xmin, float ymin, float xmax, float ymax) {
     properties.initialConfig = *rawConfig;
 }
 
-void ImageManip::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool normalizedCoords) {
-    config.setCropRotatedRect(rr, normalizedCoords);
-    properties.initialConfig = *rawConfig;
-}
-
 void ImageManip::setCenterCrop(float ratio, float whRatio) {
     config.setCenterCrop(ratio, whRatio);
-    properties.initialConfig = *rawConfig;
-}
-
-void ImageManip::setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords) {
-    config.setWarpTransformFourPoints(pt, normalizedCoords);
-    properties.initialConfig = *rawConfig;
-}
-
-void ImageManip::setWarpTransformMatrix3x3(std::vector<float> mat) {
-    config.setWarpTransformMatrix3x3(mat);
-    properties.initialConfig = *rawConfig;
-}
-
-void ImageManip::setRotationDegrees(float deg) {
-    config.setRotationDegrees(deg);
-    properties.initialConfig = *rawConfig;
-}
-
-void ImageManip::setRotationRadians(float rad) {
-    config.setRotationRadians(rad);
     properties.initialConfig = *rawConfig;
 }
 

--- a/src/pipeline/node/ImageManip.cpp
+++ b/src/pipeline/node/ImageManip.cpp
@@ -3,7 +3,7 @@ namespace dai {
 namespace node {
 
 ImageManip::ImageManip(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : Node(par, nodeId), rawConfig(std::make_shared<RawImageManipConfig>()), config(rawConfig) {}
+    : Node(par, nodeId), rawConfig(std::make_shared<RawImageManipConfig>()), initialConfig(rawConfig) {}
 
 std::string ImageManip::getName() const {
     return "ImageManip";
@@ -19,6 +19,7 @@ std::vector<Node::Output> ImageManip::getOutputs() {
 
 nlohmann::json ImageManip::getProperties() {
     nlohmann::json j;
+    properties.initialConfig = *rawConfig;
     nlohmann::to_json(j, properties);
     return j;
 }
@@ -29,32 +30,32 @@ std::shared_ptr<Node> ImageManip::clone() {
 
 // Initial ImageManipConfig
 void ImageManip::setCropRect(float xmin, float ymin, float xmax, float ymax) {
-    config.setCropRect(xmin, ymin, xmax, ymax);
+    initialConfig.setCropRect(xmin, ymin, xmax, ymax);
     properties.initialConfig = *rawConfig;
 }
 
 void ImageManip::setCenterCrop(float ratio, float whRatio) {
-    config.setCenterCrop(ratio, whRatio);
+    initialConfig.setCenterCrop(ratio, whRatio);
     properties.initialConfig = *rawConfig;
 }
 
 void ImageManip::setResize(int w, int h) {
-    config.setResize(w, h);
+    initialConfig.setResize(w, h);
     properties.initialConfig = *rawConfig;
 }
 
 void ImageManip::setResizeThumbnail(int w, int h, int bgRed, int bgGreen, int bgBlue) {
-    config.setResizeThumbnail(w, h, bgRed, bgGreen, bgBlue);
+    initialConfig.setResizeThumbnail(w, h, bgRed, bgGreen, bgBlue);
     properties.initialConfig = *rawConfig;
 }
 
 void ImageManip::setFrameType(dai::RawImgFrame::Type type) {
-    config.setFrameType(type);
+    initialConfig.setFrameType(type);
     properties.initialConfig = *rawConfig;
 }
 
 void ImageManip::setHorizontalFlip(bool flip) {
-    config.setHorizontalFlip(flip);
+    initialConfig.setHorizontalFlip(flip);
     properties.initialConfig = *rawConfig;
 }
 

--- a/src/pipeline/node/ImageManip.cpp
+++ b/src/pipeline/node/ImageManip.cpp
@@ -38,8 +38,8 @@ void ImageManip::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool no
     properties.initialConfig = *rawConfig;
 }
 
-void ImageManip::setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, RawImageManipConfig::Size2f outSize, bool normalizedCoords) {
-    config.setCropQuadrilateral(pt, outSize, normalizedCoords);
+void ImageManip::setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords) {
+    config.setCropQuadrilateral(pt, normalizedCoords);
     properties.initialConfig = *rawConfig;
 }
 

--- a/src/pipeline/node/ImageManip.cpp
+++ b/src/pipeline/node/ImageManip.cpp
@@ -38,13 +38,28 @@ void ImageManip::setCropRotatedRect(RawImageManipConfig::RotatedRect rr, bool no
     properties.initialConfig = *rawConfig;
 }
 
-void ImageManip::setCropQuadrilateral(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords) {
-    config.setCropQuadrilateral(pt, normalizedCoords);
+void ImageManip::setCenterCrop(float ratio, float whRatio) {
+    config.setCenterCrop(ratio, whRatio);
     properties.initialConfig = *rawConfig;
 }
 
-void ImageManip::setCenterCrop(float ratio, float whRatio) {
-    config.setCenterCrop(ratio, whRatio);
+void ImageManip::setWarpTransformFourPoints(std::vector<RawImageManipConfig::Point2f> pt, bool normalizedCoords) {
+    config.setWarpTransformFourPoints(pt, normalizedCoords);
+    properties.initialConfig = *rawConfig;
+}
+
+void ImageManip::setWarpTransformMatrix3x3(std::vector<float> mat) {
+    config.setWarpTransformMatrix3x3(mat);
+    properties.initialConfig = *rawConfig;
+}
+
+void ImageManip::setRotationDegrees(float deg) {
+    config.setRotationDegrees(deg);
+    properties.initialConfig = *rawConfig;
+}
+
+void ImageManip::setRotationRadians(float rad) {
+    config.setRotationRadians(rad);
     properties.initialConfig = *rawConfig;
 }
 

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -5,7 +5,8 @@
 namespace dai {
 namespace node {
 
-MonoCamera::MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : Node(par, nodeId) {
+MonoCamera::MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+        : Node(par, nodeId), rawControl(std::make_shared<RawCameraControl>()), initialControl(rawControl) {
     properties.boardSocket = CameraBoardSocket::AUTO;
     properties.resolution = MonoCameraProperties::SensorResolution::THE_720_P;
     properties.fps = 30.0;
@@ -25,6 +26,7 @@ std::vector<Node::Input> MonoCamera::getInputs() {
 
 nlohmann::json MonoCamera::getProperties() {
     nlohmann::json j;
+    properties.initialControl = *rawControl;
     nlohmann::to_json(j, properties);
     return j;
 }

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -20,7 +20,7 @@ std::vector<Node::Output> MonoCamera::getOutputs() {
 }
 
 std::vector<Node::Input> MonoCamera::getInputs() {
-    return {};
+    return {inputControl};
 }
 
 nlohmann::json MonoCamera::getProperties() {

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -6,7 +6,7 @@ namespace dai {
 namespace node {
 
 MonoCamera::MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-        : Node(par, nodeId), rawControl(std::make_shared<RawCameraControl>()), initialControl(rawControl) {
+    : Node(par, nodeId), rawControl(std::make_shared<RawCameraControl>()), initialControl(rawControl) {
     properties.boardSocket = CameraBoardSocket::AUTO;
     properties.resolution = MonoCameraProperties::SensorResolution::THE_720_P;
     properties.fps = 30.0;

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -82,5 +82,9 @@ void NeuralNetwork::setNumInferenceThreads(int numThreads) {
     properties.numThreads = numThreads;
 }
 
+int NeuralNetwork::getNumInferenceThreads() {
+    return properties.numThreads;
+}
+
 }  // namespace node
 }  // namespace dai

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -78,5 +78,9 @@ void NeuralNetwork::setNumPoolFrames(int numFrames) {
     properties.numFrames = numFrames;
 }
 
+void NeuralNetwork::setNumInferenceThreads(int numThreads) {
+    properties.numThreads = numThreads;
+}
+
 }  // namespace node
 }  // namespace dai


### PR DESCRIPTION
- Extend ImageManipConfig with Warp related functionality:
    ```
    void setCropRotatedRect(RotatedRect rr, bool normalizedCoords = true);
    void setWarpTransformFourPoints(std::vector<Point2f> pt, bool normalizedCoords);
    void setWarpTransformMatrix3x3(std::vector<float> mat);
    void setWarpBorderReplicatePixels();
    void setWarpBorderFillColor(int red, int green, int blue);
    void setRotationDegrees(float deg);
    void setRotationRadians(float rad);
    ```
- Add ImageManipConfig API allowing to skip or reuse a frame (useful when ImageManip `inputImage` is connected directly to the camera, and it has to process a series of bounding-boxes, or none). Usable only with `setWaitForConfigInput(true)`
    ```
    void setReusePreviousImage(bool reuse);
    void setSkipCurrentImage(bool skip);
    ```
- Extended CameraControl with ISP / 3A commands: 
    https://github.com/luxonis/depthai-core/blob/58033d6/include/depthai/pipeline/datatype/CameraControl.hpp
    https://github.com/luxonis/depthai-shared/blob/7fd5976/include/depthai-shared/datatype/RawCameraControl.hpp
- ColorCamera / MonoCamera nodes: added `inputControl` input, that can take control commands during runtime. Applying a set of initial commands on the `Mono/ColorCamera->initialControl` is also possible, but only these are implemented for now (will be extended in future):
    ```
    void setAutoFocusMode(AutoFocusMode mode);
    void setManualFocus(uint8_t lensPosition);
    ````
- Deprecated ImageManip API that was common to ImageManipConfig, in favor of applying on `imageManip->initialConfig` (shared with runtime messages passed via `inputConfig`):
`imageManip->setCenterCrop(0.7f) -> imageManip->initialConfig.setCenterCrop(0.7f)`
- NeuralNetwork: added `void setNumInferenceThreads(int numThreads);` - could set more than 1, but usually not recommended more than 2. Was used to improve the performance on OCR demo (two networks: text detection and bounding-box text recognition -- the latter was configured with two threads).
- Added auto/manual exposure/focus controls to `color_camera_control_example.cpp`
- Added new example: `image_manip_warp_example.cpp`


Related PR: https://github.com/luxonis/depthai-shared/pull/16