### PR TITLE
Allow direct access to the node connections

### DIFF
--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -56,8 +56,9 @@ class PipelineImpl {
     GlobalProperties globalProperties;
     // Optimized for adding, searching and removing connections
     std::unordered_map<Node::Id, std::shared_ptr<Node>> nodeMap;
+    using NodeConnectionMap = std::unordered_map<Node::Id, std::unordered_set<Node::Connection>>;
     // Connection map, NodeId represents id of node connected TO (input)
-    std::unordered_map<Node::Id, std::unordered_set<Node::Connection>> nodeConnectionMap;
+    NodeConnectionMap nodeConnectionMap;
 
     // Template create function
     template <class N>
@@ -126,6 +127,10 @@ class Pipeline {
 
     std::vector<Node::Connection> getConnections() const {
         return impl()->getConnections();
+    }
+
+    const PipelineImpl::NodeConnectionMap& getConnectionMap() const {
+        return impl()->nodeConnectionMap;
     }
 
     void link(const Node::Output& out, const Node::Input& in) {

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -129,7 +129,8 @@ class Pipeline {
         return impl()->getConnections();
     }
 
-    const PipelineImpl::NodeConnectionMap& getConnectionMap() const {
+    using NodeConnectionMap = PipelineImpl::NodeConnectionMap;
+    const NodeConnectionMap& getConnectionMap() const {
         return impl()->nodeConnectionMap;
     }
 


### PR DESCRIPTION
While writing a thin generic wrapper, I found it hard to perform a few operations without causing unnecessary state monitoring or memory allocations without this function
