### PR TITLE
Release 0.4.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(WIN32)
 endif()
 
 set(TARGET_NAME depthai-core)
-project(${TARGET_NAME} VERSION "0.3.0" LANGUAGES CXX C)
+project(${TARGET_NAME} VERSION "0.4.0" LANGUAGES CXX C)
 
 ### Dependency options
 option(DEPTHAI_BOOST_LOCAL "Use locally installed boost libraries" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(WIN32)
 endif()
 
 set(TARGET_NAME depthai-core)
-project(${TARGET_NAME} VERSION "0.4.0" LANGUAGES CXX C)
+project(${TARGET_NAME} VERSION "0.4.1" LANGUAGES CXX C)
 
 ### Dependency options
 option(DEPTHAI_BOOST_LOCAL "Use locally installed boost libraries" OFF)

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "1860863d0f10da90fc82098da935f4146a1a0d5b")            
+set(DEPTHAI_DEVICE_SIDE_COMMIT "922551b76fe361cd60dd9d24b88ce11d4dfc3e70")            
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -13,9 +13,9 @@ hunter_config(
 
 hunter_config(
     XLink
-    VERSION "luxonis-2020.2"
-    URL  "https://github.com/luxonis/XLink/archive/c944814af18f567d2d0ee54cb2e1a1dc6ee90d76.zip"
-    SHA1 "479414f7b9cfa55080c12d9ec1782bc9820d9521"
+    VERSION "luxonis-2020.2.0.1"
+    URL  "https://github.com/luxonis/XLink/archive/49528345a0e2f307d01f5eedc1a4ad47615af08b.zip"
+    SHA1 "5ae8044555f1772a85ec9100ef5446b9ee2c4a13"
     CMAKE_ARGS
         CMAKE_POSITION_INDEPENDENT_CODE=ON
 )

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -777,7 +777,7 @@ std::shared_ptr<CNNHostPipeline> Device::create_pipeline(
                         abort();
                     }
                     else{
-                        std::cerr << WARNING "Calibration file size " << sz << ENDC " < smaller than expected, data ignored. May need to recalibrate\n";
+                        std::cerr << WARNING "Calibration file size " << sz << ENDC " < smaller than expected, data ignored. Verify if calibration file is complete and correct or recalibrate\n";
                     }
                 } else {
                     calibration_reader.readData(reinterpret_cast<unsigned char*>(calibration_buff.data()), homography_size);


### PR DESCRIPTION
Tag will be created after merge.

Release includes:
Fix for model downloader when there is space in path.
Moved open3d install as optional.
Added -fusb2 for calibration.
Switched to 400p stereo resolution by default.
Added orientation check in calibration.
Flip camera orientation for OAK-1 by default.
Removed deprecated CLI options.
Increased manual exposure limits.