### PR TITLE
Reduce memory allocations by using the nodeMap

### DIFF
--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -55,7 +55,8 @@ class PipelineImpl {
     // Global pipeline properties
     GlobalProperties globalProperties;
     // Optimized for adding, searching and removing connections
-    std::unordered_map<Node::Id, std::shared_ptr<Node>> nodeMap;
+    using NodeMap = std::unordered_map<Node::Id, std::shared_ptr<Node>>;
+    NodeMap nodeMap;
     using NodeConnectionMap = std::unordered_map<Node::Id, std::unordered_set<Node::Connection>>;
     // Connection map, NodeId represents id of node connected TO (input)
     NodeConnectionMap nodeConnectionMap;
@@ -132,6 +133,11 @@ class Pipeline {
     using NodeConnectionMap = PipelineImpl::NodeConnectionMap;
     const NodeConnectionMap& getConnectionMap() const {
         return impl()->nodeConnectionMap;
+    }
+
+    using NodeMap = PipelineImpl::NodeMap;
+    const NodeMap& getNodeMap() const {
+        return impl()->nodeMap;
     }
 
     void link(const Node::Output& out, const Node::Input& in) {

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -498,39 +498,43 @@ void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, c
     // Open queues upfront, let queues know about data sizes (input queues)
     // Go through Pipeline and check for 'XLinkIn' and 'XLinkOut' nodes
     // and create corresponding default queues for them
-    for(const auto& node : pipeline.getAllNodes()) {
-        auto xlinkIn = std::dynamic_pointer_cast<const node::XLinkIn>(node);
-        if(xlinkIn != nullptr) {
-            // Create DataInputQueue's
-            inputQueueMap[xlinkIn->getStreamName()] = std::make_shared<DataInputQueue>(connection, xlinkIn->getStreamName());
-            // set max data size, for more verbosity
-            inputQueueMap[xlinkIn->getStreamName()]->setMaxDataSize(xlinkIn->getMaxDataSize());
+    for(const auto& kv : pipeline.getNodeMap()) {
+        const auto& node = kv.second;
+        const auto& xlinkIn = std::dynamic_pointer_cast<const node::XLinkIn>(node);
+        if(xlinkIn == nullptr) {
+            continue;
         }
+        // Create DataInputQueue's
+        inputQueueMap[xlinkIn->getStreamName()] = std::make_shared<DataInputQueue>(connection, xlinkIn->getStreamName());
+        // set max data size, for more verbosity
+        inputQueueMap[xlinkIn->getStreamName()]->setMaxDataSize(xlinkIn->getMaxDataSize());
     }
-    for(const auto& node : pipeline.getAllNodes()) {
-        auto xlinkOut = std::dynamic_pointer_cast<const node::XLinkOut>(node);
-        if(xlinkOut != nullptr) {
-            // Create DataOutputQueue's
-            outputQueueMap[xlinkOut->getStreamName()] = std::make_shared<DataOutputQueue>(connection, xlinkOut->getStreamName());
-
-            // Add callback for events
-            outputQueueMap[xlinkOut->getStreamName()]->addCallback([this](std::string queueName, std::shared_ptr<ADatatype>) {
-                // Lock first
-                std::unique_lock<std::mutex> lock(eventMtx);
-
-                // Check if size is equal or greater than EVENT_QUEUE_MAXIMUM_SIZE
-                if(eventQueue.size() >= EVENT_QUEUE_MAXIMUM_SIZE) {
-                    auto numToRemove = eventQueue.size() - EVENT_QUEUE_MAXIMUM_SIZE + 1;
-                    eventQueue.erase(eventQueue.begin(), eventQueue.begin() + numToRemove);
-                }
-
-                // Add to the end of event queue
-                eventQueue.push_back(queueName);
-
-                // notify the rest
-                eventCv.notify_all();
-            });
+    for(const auto& kv : pipeline.getNodeMap()) {
+        const auto& node = kv.second;
+        const auto& xlinkOut = std::dynamic_pointer_cast<const node::XLinkOut>(node);
+        if(xlinkOut == nullptr) {
+            continue;
         }
+        // Create DataOutputQueue's
+        outputQueueMap[xlinkOut->getStreamName()] = std::make_shared<DataOutputQueue>(connection, xlinkOut->getStreamName());
+
+        // Add callback for events
+        outputQueueMap[xlinkOut->getStreamName()]->addCallback([this](std::string queueName, std::shared_ptr<ADatatype>) {
+            // Lock first
+            std::unique_lock<std::mutex> lock(eventMtx);
+
+            // Check if size is equal or greater than EVENT_QUEUE_MAXIMUM_SIZE
+            if(eventQueue.size() >= EVENT_QUEUE_MAXIMUM_SIZE) {
+                auto numToRemove = eventQueue.size() - EVENT_QUEUE_MAXIMUM_SIZE + 1;
+                eventQueue.erase(eventQueue.begin(), eventQueue.begin() + numToRemove);
+            }
+
+            // Add to the end of event queue
+            eventQueue.push_back(queueName);
+
+            // notify the rest
+            eventCv.notify_all();
+        });
     }
 }
 


### PR DESCRIPTION
- Add an accesor in `Pipeline` for the underlying node map
- Use the nodeMap acccessor, use early return to reduce indent
