### PR TITLE
Openvino 2021.2 support

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "cae01e25ced0510ca2cba17e383fe0ef99e036b1")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "3af09515e197052d1033ef5b9b9eb65c37bd0fed")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "f480b8f4c161ccda18d78f147a2dc210851bea65")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "127b920c32b208d5c49c604158358433bc7db2d7")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "387165012cfd7a8da4ea88eae3089ea00c78fbc0")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "52b5afe85633fd43047f671407d68580ac20b006")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "3af09515e197052d1033ef5b9b9eb65c37bd0fed")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "387165012cfd7a8da4ea88eae3089ea00c78fbc0")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "127b920c32b208d5c49c604158358433bc7db2d7")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "cae01e25ced0510ca2cba17e383fe0ef99e036b1")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "52b5afe85633fd43047f671407d68580ac20b006")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "e088f9f0d96a0d97a5a3bf2281c8fcb719a68fcf")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "e22af0891a00faf026a6eca545422c440eb70020")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "f480b8f4c161ccda18d78f147a2dc210851bea65")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -56,16 +56,16 @@ dai_add_example(mono_camera src/mono_camera_example.cpp)
 
 # NeuralNetwork node, mobilenet example
 hunter_private_data(
-    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet-ssd_6_shaves.blob"
-    SHA1 "c72a4902416be329fb0b455d0dcf8fb4f680aff7"
-    FILE "mobilenet-ssd_6_shaves.blob"
+    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet-ssd_openvino_2021.2_6shave.blob"
+    SHA1 "f0e14978b3f77a4f93b9f969cd39e58bb7aef490"
+    FILE "mobilenet-ssd_openvino_2021.2_6shave.blob"
     LOCATION mobilenet_blob
 )
 
 hunter_private_data(
-    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/tiny_yolo_v3_6shaves.blob"
-    SHA1 "7c87d89ab3bc1d58de7f61c0bbd4844a200ddeb5"
-    FILE "tiny_yolo_v3_6shaves.blob"
+    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/tiny-yolo-v3_openvino_2021.2_6shave.blob"
+    SHA1 "f0ac263a0d55c374e1892eea21c9b7d1170bde46"
+    FILE "tiny-yolo-v3_openvino_2021.2_6shave.blob"
     LOCATION tiny_yolo_v3_blob
 )
 

