### PR TITLE
Gen2 improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,11 +109,14 @@ add_library(${TARGET_NAME}
     src/pipeline/node/MyProducer.cpp
     src/pipeline/node/VideoEncoder.cpp
     src/pipeline/node/DetectionNetwork.cpp
+    src/pipeline/node/SystemLogger.cpp
     src/pipeline/datatype/Buffer.cpp
     src/pipeline/datatype/ImgFrame.cpp
     src/pipeline/datatype/ImageManipConfig.cpp
     src/pipeline/datatype/CameraControl.cpp
     src/pipeline/datatype/NNData.cpp
+    src/pipeline/datatype/ImgDetections.cpp
+    src/pipeline/datatype/SystemInformation.cpp
     src/pipeline/datatype/StreamPacketParser.cpp
     src/utility/Initialization.cpp
     src/utility/Resources.cpp

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "b61d25678d97cde166198196c41301b2ca6cb114")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "9d1f1eeb28069caca3ba22cec3317566db115608")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "3e052d34a8e15d96aab8e84e9ba93d1627f61431")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "b61d25678d97cde166198196c41301b2ca6cb114")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "6d322de4a2f5df22b09dcaba137f20704198d38f")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "723f398414c9db3260b032b6b3cf07e92824b7e8")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "9d1f1eeb28069caca3ba22cec3317566db115608")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "6d322de4a2f5df22b09dcaba137f20704198d38f")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,8 +8,8 @@ hunter_config(
 hunter_config(
     XLink
     VERSION "luxonis-2020.2-mx_id_compatible"
-    URL "https://github.com/luxonis/XLink/archive/20b5e9b0ac40067f6c8332a03750005ecd01098d.tar.gz"
-    SHA1 "a9e35c7995459a9cfe4a083dc2ee54c606df897e"
+    URL "https://github.com/luxonis/XLink/archive/a37981fc345894292b71a60c337a28b2acf6d572.tar.gz"
+    SHA1 "c285f578174b9dcf35bdc159d4f9f8c05a635629"
 )
 
 hunter_config(

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,8 +8,8 @@ hunter_config(
 hunter_config(
     XLink
     VERSION "luxonis-2020.2-mx_id_compatible"
-    URL "https://github.com/luxonis/XLink/archive/04bf4dc9be5da5bd471f6df94dbbe995e425d7b1.tar.gz"
-    SHA1 "5aef4de522ae1f0c8a9493158f1bf3a8332cd588"
+    URL "https://github.com/luxonis/XLink/archive/20b5e9b0ac40067f6c8332a03750005ecd01098d.tar.gz"
+    SHA1 "a9e35c7995459a9cfe4a083dc2ee54c606df897e"
 )
 
 hunter_config(

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -37,6 +37,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang|GNU)$")
   add_flag(-Werror-non-virtual-dtor) # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
   add_flag(-Werror-sign-compare)     # warn the user if they compare a signed and unsigned numbers
   add_flag(-Werror-reorder)          # field '$1' will be initialized after field '$2'
+  add_flag(-Werror-switch-enum)      # if switch case is missing - error
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # using Visual Studio C++

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,7 +13,6 @@ macro(dai_add_example example_name example_src)
     # parse the rest of the arguments
     set(arguments ${ARGV})
     list(REMOVE_AT arguments 0 1)
-    message(STATUS "arguments are: ${arguments}")
     
     # If 'DEPTHAI_TEST_EXAMPLES' is ON, then examples will be part of the test suite
     if(DEPTHAI_TEST_EXAMPLES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -77,4 +77,5 @@ dai_add_example(image_manip src/image_manip_example.cpp)
 # Color Camera config example
 dai_add_example(color_camera_control src/color_camera_control_example.cpp)
 
-
+# System information example
+dai_add_example(system_information src/system_information_example.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -79,3 +79,6 @@ dai_add_example(color_camera_control src/color_camera_control_example.cpp)
 
 # System information example
 dai_add_example(system_information src/system_information_example.cpp)
+
+# Device getQueueEvent example
+dai_add_example(device_queue_event src/device_queue_event_example.cpp)

--- a/examples/cmake/ExecuteTestTimeout.cmake
+++ b/examples/cmake/ExecuteTestTimeout.cmake
@@ -28,7 +28,7 @@ execute_process(COMMAND timeout -s SIGINT -k 5 ${TIMEOUT_SECONDS} ${arguments} R
 message(STATUS "After timeout, ${PATH_TO_TEST_EXECUTABLE} produced the following exit code: ${error_variable}")
 
 # After that, wait for ~3 seconds
-execute_process(COMMAND sleep 3)
+# execute_process(COMMAND sleep 3)
 
 if(error_variable MATCHES "timeout" OR error_variable EQUAL 128 OR error_variable EQUAL 124)
     # Okay

--- a/examples/src/camera_video_example.cpp
+++ b/examples/src/camera_video_example.cpp
@@ -30,6 +30,7 @@ dai::Pipeline createCameraFullPipeline(){
 
 int main(){
     using namespace std;
+    using namespace std::chrono;
 
     // Create pipeline
     dai::Pipeline p = createCameraFullPipeline();
@@ -47,7 +48,9 @@ int main(){
         auto imgFrame = video->get<dai::ImgFrame>();
         if(imgFrame){
 
-            printf("Frame - w: %d, h: %d\n", imgFrame->getWidth(), imgFrame->getHeight());
+            auto dur = steady_clock::now() - imgFrame->getTimestamp();
+            
+            printf("Frame - w: %d, h: %d, latency: %dms\n", imgFrame->getWidth(), imgFrame->getHeight(), duration_cast<milliseconds>(dur).count());
 
             frame = cv::Mat(imgFrame->getHeight() * 3 / 2, imgFrame->getWidth(), CV_8UC1, imgFrame->getData().data());
             

--- a/examples/src/camera_video_example.cpp
+++ b/examples/src/camera_video_example.cpp
@@ -50,7 +50,7 @@ int main(){
 
             auto dur = steady_clock::now() - imgFrame->getTimestamp();
             
-            printf("Frame - w: %d, h: %d, latency: %dms\n", imgFrame->getWidth(), imgFrame->getHeight(), duration_cast<milliseconds>(dur).count());
+            printf("Frame - w: %d, h: %d, latency: %ldms\n", imgFrame->getWidth(), imgFrame->getHeight(), duration_cast<milliseconds>(dur).count());
 
             frame = cv::Mat(imgFrame->getHeight() * 3 / 2, imgFrame->getWidth(), CV_8UC1, imgFrame->getData().data());
             

--- a/examples/src/device_queue_event_example.cpp
+++ b/examples/src/device_queue_event_example.cpp
@@ -1,0 +1,69 @@
+
+#include <iostream>
+#include <cstdio>
+
+#include "utility.hpp"
+
+// Inludes common necessary includes for development using depthai library
+#include "depthai/depthai.hpp"
+
+
+int main(int argc, char** argv){
+
+    using namespace std;
+    using namespace std::chrono;
+
+    dai::Pipeline p;
+
+    auto colorCam = p.create<dai::node::ColorCamera>();
+    auto xout = p.create<dai::node::XLinkOut>();
+    auto xout2 = p.create<dai::node::XLinkOut>();
+    auto videnc = p.create<dai::node::VideoEncoder>();
+
+    // XLinkOut
+    xout->setStreamName("mjpeg");
+    xout2->setStreamName("preview");
+
+    // ColorCamera    
+    colorCam->setPreviewSize(300, 300);
+    colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+    //colorCam->setFps(5.0);
+    colorCam->setInterleaved(true);
+
+    // VideoEncoder
+    videnc->setDefaultProfilePreset(1920, 1080, 30, dai::VideoEncoderProperties::Profile::MJPEG);
+
+    // Link plugins CAM -> XLINK
+    colorCam->video.link(videnc->input);
+    colorCam->preview.link(xout2->input);
+    videnc->bitstream.link(xout->input);
+
+    // Connect to device with above created pipeline
+    dai::Device d(p);
+    // Start the pipeline
+    d.startPipeline();
+
+    // Sets queues size and behaviour
+    d.getOutputQueue("mjpeg", 8, false);
+    d.getOutputQueue("preview", 8, false);
+    
+    while(1){
+
+        auto ev = d.getQueueEvent();
+        if(ev == "preview"){
+            auto preview = d.getOutputQueue(ev)->get<dai::ImgFrame>();
+            cv::imshow("preview", cv::Mat(preview->getHeight(), preview->getWidth(), CV_8UC3, preview->getData().data()));
+        } else if(ev == "mjpeg"){
+            auto mjpeg = d.getOutputQueue(ev)->get<dai::ImgFrame>();
+            cv::Mat decodedFrame = cv::imdecode(cv::Mat(mjpeg->getData()), cv::IMREAD_COLOR);
+            cv::imshow("mjpeg", decodedFrame);
+        }
+        
+        int key = cv::waitKey(1);
+        if (key == 'q'){
+            return 0;
+        } 
+    }
+
+    return 0;
+}

--- a/examples/src/mjpeg_encoding_example.cpp
+++ b/examples/src/mjpeg_encoding_example.cpp
@@ -11,6 +11,7 @@
 int main(int argc, char** argv){
 
     using namespace std;
+    using namespace std::chrono;
 
     dai::Pipeline p;
 
@@ -46,29 +47,28 @@ int main(int argc, char** argv){
     auto previewQueue = d.getOutputQueue("preview", 8, false);
     while(1){
 
-        auto t1 = std::chrono::steady_clock::now();            
-        
+        auto t1 = steady_clock::now();            
         auto preview = previewQueue->get<dai::ImgFrame>();
-
-        auto t2 = std::chrono::steady_clock::now();
+        auto t2 = steady_clock::now();
         cv::imshow("preview", cv::Mat(preview->getHeight(), preview->getWidth(), CV_8UC3, preview->getData().data()));
-        auto t3 = std::chrono::steady_clock::now();
+        auto t3 = steady_clock::now();
         auto mjpeg = mjpegQueue->get<dai::ImgFrame>();
-        auto t4 = std::chrono::steady_clock::now();
+        auto t4 = steady_clock::now();
         cv::Mat decodedFrame = cv::imdecode( cv::Mat(mjpeg->getData()), cv::IMREAD_COLOR);
-        auto t5 = std::chrono::steady_clock::now();
+        auto t5 = steady_clock::now();
         cv::imshow("mjpeg", decodedFrame);
 
-        double tsPreview = preview->getTimestamp().sec + preview->getTimestamp().nsec / 1000000000.0;
-        double tsMjpeg = mjpeg->getTimestamp().sec + mjpeg->getTimestamp().nsec / 1000000000.0;
+        
+        int previewLatency = duration_cast<milliseconds>(steady_clock::now() - preview->getTimestamp()).count();
+        int mjpegLatency = duration_cast<milliseconds>(steady_clock::now() - preview->getTimestamp()).count();
 
-        int ms1 = std::chrono::duration_cast<std::chrono::milliseconds>(t2-t1).count();
-        int ms2 = std::chrono::duration_cast<std::chrono::milliseconds>(t3-t2).count();
-        int ms3 = std::chrono::duration_cast<std::chrono::milliseconds>(t4-t3).count();
-        int ms4 = std::chrono::duration_cast<std::chrono::milliseconds>(t5-t4).count();
-        int loop = std::chrono::duration_cast<std::chrono::milliseconds>(t5-t1).count();
+        int ms1 = duration_cast<milliseconds>(t2-t1).count();
+        int ms2 = duration_cast<milliseconds>(t3-t2).count();
+        int ms3 = duration_cast<milliseconds>(t4-t3).count();
+        int ms4 = duration_cast<milliseconds>(t5-t4).count();
+        int loop = duration_cast<milliseconds>(t5-t1).count();
 
-        std::cout << ms1 << " " << ms2 << " " << ms3 << " " << ms4 << " loop: " << loop << "sync offset: " << tsPreview << " sync mjpeg " << tsMjpeg << std::endl;
+        std::cout << ms1 << " " << ms2 << " " << ms3 << " " << ms4 << " loop: " << loop << " | Latencies - preview : " << previewLatency << " mjpeg: " << mjpegLatency << std::endl;
         int key = cv::waitKey(1);
         if (key == 'q'){
             return 0;

--- a/examples/src/mono_camera_example.cpp
+++ b/examples/src/mono_camera_example.cpp
@@ -29,6 +29,7 @@ dai::Pipeline createMonoPipeline(){
 
 int main(){
     using namespace std;
+    using namespace std::chrono;
 
     // Create pipeline
     dai::Pipeline p = createMonoPipeline();
@@ -46,7 +47,8 @@ int main(){
         auto imgFrame = monoQueue->get<dai::ImgFrame>();
         if(imgFrame){
 
-            printf("Frame - w: %d, h: %d\n", imgFrame->getWidth(), imgFrame->getHeight());
+            int latencyMs = duration_cast<milliseconds>(steady_clock::now() - imgFrame->getTimestamp()).count();
+            printf("Frame - w: %d, h: %d, latency %dms\n", imgFrame->getWidth(), imgFrame->getHeight(), latencyMs);
 
             frame = cv::Mat(imgFrame->getHeight(), imgFrame->getWidth(), CV_8UC1, imgFrame->getData().data());
             

--- a/examples/src/system_information_example.cpp
+++ b/examples/src/system_information_example.cpp
@@ -1,0 +1,55 @@
+
+
+#include <iostream>
+#include <cstdio>
+
+#include "utility.hpp"
+
+// Inludes common necessary includes for development using depthai library
+#include "depthai/depthai.hpp"
+
+void printSystemInformation(dai::SystemInformation);
+
+int main(){
+    using namespace std;
+
+    dai::Pipeline pipeline;
+    auto sysLog = pipeline.create<dai::node::SystemLogger>();
+    auto xout = pipeline.create<dai::node::XLinkOut>();
+    
+    // properties
+    sysLog->setRate(1.0f); // 1 hz updates
+    xout->setStreamName("sysinfo");
+
+    // links
+    sysLog->out.link(xout->input);
+
+    // Connect to device
+    dai::Device device(pipeline);
+
+    // Create 'sysinfo' queue
+    auto queue = device.getOutputQueue("sysinfo");
+
+    // Query device (before pipeline starts)
+    dai::MemoryInfo ddr = device.getDdrMemoryUsage();
+    printf("Ddr used / total - %.2f / %.2f MiB\n", ddr.used / (1024.0f*1024.0f), ddr.total / (1024.0f*1024.0f));
+
+    // Start pipeline 
+    device.startPipeline();
+
+    while(1){
+        auto sysInfo = queue->get<dai::SystemInformation>();
+        printSystemInformation(*sysInfo);
+    }
+}
+
+void printSystemInformation(dai::SystemInformation info){
+
+    printf("Ddr used / total - %.2f / %.2f MiB\n", info.memoryDdrUsage.used / (1024.0f*1024.0f), info.memoryDdrUsage.total / (1024.0f*1024.0f));
+    printf("LeonOs heap used / total - %.2f / %.2f MiB\n", info.memoryLeonOsUsage.used / (1024.0f*1024.0f), info.memoryLeonOsUsage.total / (1024.0f*1024.0f));
+    printf("LeonRt heap used / total - %.2f / %.2f MiB\n", info.memoryLeonRtUsage.used / (1024.0f*1024.0f), info.memoryLeonRtUsage.total / (1024.0f*1024.0f));
+
+    const auto& t = info.chipTemperature;
+    printf("Chip temperature - average: %.2f, css: %.2f, mss: %.2f, upa0: %.2f, upa1: %.2f\n", t.average, t.css, t.mss, t.upa0, t.upa1);
+
+}

--- a/examples/src/system_information_example.cpp
+++ b/examples/src/system_information_example.cpp
@@ -52,4 +52,6 @@ void printSystemInformation(dai::SystemInformation info){
     const auto& t = info.chipTemperature;
     printf("Chip temperature - average: %.2f, css: %.2f, mss: %.2f, upa0: %.2f, upa1: %.2f\n", t.average, t.css, t.mss, t.upa0, t.upa1);
 
+
+    printf("Cpu usage - Leon OS: %.2f %%, Leon RT: %.2f %%\n", info.cpuLeonOsUsage.average * 100, info.cpuLeonRtUsage.average * 100);
 }

--- a/include/depthai/depthai.hpp
+++ b/include/depthai/depthai.hpp
@@ -20,6 +20,7 @@
 #include "pipeline/node/NeuralNetwork.hpp"
 #include "pipeline/node/SPIOut.hpp"
 #include "pipeline/node/StereoDepth.hpp"
+#include "pipeline/node/SystemLogger.hpp"
 #include "pipeline/node/VideoEncoder.hpp"
 #include "pipeline/node/XLinkIn.hpp"
 #include "pipeline/node/XLinkOut.hpp"
@@ -28,8 +29,10 @@
 #include "pipeline/datatype/Buffer.hpp"
 #include "pipeline/datatype/CameraControl.hpp"
 #include "pipeline/datatype/ImageManipConfig.hpp"
+#include "pipeline/datatype/ImgDetections.hpp"
 #include "pipeline/datatype/ImgFrame.hpp"
 #include "pipeline/datatype/NNData.hpp"
+#include "pipeline/datatype/SystemInformation.hpp"
 
 // namespace dai {
 // namespace{

--- a/include/depthai/device/DataQueue.hpp
+++ b/include/depthai/device/DataQueue.hpp
@@ -32,6 +32,12 @@ class DataOutputQueue {
     DataOutputQueue(const std::shared_ptr<XLinkConnection>& conn, const std::string& streamName, unsigned int maxSize = 16, bool blocking = true);
     ~DataOutputQueue();
 
+    void setBlocking(bool blocking);
+    bool getBlocking() const;
+
+    void setMaxSize(unsigned int maxSize);
+    unsigned int getMaxSize(unsigned int maxSize) const;
+
     std::string getName() const;
 
     template <class T>
@@ -162,10 +168,19 @@ class DataInputQueue {
     std::shared_ptr<std::string> pExceptionMessage;
     std::string& exceptionMessage;
     std::string streamName;
+    std::size_t maxDataSize;
 
    public:
     DataInputQueue(const std::shared_ptr<XLinkConnection>& conn, const std::string& streamName, unsigned int maxSize = 16, bool blocking = true);
     ~DataInputQueue();
+
+    void setMaxDataSize(std::size_t maxSize);
+
+    void setBlocking(bool blocking);
+    bool getBlocking() const;
+
+    void setMaxSize(unsigned int maxSize);
+    unsigned int getMaxSize(unsigned int maxSize) const;
 
     std::string getName() const;
 

--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -75,6 +75,13 @@ class Device {
     std::shared_ptr<DataOutputQueue> getOutputQueue(const std::string& name, unsigned int maxSize, bool blocking = true);
 
     /**
+     * Get all available output queue names
+     *
+     * @return Array of output queue names
+     */
+    std::vector<std::string> getOutputQueueNames() const;
+
+    /**
      * Gets an input queue corresponding to stream name. If it doesn't exist it throws
      *
      * @param name Queue/stream name, set in XLinkIn node
@@ -92,7 +99,13 @@ class Device {
      */
     std::shared_ptr<DataInputQueue> getInputQueue(const std::string& name, unsigned int maxSize, bool blocking = true);
 
-    // callback
+    /**
+     * Get all available input queue names
+     *
+     * @return Array of output queue names
+     */
+    std::vector<std::string> getInputQueueNames() const;
+
     void setCallback(const std::string& name, std::function<std::shared_ptr<RawBuffer>(std::shared_ptr<RawBuffer>)> cb);
 
     /**
@@ -176,7 +189,6 @@ class Device {
     std::mutex eventMtx;
     std::condition_variable eventCv;
     std::deque<std::string> eventQueue;
-    std::vector<std::string> allQueueNames;
 
     // Watchdog thread
     std::thread watchdogThread;

--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -17,6 +17,7 @@
 // shared
 #include "depthai-shared/log/LogLevel.hpp"
 #include "depthai-shared/pb/common/ChipTemperature.hpp"
+#include "depthai-shared/pb/common/CpuUsage.hpp"
 #include "depthai-shared/pb/common/MemoryInfo.hpp"
 
 // libraries
@@ -31,6 +32,7 @@ class Device {
     // constants
     static constexpr std::chrono::seconds DEFAULT_SEARCH_TIME{3};
     static constexpr std::size_t EVENT_QUEUE_MAXIMUM_SIZE{2048};
+    static constexpr float DEFAULT_SYSTEM_INFORMATION_LOGGING_RATE_HZ{1.0f};
 
     // static API
     template <typename Rep, typename Period>
@@ -53,8 +55,34 @@ class Device {
     bool isPipelineRunning();
     bool startPipeline();
 
+    /**
+     * Sets the devices logging severity level. By default logs are printed to standard output
+     *
+     * @param level Logging severity level
+     */
     void setLogLevel(LogLevel level);
+
+    /**
+     * Gets current logging severity level of the device.
+     *
+     * @return Logging severity level
+     */
     LogLevel getLogLevel();
+
+    /**
+     * Sets rate of system information logging ("info" severity). Default 1Hz
+     * If parameter is less or equal to zero, then system information logging will be disabled
+     *
+     * @param rateHz Logging rate in Hz
+     */
+    void setSystemInformationLoggingRate(float rateHz);
+
+    /**
+     * Gets current rate of system information logging ("info" severity) in Hz.
+     *
+     * @return Logging rate in Hz
+     */
+    float getSystemInformationLoggingRate();
 
     /**
      * Gets an output queue corresponding to stream name. If it doesn't exist it throws
@@ -164,11 +192,47 @@ class Device {
      */
     std::string getQueueEvent(std::chrono::microseconds timeout = std::chrono::microseconds(-1));
 
-    // Convinience functions for querying current system information
+    /**
+     * Retrieves current DDR memory information from device
+     *
+     * @return Used, remaining and total ddr memory
+     */
     MemoryInfo getDdrMemoryUsage();
+
+    /**
+     * Retrieves current LeonOS heap information from device
+     *
+     * @return Used, remaining and total heap memory
+     */
     MemoryInfo getLeonOsHeapUsage();
+
+    /**
+     * Retrieves current LeonRT heap information from device
+     *
+     * @return Used, remaining and total heap memory
+     */
     MemoryInfo getLeonRtHeapUsage();
+
+    /**
+     * Retrieves current chip temperature as measured by device
+     *
+     * @return Temperature of various onboard sensors
+     */
     ChipTemperature getChipTemperature();
+
+    /**
+     * Retrieves average LeonOS cpu usage
+     *
+     * @return Average CPU usage and sampling duration
+     */
+    CpuUsage getLeonOsCpuUsage();
+
+    /**
+     * Retrieves average LeonRt cpu usage
+     *
+     * @return Average CPU usage and sampling duration
+     */
+    CpuUsage getLeonRtCpuUsage();
 
    private:
     // private static

--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -14,6 +14,8 @@
 
 // shared
 #include "depthai-shared/log/LogLevel.hpp"
+#include "depthai-shared/pb/common/ChipTemperature.hpp"
+#include "depthai-shared/pb/common/MemoryInfo.hpp"
 
 // libraries
 #include "nanorpc/core/client.h"
@@ -56,13 +58,11 @@ class Device {
     // callback
     void setCallback(const std::string& name, std::function<std::shared_ptr<RawBuffer>(std::shared_ptr<RawBuffer>)> cb);
 
-    // bool startTestPipeline(int testId);
-
-    // std::vector<std::string> get_available_streams();
-    // void request_jpeg();
-    // void request_af_trigger();
-    // void request_af_mode(CaptureMetadata::AutofocusMode mode);
-    // std::map<std::string, int> get_nn_to_depth_bbox_mapping();
+    // Convinience functions for querying current system information
+    MemoryInfo getDdrMemoryUsage();
+    MemoryInfo getLeonOsHeapUsage();
+    MemoryInfo getLeonRtHeapUsage();
+    ChipTemperature getChipTemperature();
 
    private:
     // private static

--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -26,15 +26,17 @@ namespace dai {
 // Device (RAII), connects to device and maintains watchdog, timesync, ...
 class Device {
    public:
+    // constants
+    static constexpr std::chrono::seconds DEFAULT_SEARCH_TIME{3};
+
     // static API
+    template <typename Rep, typename Period>
+    static std::tuple<bool, DeviceInfo> getAnyAvailableDevice(std::chrono::duration<Rep, Period> timeout);
+    static std::tuple<bool, DeviceInfo> getAnyAvailableDevice();
     static std::tuple<bool, DeviceInfo> getFirstAvailableDevice();
     static std::tuple<bool, DeviceInfo> getDeviceByMxId(std::string mxId);
     static std::vector<DeviceInfo> getAllAvailableDevices();
     static std::vector<std::uint8_t> getEmbeddedDeviceBinary(bool usb2Mode, OpenVINO::Version version = Pipeline::DEFAULT_OPENVINO_VERSION);
-
-    // static std::vector<deviceDesc_t> getAllConnectedDevices();
-    // static std::tuple<bool, deviceDesc_t> getFirstAvailableDeviceDesc();
-    /////
 
     explicit Device(const Pipeline& pipeline);
     Device(const Pipeline& pipeline, bool usb2Mode);

--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -30,7 +30,7 @@ class Device {
    public:
     // constants
     static constexpr std::chrono::seconds DEFAULT_SEARCH_TIME{3};
-    static constexpr std::size_t EVENT_QUEUE_MAXIMUM_SIZE{32768};
+    static constexpr std::size_t EVENT_QUEUE_MAXIMUM_SIZE{2048};
 
     // static API
     template <typename Rep, typename Period>

--- a/include/depthai/pipeline/datatype/ImgDetections.hpp
+++ b/include/depthai/pipeline/datatype/ImgDetections.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <chrono>
+#include <unordered_map>
+#include <vector>
+
+#include "depthai-shared/datatype/RawImgDetections.hpp"
+#include "depthai/pipeline/datatype/Buffer.hpp"
+namespace dai {
+
+// protected inheritance, so serialize isn't visible to users
+class ImgDetections : public Buffer {
+    std::shared_ptr<RawBuffer> serialize() const override;
+    RawImgDetections& dets;
+
+   public:
+    ImgDetections();
+    explicit ImgDetections(std::shared_ptr<RawImgDetections> ptr);
+    virtual ~ImgDetections() = default;
+
+    // reference
+    std::vector<ImgDetection>& detections;
+};
+
+}  // namespace dai

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -35,7 +35,6 @@ class ImgFrame : public Buffer {
     void setWidth(unsigned int);
     void setHeight(unsigned int);
     void setType(RawImgFrame::Type);
-
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <chrono>
 #include <unordered_map>
 #include <vector>
 
 #include "depthai-shared/datatype/RawImgFrame.hpp"
 #include "depthai/pipeline/datatype/Buffer.hpp"
-
 namespace dai {
 
 // protected inheritance, so serialize isn't visible to users
@@ -19,7 +19,7 @@ class ImgFrame : public Buffer {
     virtual ~ImgFrame() = default;
 
     // getters
-    Timestamp getTimestamp() const;
+    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
     unsigned int getInstanceNum() const;
     unsigned int getCategory() const;
     unsigned int getSequenceNum() const;
@@ -28,13 +28,14 @@ class ImgFrame : public Buffer {
     RawImgFrame::Type getType() const;
 
     // setters
-    void setTimestamp(Timestamp ts);
+    void setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp);
     void setInstanceNum(unsigned int);
     void setCategory(unsigned int);
     void setSequenceNum(unsigned int);
     void setWidth(unsigned int);
     void setHeight(unsigned int);
     void setType(RawImgFrame::Type);
+
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/datatype/SystemInformation.hpp
+++ b/include/depthai/pipeline/datatype/SystemInformation.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <chrono>
+#include <unordered_map>
+#include <vector>
+
+#include "depthai-shared/datatype/RawSystemInformation.hpp"
+#include "depthai/pipeline/datatype/Buffer.hpp"
+namespace dai {
+
+// protected inheritance, so serialize isn't visible to users
+class SystemInformation : public Buffer {
+    std::shared_ptr<RawBuffer> serialize() const override;
+    RawSystemInformation& systemInformation;
+
+   public:
+    SystemInformation();
+    explicit SystemInformation(std::shared_ptr<RawSystemInformation> ptr);
+    virtual ~SystemInformation() = default;
+
+    MemoryInfo& memoryDdrUsage;
+    MemoryInfo& memoryLeonOsUsage;
+    MemoryInfo& memoryLeonRtUsage;
+    CpuUsage& cpuLeonOsUsage;
+    CpuUsage& cpuLeonRtUsage;
+    ChipTemperature& chipTemperature;
+};
+
+}  // namespace dai

--- a/include/depthai/pipeline/node/SystemLogger.hpp
+++ b/include/depthai/pipeline/node/SystemLogger.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <depthai/pipeline/Node.hpp>
+
+// shared
+#include <depthai-shared/pb/properties/SystemLoggerProperties.hpp>
+
+namespace dai {
+namespace node {
+class SystemLogger : public Node {
+    dai::SystemLoggerProperties properties;
+
+    std::string getName() const override;
+    std::vector<Input> getInputs() override;
+    std::vector<Output> getOutputs() override;
+    nlohmann::json getProperties() override;
+    std::shared_ptr<Node> clone() override;
+
+   public:
+    SystemLogger(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
+
+    Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::SystemInformation, false}}};
+
+    void setRate(float hz);
+};
+
+}  // namespace node
+}  // namespace dai

--- a/include/depthai/pipeline/node/XLinkIn.hpp
+++ b/include/depthai/pipeline/node/XLinkIn.hpp
@@ -24,6 +24,10 @@ class XLinkIn : public Node {
     void setStreamName(const std::string& name);
     void setMaxDataSize(std::uint32_t maxDataSize);
     void setNumFrames(std::uint32_t numFrames);
+
+    std::string getStreamName() const;
+    std::uint32_t getMaxDataSize() const;
+    std::uint32_t getNumFrames() const;
 };
 
 }  // namespace node

--- a/include/depthai/pipeline/node/XLinkOut.hpp
+++ b/include/depthai/pipeline/node/XLinkOut.hpp
@@ -23,6 +23,9 @@ class XLinkOut : public Node {
 
     void setStreamName(const std::string& name);
     void setFpsLimit(float fps);
+
+    std::string getStreamName() const;
+    float getFpsLimit() const;
 };
 
 }  // namespace node

--- a/include/depthai/utility/LockingQueue.hpp
+++ b/include/depthai/utility/LockingQueue.hpp
@@ -9,9 +9,33 @@ template <typename T>
 class LockingQueue {
    public:
     LockingQueue() = default;
-    explicit LockingQueue(int maxSize, bool blocking = true) {
+    explicit LockingQueue(unsigned maxSize, bool blocking = true) {
         this->maxSize = maxSize;
         this->blocking = blocking;
+    }
+
+    void setMaxSize(unsigned sz) {
+        // Lock first
+        std::unique_lock<std::mutex> lock(guard);
+        maxSize = sz;
+    }
+
+    void setBlocking(bool bl) {
+        // Lock first
+        std::unique_lock<std::mutex> lock(guard);
+        blocking = bl;
+    }
+
+    unsigned getMaxSize() const {
+        // Lock first
+        std::unique_lock<std::mutex> lock(guard);
+        return maxSize;
+    }
+
+    bool getBlocking() const {
+        // Lock first
+        std::unique_lock<std::mutex> lock(guard);
+        return blocking;
     }
 
     void destruct() {
@@ -80,7 +104,9 @@ class LockingQueue {
         {
             std::unique_lock<std::mutex> lock(guard);
             if(!blocking) {
-                if(queue.size() >= maxSize) {
+                // if non blocking, remove as many oldest elements as necessary, so next one will fit
+                // necessary if maxSize was changed
+                while(queue.size() >= maxSize) {
                     queue.pop();
                 }
             } else {
@@ -99,7 +125,9 @@ class LockingQueue {
         {
             std::unique_lock<std::mutex> lock(guard);
             if(!blocking) {
-                if(queue.size() >= maxSize) {
+                // if non blocking, remove as many oldest elements as necessary, so next one will fit
+                // necessary if maxSize was changed
+                while(queue.size() >= maxSize) {
                     queue.pop();
                 }
             } else {

--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -51,7 +51,10 @@ DataOutputQueue::DataOutputQueue(const std::shared_ptr<XLinkConnection>& conn, c
                     std::vector<std::uint8_t> metadata;
                     DatatypeEnum type;
                     data->getRaw()->serialize(metadata, type);
-                    spdlog::trace("Received message from device - data size: {}, data type: {} data: {}", data->getRaw()->data.size(), type, nlohmann::json::from_msgpack(metadata).dump());
+                    spdlog::trace("Received message from device - data size: {}, data type: {} data: {}",
+                                  data->getRaw()->data.size(),
+                                  type,
+                                  nlohmann::json::from_msgpack(metadata).dump());
                 }
 
                 // release packet
@@ -128,7 +131,10 @@ DataInputQueue::DataInputQueue(const std::shared_ptr<XLinkConnection>& conn, con
                     std::vector<std::uint8_t> metadata;
                     DatatypeEnum type;
                     data->serialize(metadata, type);
-                    spdlog::trace("Sending message to device - data size: {}, data type: {} data: {}", data->data.size(), type, nlohmann::json::from_msgpack(metadata).dump());
+                    spdlog::trace("Sending message to device - data size: {}, data type: {} data: {}",
+                                  data->data.size(),
+                                  type,
+                                  nlohmann::json::from_msgpack(metadata).dump());
                 }
 
                 // serialize

--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -67,7 +67,7 @@ DataOutputQueue::DataOutputQueue(const std::shared_ptr<XLinkConnection>& conn, c
             conn->closeStream(name);
 
         } catch(const std::exception& ex) {
-            *pExceptionMessageCopy = std::string(ex.what());
+            *pExceptionMessageCopy = fmt::format("Communication exception - possible device error/misconfiguration. Original message '{}'", ex.what());
         }
 
         queue.destruct();
@@ -145,7 +145,7 @@ DataInputQueue::DataInputQueue(const std::shared_ptr<XLinkConnection>& conn, con
             conn->closeStream(name);
 
         } catch(const std::exception& ex) {
-            *pExceptionMessageCopy = std::string(ex.what());
+            *pExceptionMessageCopy = fmt::format("Communication exception - possible device error/misconfiguration. Original message '{}'", ex.what());
         }
 
         queue.destruct();

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -634,7 +634,7 @@ std::vector<std::string> Device::getQueueEvents(const std::vector<std::string>& 
         return true;
     };
 
-    if(timeout < std::chrono::microseconds(0)){
+    if(timeout < std::chrono::microseconds(0)) {
         // if timeout < 0, infinite wait time (no timeout)
         eventCv.wait(lock, predicate);
     } else {

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -587,6 +587,19 @@ void Device::setCallback(const std::string& name, std::function<std::shared_ptr<
 }
 
 std::vector<std::string> Device::getQueueEvents(const std::vector<std::string>& queueNames, std::size_t maxNumEvents, std::chrono::microseconds timeout) {
+    // First check if specified queues names are actually opened
+    auto availableQueueNames = getOutputQueueNames();
+    for(const auto& outputQueue : queueNames) {
+        bool found = false;
+        for(const auto& availableQueueName : availableQueueNames) {
+            if(outputQueue == availableQueueName) {
+                found = true;
+                break;
+            }
+        }
+        if(!found) throw std::runtime_error(fmt::format("Queue with name '{}' doesn't exist", outputQueue));
+    }
+
     // Blocking part
     // lock eventMtx
     std::unique_lock<std::mutex> lock(eventMtx);

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -633,11 +633,14 @@ std::vector<std::string> Device::getQueueEvents(const std::vector<std::string>& 
         // Otherwise acknowledge the wait and exit
         return true;
     };
-    // If timeout < 0, inifinite, else timeout
-    if(timeout < std::chrono::microseconds(0))
+
+    if(timeout < std::chrono::microseconds(0)){
+        // if timeout < 0, infinite wait time (no timeout)
         eventCv.wait(lock, predicate);
-    else
+    } else {
+        // otherwise respect timeout
         eventCv.wait_for(lock, timeout, predicate);
+    }
 
     // eventFromQueue should now contain the event name
     return eventsFromQueue;

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -83,6 +83,7 @@ template std::tuple<bool, DeviceInfo> Device::getAnyAvailableDevice(std::chrono:
 template std::tuple<bool, DeviceInfo> Device::getAnyAvailableDevice(std::chrono::seconds);
 constexpr std::chrono::seconds Device::DEFAULT_SEARCH_TIME;
 constexpr std::size_t Device::EVENT_QUEUE_MAXIMUM_SIZE;
+constexpr float Device::DEFAULT_SYSTEM_INFORMATION_LOGGING_RATE_HZ;
 
 template <typename Rep, typename Period>
 std::tuple<bool, DeviceInfo> Device::getAnyAvailableDevice(std::chrono::duration<Rep, Period> timeout) {
@@ -469,6 +470,9 @@ void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, c
         setLogLevel(LogLevel::WARN);
     }
 
+    // Sets system inforation logging rate. By default 1s
+    setSystemInformationLoggingRate(DEFAULT_SYSTEM_INFORMATION_LOGGING_RATE_HZ);
+
     // Open queues upfront, let queues know about data sizes (input queues)
     // Go through Pipeline and check for 'XLinkIn' and 'XLinkOut' nodes
     // and create corresponding default queues for them
@@ -694,6 +698,14 @@ ChipTemperature Device::getChipTemperature() {
     return client->call("getChipTemperature").as<ChipTemperature>();
 }
 
+CpuUsage Device::getLeonOsCpuUsage() {
+    return client->call("getLeonOsCpuUsage").as<CpuUsage>();
+}
+
+CpuUsage Device::getLeonRtCpuUsage() {
+    return client->call("getLeonRtCpuUsage").as<CpuUsage>();
+}
+
 bool Device::isPipelineRunning() {
     return client->call("isPipelineRunning").as<bool>();
 }
@@ -705,6 +717,14 @@ void Device::setLogLevel(LogLevel level) {
 
 LogLevel Device::getLogLevel() {
     return client->call("getLogLevel").as<LogLevel>();
+}
+
+void Device::setSystemInformationLoggingRate(float rateHz) {
+    client->call("setSystemInformationLoggingRate", rateHz);
+}
+
+float Device::getSystemInformationLoggingRate() {
+    return client->call("getSystemInformationLoggingrate").as<float>();
 }
 
 bool Device::startPipeline() {

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -504,9 +504,6 @@ void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, c
                 // notify the rest
                 eventCv.notify_all();
             });
-
-            // Add this queue to list
-            allQueueNames.push_back(xlinkOut->getStreamName());
         }
     }
 }
@@ -536,6 +533,15 @@ std::shared_ptr<DataOutputQueue> Device::getOutputQueue(const std::string& name,
     return outputQueueMap.at(name);
 }
 
+std::vector<std::string> Device::getOutputQueueNames() const {
+    std::vector<std::string> names;
+    names.reserve(outputQueueMap.size());
+    for(const auto& kv : outputQueueMap) {
+        names.push_back(kv.first);
+    }
+    return names;
+}
+
 std::shared_ptr<DataInputQueue> Device::getInputQueue(const std::string& name) {
     // Throw if queue not created
     // all queues for xlink streams are created upfront
@@ -559,6 +565,15 @@ std::shared_ptr<DataInputQueue> Device::getInputQueue(const std::string& name, u
 
     // Return pointer to this DataQueue
     return inputQueueMap.at(name);
+}
+
+std::vector<std::string> Device::getInputQueueNames() const {
+    std::vector<std::string> names;
+    names.reserve(inputQueueMap.size());
+    for(const auto& kv : inputQueueMap) {
+        names.push_back(kv.first);
+    }
+    return names;
 }
 
 void Device::setCallback(const std::string& name, std::function<std::shared_ptr<RawBuffer>(std::shared_ptr<RawBuffer>)> cb) {
@@ -626,7 +641,7 @@ std::vector<std::string> Device::getQueueEvents(std::string queueName, std::size
 }
 
 std::vector<std::string> Device::getQueueEvents(std::size_t maxNumEvents, std::chrono::microseconds timeout) {
-    return getQueueEvents(allQueueNames, maxNumEvents, timeout);
+    return getQueueEvents(getOutputQueueNames(), maxNumEvents, timeout);
 }
 
 std::string Device::getQueueEvent(const std::vector<std::string>& queueNames, std::chrono::microseconds timeout) {
@@ -643,7 +658,7 @@ std::string Device::getQueueEvent(std::string queueName, std::chrono::microsecon
 }
 
 std::string Device::getQueueEvent(std::chrono::microseconds timeout) {
-    return getQueueEvent(allQueueNames, timeout);
+    return getQueueEvent(getOutputQueueNames(), timeout);
 }
 
 // Convinience functions for querying current system information

--- a/src/pipeline/datatype/ImgDetections.cpp
+++ b/src/pipeline/datatype/ImgDetections.cpp
@@ -1,0 +1,13 @@
+#include "depthai/pipeline/datatype/ImgDetections.hpp"
+
+namespace dai {
+
+std::shared_ptr<RawBuffer> ImgDetections::serialize() const {
+    return raw;
+}
+
+ImgDetections::ImgDetections() : Buffer(std::make_shared<RawImgDetections>()), dets(*dynamic_cast<RawImgDetections*>(raw.get())), detections(dets.detections) {}
+ImgDetections::ImgDetections(std::shared_ptr<RawImgDetections> ptr)
+    : Buffer(std::move(ptr)), dets(*dynamic_cast<RawImgDetections*>(raw.get())), detections(dets.detections) {}
+
+}  // namespace dai

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -2,7 +2,6 @@
 
 #include "spdlog/fmt/fmt.h"
 
-
 namespace dai {
 
 std::shared_ptr<RawBuffer> ImgFrame::serialize() const {

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -1,19 +1,26 @@
 #include "depthai/pipeline/datatype/ImgFrame.hpp"
 
+#include "spdlog/fmt/fmt.h"
+
+
 namespace dai {
 
 std::shared_ptr<RawBuffer> ImgFrame::serialize() const {
     return raw;
 }
 
-ImgFrame::ImgFrame() : Buffer(std::make_shared<RawImgFrame>()), img(*dynamic_cast<RawImgFrame*>(raw.get())) {}
+ImgFrame::ImgFrame() : Buffer(std::make_shared<RawImgFrame>()), img(*dynamic_cast<RawImgFrame*>(raw.get())) {
+    // set timestamp to now
+    setTimestamp(std::chrono::steady_clock::now());
+}
 ImgFrame::ImgFrame(std::shared_ptr<RawImgFrame> ptr) : Buffer(std::move(ptr)), img(*dynamic_cast<RawImgFrame*>(raw.get())) {}
 
 // helpers
 
 // getters
-Timestamp ImgFrame::getTimestamp() const {
-    return img.ts;
+std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestamp() const {
+    using namespace std::chrono;
+    return std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration>{seconds(img.ts.sec) + nanoseconds(img.ts.nsec)};
 }
 unsigned int ImgFrame::getInstanceNum() const {
     return img.instanceNum;
@@ -35,8 +42,12 @@ RawImgFrame::Type ImgFrame::getType() const {
 }
 
 // setters
-void ImgFrame::setTimestamp(Timestamp ts) {
-    img.ts = ts;
+void ImgFrame::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
+    // Set timestamp from timepoint
+    using namespace std::chrono;
+    auto ts = tp.time_since_epoch();
+    img.ts.sec = duration_cast<seconds>(ts).count();
+    img.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
 }
 void ImgFrame::setInstanceNum(unsigned int instanceNum) {
     img.instanceNum = instanceNum;

--- a/src/pipeline/datatype/StreamPacketParser.cpp
+++ b/src/pipeline/datatype/StreamPacketParser.cpp
@@ -154,7 +154,7 @@ std::shared_ptr<ADatatype> parsePacketToADatatype(streamPacketDesc_t* packet) {
         case DatatypeEnum::SystemInformation:
             return std::make_shared<SystemInformation>(parseDatatype<RawSystemInformation>(jser, data));
             break;
-            
+
         default:
             throw std::runtime_error("Bad packet, couldn't parse");
             break;

--- a/src/pipeline/datatype/SystemInformation.cpp
+++ b/src/pipeline/datatype/SystemInformation.cpp
@@ -1,0 +1,29 @@
+#include "depthai/pipeline/datatype/SystemInformation.hpp"
+
+namespace dai {
+
+std::shared_ptr<RawBuffer> SystemInformation::serialize() const {
+    return raw;
+}
+
+SystemInformation::SystemInformation()
+    : Buffer(std::make_shared<RawSystemInformation>()),
+      systemInformation(*dynamic_cast<RawSystemInformation*>(raw.get())),
+      memoryDdrUsage(systemInformation.memoryDdrUsage),
+      memoryLeonOsUsage(systemInformation.memoryLeonOsUsage),
+      memoryLeonRtUsage(systemInformation.memoryLeonRtUsage),
+      cpuLeonOsUsage(systemInformation.cpuLeonOsUsage),
+      cpuLeonRtUsage(systemInformation.cpuLeonRtUsage),
+      chipTemperature(systemInformation.chipTemperature) {}
+
+SystemInformation::SystemInformation(std::shared_ptr<RawSystemInformation> ptr)
+    : Buffer(std::move(ptr)),
+      systemInformation(*dynamic_cast<RawSystemInformation*>(raw.get())),
+      memoryDdrUsage(systemInformation.memoryDdrUsage),
+      memoryLeonOsUsage(systemInformation.memoryLeonOsUsage),
+      memoryLeonRtUsage(systemInformation.memoryLeonRtUsage),
+      cpuLeonOsUsage(systemInformation.cpuLeonOsUsage),
+      cpuLeonRtUsage(systemInformation.cpuLeonRtUsage),
+      chipTemperature(systemInformation.chipTemperature) {}
+
+}  // namespace dai

--- a/src/pipeline/node/SystemLogger.cpp
+++ b/src/pipeline/node/SystemLogger.cpp
@@ -1,0 +1,37 @@
+#include "depthai/pipeline/node/SystemLogger.hpp"
+
+namespace dai {
+namespace node {
+
+SystemLogger::SystemLogger(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : Node(par, nodeId) {
+    properties.rateHz = 1.0f;
+}
+
+std::string SystemLogger::getName() const {
+    return "SystemLogger";
+}
+
+std::vector<Node::Input> SystemLogger::getInputs() {
+    return {};
+}
+
+std::vector<Node::Output> SystemLogger::getOutputs() {
+    return {out};
+}
+
+nlohmann::json SystemLogger::getProperties() {
+    nlohmann::json j;
+    nlohmann::to_json(j, properties);
+    return j;
+}
+
+std::shared_ptr<Node> SystemLogger::clone() {
+    return std::make_shared<std::decay<decltype(*this)>::type>(*this);
+}
+
+void SystemLogger::setRate(float hz) {
+    properties.rateHz = hz;
+}
+
+}  // namespace node
+}  // namespace dai

--- a/src/pipeline/node/XLinkIn.cpp
+++ b/src/pipeline/node/XLinkIn.cpp
@@ -39,5 +39,17 @@ void XLinkIn::setNumFrames(std::uint32_t numFrames) {
     properties.numFrames = numFrames;
 }
 
+std::string XLinkIn::getStreamName() const {
+    return properties.streamName;
+}
+
+std::uint32_t XLinkIn::getMaxDataSize() const {
+    return properties.maxDataSize;
+}
+
+std::uint32_t XLinkIn::getNumFrames() const {
+    return properties.numFrames;
+}
+
 }  // namespace node
 }  // namespace dai

--- a/src/pipeline/node/XLinkOut.cpp
+++ b/src/pipeline/node/XLinkOut.cpp
@@ -37,5 +37,13 @@ void XLinkOut::setFpsLimit(float fps) {
     properties.maxFpsLimit = fps;
 }
 
+std::string XLinkOut::getStreamName() const {
+    return properties.streamName;
+}
+
+float XLinkOut::getFpsLimit() const {
+    return properties.maxFpsLimit;
+}
+
 }  // namespace node
 }  // namespace dai

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -430,6 +430,8 @@ std::string XLinkConnection::convertErrorCodeToString(XLinkError_t errorCode) {
             return "X_LINK_ERROR";
         case X_LINK_OUT_OF_MEMORY:
             return "X_LINK_OUT_OF_MEMORY";
+        case X_LINK_NOT_IMPLEMENTED:
+            return "X_LINK_NOT_IMPLEMENTED";
         default:
             return "<UNKNOWN ERROR>";
     }


### PR DESCRIPTION
This PR adds a couple of improvements: (related PR: https://github.com/luxonis/depthai-shared/pull/17)
 - Queues are created from pipeline description and checks are performed if trying to access queues which don't correspond to pipeline
 - Added queue events, which enable to block on multiple queues at the same time
 - Added callback capability to DataOutputQueue
 - `Device` constructors have a better default - waits 3s for the device and as a last resort tries connecting to an already booted device (debugging case) - makes testing faster, removes the need to add delays.
 - Added functions to query devices system information
 - Added initial docstring documentation
 - Improved error messages and added more checks
 - Improved ImgFrame::getTimestamp by returning `time_point` (compared to synced `steady_clock`)
 - StreamPacketParser - added missing message types and modified build system to error out if missing in the future
 - Added `SystemInformation` message and `SystemLogger` node