### PR TITLE
Add confirmation that the device has booted up

### DIFF
--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -199,10 +199,14 @@ void XLinkConnection::initDevice(const DeviceInfo& deviceToInit, XLinkDeviceStat
             throw std::runtime_error("Failed to find device (" + std::string(deviceToBoot.desc.name) + "), error message: " + convertErrorCodeToString(rc));
         }
 
+        bool boot_status;
         if(bootWithPath) {
-            bootAvailableDevice(foundDeviceDesc, pathToMvcmd);
+            boot_status = bootAvailableDevice(foundDeviceDesc, pathToMvcmd);
         } else {
-            bootAvailableDevice(foundDeviceDesc, mvcmd);
+            boot_status = bootAvailableDevice(foundDeviceDesc, mvcmd);
+        }
+        if(!boot_status) {
+            throw std::runtime_error("Failed to boot device!");
         }
     }
 

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -199,13 +199,13 @@ void XLinkConnection::initDevice(const DeviceInfo& deviceToInit, XLinkDeviceStat
             throw std::runtime_error("Failed to find device (" + std::string(deviceToBoot.desc.name) + "), error message: " + convertErrorCodeToString(rc));
         }
 
-        bool boot_status;
+        bool bootStatus;
         if(bootWithPath) {
-            boot_status = bootAvailableDevice(foundDeviceDesc, pathToMvcmd);
+            bootStatus = bootAvailableDevice(foundDeviceDesc, pathToMvcmd);
         } else {
-            boot_status = bootAvailableDevice(foundDeviceDesc, mvcmd);
+            bootStatus = bootAvailableDevice(foundDeviceDesc, mvcmd);
         }
-        if(!boot_status) {
+        if(!bootStatus) {
             throw std::runtime_error("Failed to boot device!");
         }
     }


### PR DESCRIPTION
Found useful while debugging:
```
$ ./examples/system_information 
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to find device after booting, error message: X_LINK_DEVICE_NOT_FOUND
Aborted (core dumped)
$ lsusb
Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 001 Device 011: ID 03e7:2485  
Bus 001 Device 002: ID 04f3:0103 Elan Microelectronics Corp. ActiveJet K-2024 Multimedia Keyboard
```