--- a/include/depthai/openvino/OpenVINO.hpp
+++ b/include/depthai/openvino/OpenVINO.hpp
@@ -13,13 +13,7 @@ namespace dai {
 class OpenVINO {
    public:
     // OpenVINOVersion holds supported version information
-    enum Version {
-        VERSION_2020_1,
-        VERSION_2020_2,
-        VERSION_2020_3,
-        VERSION_2020_4,
-        VERSION_2021_1,
-    };
+    enum Version { VERSION_2020_1, VERSION_2020_2, VERSION_2020_3, VERSION_2020_4, VERSION_2021_1, VERSION_2021_2 };
 
     static std::vector<Version> getVersions();
     static std::string getVersionName(Version version);

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -44,6 +44,7 @@ class NeuralNetwork : public Node {
     void setBlobPath(const std::string& path);
     void setNumPoolFrames(int numFrames);
     void setNumInferenceThreads(int numThreads);
+    void setNumNCEPerInferenceThread(int numNCEPerThread);
     // Zero means AUTO. TODO add AUTO in NeuralNetworkProperties
     int getNumInferenceThreads();
     // TODO add getters for other API

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -1,7 +1,6 @@
 #include "depthai/device/Device.hpp"
 
 // std
-#include <fstream>
 #include <iostream>
 
 // shared
@@ -279,10 +278,6 @@ Device::~Device() {
 }
 
 void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd) {
-    if(!pathToMvcmd.empty()) {
-        std::ifstream f(pathToMvcmd.c_str());
-        if(!f.good()) throw std::runtime_error("Error path doesn't exist. Note: Environment variables in path are not expanded. (E.g. '~', '$PATH').");
-    }
     // Initalize depthai library if not already
     initialize();
 

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -279,9 +279,10 @@ Device::~Device() {
 }
 
 void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd) {
-    std::ifstream f(pathToMvcmd.c_str());
-    if(!f.good()) throw std::runtime_error("Error path doesn't exist. Note: Environment variables in path are not expanded. (E.g. '~', '$PATH').");
-
+    if(!pathToMvcmd.empty()) {
+        std::ifstream f(pathToMvcmd.c_str());
+        if(!f.good()) throw std::runtime_error("Error path doesn't exist. Note: Environment variables in path are not expanded. (E.g. '~', '$PATH').");
+    }
     // Initalize depthai library if not already
     initialize();
 

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -1,6 +1,7 @@
 #include "depthai/device/Device.hpp"
 
 // std
+#include <fstream>
 #include <iostream>
 
 // shared
@@ -278,6 +279,9 @@ Device::~Device() {
 }
 
 void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd) {
+    std::ifstream f(pathToMvcmd.c_str());
+    if(!f.good()) throw std::runtime_error("Error path doesn't exist. Note: Environment variables in path are not expanded. (E.g. '~', '$PATH').");
+
     // Initalize depthai library if not already
     initialize();
 

--- a/src/openvino/OpenVINO.cpp
+++ b/src/openvino/OpenVINO.cpp
@@ -16,16 +16,21 @@ namespace dai {
 // major and minor represent openvino NN blob version information
 const std::map<std::pair<std::uint32_t, std::uint32_t>, OpenVINO::Version> OpenVINO::blobVersionToLatestOpenvinoMapping = {
     {{5, 0}, OpenVINO::VERSION_2020_3},
-    {{6, 0}, OpenVINO::VERSION_2021_1},
+    {{6, 0}, OpenVINO::VERSION_2021_2},
 };
 
 const std::map<std::pair<std::uint32_t, std::uint32_t>, std::vector<OpenVINO::Version>> OpenVINO::blobVersionToOpenvinoMapping = {
     {{5, 0}, {OpenVINO::VERSION_2020_1, OpenVINO::VERSION_2020_2, OpenVINO::VERSION_2020_3}},
-    {{6, 0}, {OpenVINO::VERSION_2020_4, OpenVINO::VERSION_2021_1}},
+    {{6, 0}, {OpenVINO::VERSION_2020_4, OpenVINO::VERSION_2021_1, OpenVINO::VERSION_2021_2}},
 };
 
 std::vector<OpenVINO::Version> OpenVINO::getVersions() {
-    return {OpenVINO::VERSION_2020_1, OpenVINO::VERSION_2020_2, OpenVINO::VERSION_2020_3, OpenVINO::VERSION_2020_4, OpenVINO::VERSION_2021_1};
+    return {OpenVINO::VERSION_2020_1,
+            OpenVINO::VERSION_2020_2,
+            OpenVINO::VERSION_2020_3,
+            OpenVINO::VERSION_2020_4,
+            OpenVINO::VERSION_2021_1,
+            OpenVINO::VERSION_2021_2};
 }
 
 std::string OpenVINO::getVersionName(OpenVINO::Version version) {
@@ -40,6 +45,8 @@ std::string OpenVINO::getVersionName(OpenVINO::Version version) {
             return "2020.4";
         case OpenVINO::VERSION_2021_1:
             return "2021.1";
+        case OpenVINO::VERSION_2021_2:
+            return "2021.2";
     }
     throw std::logic_error("OpenVINO - Unknown version enum specified");
 }

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -90,6 +90,11 @@ void NeuralNetwork::setNumInferenceThreads(int numThreads) {
     properties.numThreads = numThreads;
 }
 
+void NeuralNetwork::setNumNCEPerInferenceThread(int numNCEPerThread) {
+    NeuralNetworkProperties& properties = getPropertiesRef();
+    properties.numNCEPerThread = numNCEPerThread;
+}
+
 int NeuralNetwork::getNumInferenceThreads() {
     NeuralNetworkProperties& properties = getPropertiesRef();
     return properties.numThreads;

--- a/src/utility/Resources.cpp
+++ b/src/utility/Resources.cpp
@@ -35,22 +35,26 @@ constexpr static auto DEPTHAI_CMD_OPENVINO_2020_3_PATH = "depthai-device-openvin
 constexpr static auto DEPTHAI_CMD_OPENVINO_2020_2_PATH = DEPTHAI_CMD_OPENVINO_2020_3_PATH;
 constexpr static auto DEPTHAI_CMD_OPENVINO_2020_4_PATH = "depthai-device-openvino-2020.4-" DEPTHAI_DEVICE_VERSION ".cmd";
 constexpr static auto DEPTHAI_CMD_OPENVINO_2021_1_PATH = "depthai-device-openvino-2021.1-" DEPTHAI_DEVICE_VERSION ".cmd";
+constexpr static auto DEPTHAI_CMD_OPENVINO_2021_2_PATH = "depthai-device-openvino-2021.2-" DEPTHAI_DEVICE_VERSION ".cmd";
 constexpr static auto DEPTHAI_CMD_OPENVINO_2020_1_USB2_PATCH_PATH = "depthai-device-usb2-patch-openvino-2020.1-" DEPTHAI_DEVICE_VERSION ".patch";
 constexpr static auto DEPTHAI_CMD_OPENVINO_2020_3_USB2_PATCH_PATH = "depthai-device-usb2-patch-openvino-2020.3-" DEPTHAI_DEVICE_VERSION ".patch";
 constexpr static auto DEPTHAI_CMD_OPENVINO_2020_2_USB2_PATCH_PATH = DEPTHAI_CMD_OPENVINO_2020_3_USB2_PATCH_PATH;
 constexpr static auto DEPTHAI_CMD_OPENVINO_2020_4_USB2_PATCH_PATH = "depthai-device-usb2-patch-openvino-2020.4-" DEPTHAI_DEVICE_VERSION ".patch";
 constexpr static auto DEPTHAI_CMD_OPENVINO_2021_1_USB2_PATCH_PATH = "depthai-device-usb2-patch-openvino-2021.1-" DEPTHAI_DEVICE_VERSION ".patch";
-constexpr static std::array<const char*, 10> resourcesListTarXz = {
+constexpr static auto DEPTHAI_CMD_OPENVINO_2021_2_USB2_PATCH_PATH = "depthai-device-usb2-patch-openvino-2021.2-" DEPTHAI_DEVICE_VERSION ".patch";
+constexpr static std::array<const char*, 12> resourcesListTarXz = {
     DEPTHAI_CMD_OPENVINO_2020_1_PATH,
     DEPTHAI_CMD_OPENVINO_2020_2_PATH,
     DEPTHAI_CMD_OPENVINO_2020_3_PATH,
     DEPTHAI_CMD_OPENVINO_2020_4_PATH,
     DEPTHAI_CMD_OPENVINO_2021_1_PATH,
+    DEPTHAI_CMD_OPENVINO_2021_2_PATH,
     DEPTHAI_CMD_OPENVINO_2020_1_USB2_PATCH_PATH,
     DEPTHAI_CMD_OPENVINO_2020_2_USB2_PATCH_PATH,
     DEPTHAI_CMD_OPENVINO_2020_3_USB2_PATCH_PATH,
     DEPTHAI_CMD_OPENVINO_2020_4_USB2_PATCH_PATH,
     DEPTHAI_CMD_OPENVINO_2021_1_USB2_PATCH_PATH,
+    DEPTHAI_CMD_OPENVINO_2021_2_USB2_PATCH_PATH,
 };
 
 std::vector<std::uint8_t> Resources::getDeviceBinary(OpenVINO::Version version, bool usb2Mode) {
@@ -86,6 +90,10 @@ std::vector<std::uint8_t> Resources::getDeviceBinary(OpenVINO::Version version, 
         case OpenVINO::VERSION_2021_1:
             depthaiBinary = resourceMap[DEPTHAI_CMD_OPENVINO_2021_1_PATH];
             depthaiUsb2Patch = resourceMap[DEPTHAI_CMD_OPENVINO_2021_1_USB2_PATCH_PATH];
+            break;
+        case OpenVINO::VERSION_2021_2:
+            depthaiBinary = resourceMap[DEPTHAI_CMD_OPENVINO_2021_2_PATH];
+            depthaiUsb2Patch = resourceMap[DEPTHAI_CMD_OPENVINO_2021_2_USB2_PATCH_PATH];
             break;
     }
 

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstring>
+#include <fstream>
 #include <iostream>
 #include <thread>
 #include <vector>
@@ -133,6 +134,10 @@ XLinkConnection::XLinkConnection(const DeviceInfo& deviceDesc, std::vector<std::
 }
 
 XLinkConnection::XLinkConnection(const DeviceInfo& deviceDesc, std::string pathToMvcmd, XLinkDeviceState_t expectedState) {
+    if(!pathToMvcmd.empty()) {
+        std::ifstream f(pathToMvcmd.c_str());
+        if(!f.good()) throw std::runtime_error("Error path doesn't exist. Note: Environment variables in path are not expanded. (E.g. '~', '$PATH').");
+    }
     bootDevice = true;
     bootWithPath = true;
     this->pathToMvcmd = std::move(pathToMvcmd);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,9 +35,9 @@ endmacro()
 
 # Mobilenet network
 hunter_private_data(
-    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet.blob"
-    SHA1 "e89d3ee9f26d80397e44f89c6b375990064a4a42"
-    FILE "mobilenet.blob"
+    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/mobilenet-ssd_openvino_2021.2_6shave.blob"
+    SHA1 "f0e14978b3f77a4f93b9f969cd39e58bb7aef490"
+    FILE "mobilenet-ssd_openvino_2021.2_6shave.blob"
     LOCATION mobilenet_blob
 )
 


### PR DESCRIPTION
Added support for openvino 2021.2
On the FW side added additional checks in NN node if the blob is compatible with openvino version.
Added option to specify more than 1 NCE per inference thread. 

Related PR: https://github.com/luxonis/depthai-shared/pull/20