### PR TITLE
Gen2 - Input queue size capability

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "e22af0891a00faf026a6eca545422c440eb70020")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "17ff92fe24252ab91f0bf0fc53b466ac5efbdc47")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -102,3 +102,7 @@ target_compile_definitions(mobilenet_device_side_decoding PRIVATE BLOB_PATH="${m
 # Device side decoding example for tiny-yolo-v3
 dai_add_example(tiny_yolo_v3_device_side_decoding src/tiny_yolo_v3_device_side_decoding_example.cpp)
 target_compile_definitions(tiny_yolo_v3_device_side_decoding PRIVATE BLOB_PATH="${tiny_yolo_v3_blob}")
+
+# NN sync example
+dai_add_example(camera_mobilenet_sync src/camera_mobilenet_sync_example.cpp)
+target_compile_definitions(camera_mobilenet_sync PRIVATE BLOB_PATH="${mobilenet_blob}")

--- a/examples/src/camera_mobilenet_sync_example.cpp
+++ b/examples/src/camera_mobilenet_sync_example.cpp
@@ -1,0 +1,146 @@
+#include <iostream>
+#include <cstdio>
+#include <deque>
+
+#include "utility.hpp"
+
+// Inludes common necessary includes for development using depthai library
+#include "depthai/depthai.hpp"
+
+
+int main(int argc, char** argv){
+    using namespace std;
+    using namespace std::chrono;
+
+    // Default blob path provided by Hunter private data download
+    // Applicable for easier example usage only
+    std::string nnPath(BLOB_PATH);
+    // If path to blob specified, use that
+    if(argc > 1){
+        nnPath = std::string(argv[1]);
+    }
+
+    dai::Pipeline pipeline;
+
+    auto colorCam = pipeline.create<dai::node::ColorCamera>();
+    auto nn = pipeline.create<dai::node::MobileNetDetectionNetwork>();
+    auto camOut = pipeline.create<dai::node::XLinkOut>();
+    auto passthroughMeta = pipeline.create<dai::node::XLinkOut>();
+    auto resultOut = pipeline.create<dai::node::XLinkOut>();
+
+    camOut->setStreamName("preview");
+    passthroughMeta->setMetadataOnly(true);
+    passthroughMeta->setStreamName("passthroughMeta");
+    resultOut->setStreamName("resultOut");
+    
+    // ColorCamera options
+    colorCam->setPreviewSize(300, 300);
+    colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+    colorCam->setInterleaved(false);
+    colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
+
+    // NN input options
+    nn->input.setBlocking(false);
+    nn->input.setQueueSize(1);
+    nn->setBlobPath(nnPath);
+    // Change to 1 to observe slower consumer syncing
+    nn->setNumInferenceThreads(2);
+
+
+    // Link nodes CAM -> XLINK
+    colorCam->preview.link(nn->input);
+    colorCam->preview.link(camOut->input);
+    nn->passthrough.link(passthroughMeta->input); 
+    nn->out.link(resultOut->input); 
+
+    // Connect to device and start pipeline
+    dai::Device device(pipeline);
+    device.startPipeline();
+
+    // Create input & output queues
+    auto previewQueue = device.getOutputQueue("preview");
+    auto passthroughQueue = device.getOutputQueue("passthroughMeta");
+    auto resultQueue = device.getOutputQueue("resultOut");
+
+    // Get first passthrough and result at the same time
+    auto prevPassthrough = passthroughQueue->get<dai::ImgFrame>();
+    auto prevResult = resultQueue->get<dai::ImgDetections>();
+
+    // statistics
+    nanoseconds sumLatency{0};
+    milliseconds avgLatency{0};
+    int numFrames = 0;
+    int nnFps = 0, lastNnFps = 0;
+    auto lastTime = steady_clock::now();
+
+    while(true){
+
+        // Get first passthrough and result at the same time
+        auto passthrough = passthroughQueue->get<dai::ImgFrame>();
+        auto result = resultQueue->get<dai::ImgDetections>();
+
+        nnFps++;
+
+        // Match up prevResults and previews
+        while(true){
+            
+            // pop the preview
+            auto preview = previewQueue->get<dai::ImgFrame>();
+            
+            // process
+            cv::Mat frame = toMat(preview->getData(), preview->getWidth(), preview->getHeight(), 3, 1);
+
+            // Draw all detections
+            for(const auto& d : result->detections){
+                int x1 = d.xmin * frame.cols;
+                int y1 = d.ymin * frame.rows;
+                int x2 = d.xmax * frame.cols;
+                int y2 = d.ymax * frame.rows;
+                cv::rectangle(frame, cv::Rect(cv::Point(x1, y1), cv::Point(x2, y2)), cv::Scalar(255,255,255));
+            }
+
+            // Draw avg latency and previous fps
+            cv::putText(frame, std::string("NN: ") + std::to_string(lastNnFps), cv::Point(5,20), cv::FONT_HERSHEY_PLAIN, 1, cv::Scalar(255,0,0));
+            cv::putText(frame, std::string("Latency: ") + std::to_string(avgLatency.count()), cv::Point(frame.cols - 120, 20), cv::FONT_HERSHEY_PLAIN, 1, cv::Scalar(255,0,0));
+
+            // Display
+            cv::imshow("frame", frame);
+            
+            // If seq number >= next detection seq number - 1, break
+            if(preview->getSequenceNum() >= passthrough->getSequenceNum() - 1){
+
+                numFrames++;
+                sumLatency = sumLatency + (steady_clock::now() - preview->getTimestamp());
+
+                if(steady_clock::now() - lastTime >= seconds(1)){
+                    
+                    // calculate fps
+                    lastNnFps = nnFps;
+                    nnFps = 0.0f;
+
+                    //calculate latency
+                    avgLatency = duration_cast<milliseconds>(sumLatency / numFrames);
+                    sumLatency = nanoseconds(0);
+                    numFrames = 0;
+                    
+                    //reset last time
+                    lastTime = steady_clock::now();
+                }
+
+                // break out of the loop
+                break;
+            }
+        }
+
+        // Move current NN results to prev
+        prevPassthrough = passthrough;
+        prevResult = result;
+
+        int key = cv::waitKey(1);
+        if (key == 'q'){
+            return 0;
+        } 
+
+    }
+
+}

--- a/include/depthai/device/DataQueue.hpp
+++ b/include/depthai/device/DataQueue.hpp
@@ -38,14 +38,14 @@ class DataOutputQueue {
     ~DataOutputQueue();
 
     /**
-     * Sets queue behaviour when full (maxSize)
+     * Sets queue behavior when full (maxSize)
      *
      * @param blocking Specifies if block or overwrite the oldest message in the queue
      */
     void setBlocking(bool blocking);
 
     /**
-     * Gets current queue behaviour when full (maxSize)
+     * Gets current queue behavior when full (maxSize)
      *
      * @return true if blocking, false otherwise
      */
@@ -265,14 +265,14 @@ class DataInputQueue {
     std::size_t getMaxDataSize();
 
     /**
-     * Sets queue behaviour when full (maxSize)
+     * Sets queue behavior when full (maxSize)
      *
      * @param blocking Specifies if block or overwrite the oldest message in the queue
      */
     void setBlocking(bool blocking);
 
     /**
-     * Gets current queue behaviour when full (maxSize)
+     * Gets current queue behavior when full (maxSize)
      *
      * @return true if blocking, false otherwise
      */

--- a/include/depthai/device/DataQueue.hpp
+++ b/include/depthai/device/DataQueue.hpp
@@ -146,6 +146,18 @@ class DataOutputQueue {
         return get<ADatatype>();
     }
 
+    template <class T>
+    std::shared_ptr<T> front() {
+        if(!running) throw std::runtime_error(exceptionMessage.c_str());
+        std::shared_ptr<ADatatype> val = nullptr;
+        if(!queue.front(val)) return nullptr;
+        return std::dynamic_pointer_cast<T>(val);
+    }
+
+    std::shared_ptr<ADatatype> front() {
+        return front<ADatatype>();
+    }
+
     template <class T, typename Rep, typename Period>
     std::shared_ptr<T> get(std::chrono::duration<Rep, Period> timeout, bool& hasTimedout) {
         if(!running) throw std::runtime_error(exceptionMessage.c_str());

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -79,7 +79,7 @@ class Node {
 
        public:
         /**
-         * Overrides default input queue behvairor.
+         * Overrides default input queue behavior.
          * @param blocking True blocking, false overwriting
          */
         void setBlocking(bool blocking);

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -41,7 +41,7 @@ class Node {
 
     struct Output {
         enum class Type { MSender, SSender };
-        const Node& parent;
+        Node& parent;
         const std::string name;
         const Type type;
         // Which types and do descendants count as well?
@@ -59,19 +59,49 @@ class Node {
 
     struct Input {
         enum class Type { SReceiver, MReceiver };
-        const Node& parent;
+        Node& parent;
         const std::string name;
         const Type type;
-        bool blocking{true};
+        bool defaultBlocking{true};
+        int defaultQueueSize{8};
+        tl::optional<bool> blocking;
+        tl::optional<int> queueSize;
         friend struct Output;
-        // Which types and do descendants count as well?
         const std::vector<DatatypeHierarchy> possibleDatatypes;
+
+        /// Constructs Input with default blocking and queueSize options
         Input(Node& par, std::string n, Type t, std::vector<DatatypeHierarchy> types)
             : parent(par), name(std::move(n)), type(t), possibleDatatypes(std::move(types)) {}
 
+        /// Constructs Input with specified blocking and queueSize options
+        Input(Node& par, std::string n, Type t, bool blocking, int queueSize, std::vector<DatatypeHierarchy> types)
+            : parent(par), name(std::move(n)), type(t), defaultBlocking(blocking), defaultQueueSize(queueSize), possibleDatatypes(std::move(types)) {}
+
        public:
+        /**
+         * Overrides default input queue behvairor.
+         * @param blocking True blocking, false overwriting
+         */
         void setBlocking(bool blocking);
+
+        /**
+         * Get input queue behavior
+         * @return True blocking, false overwriting
+         */
         bool getBlocking() const;
+
+        /**
+         * Overrides default input queue size.
+         * If queue size fills up, behavior depends on `blocking` attribute
+         * @param size Maximum input queue size
+         */
+        void setQueueSize(int size);
+
+        /**
+         * Get input queue size.
+         * @return Maximum input queue size
+         */
+        int getQueueSize() const;
     };
 
     // when Pipeline tries to serialize and construct on remote, it will check if all connected nodes are on same pipeline
@@ -83,7 +113,8 @@ class Node {
     virtual std::shared_ptr<Node> clone() = 0;
 
     // access
-    Pipeline getParentPipeline() const;
+    Pipeline getParentPipeline();
+    const Pipeline getParentPipeline() const;
 
    public:
     const Id id;

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -25,8 +25,17 @@ class ColorCamera : public Node {
 
     CameraControl initialControl;
 
-    Input inputConfig{*this, "inputConfig", Input::Type::SReceiver, {{DatatypeEnum::ImageManipConfig, false}}};
-    Input inputControl{*this, "inputControl", Input::Type::SReceiver, {{DatatypeEnum::CameraControl, false}}};
+    /**
+     * Input for ImageManipConfig message, which can modify crop paremeters in runtime
+     * Default queue is non-blocking with size 8
+     */
+    Input inputConfig{*this, "inputConfig", Input::Type::SReceiver, false, 8, {{DatatypeEnum::ImageManipConfig, false}}};
+
+    /**
+     * Input for CameraControl message, which can modify camera parameters in runtime
+     * Default queue is blocking with size 8
+     */
+    Input inputControl{*this, "inputControl", Input::Type::SReceiver, true, 8, {{DatatypeEnum::CameraControl, false}}};
 
     Output video{*this, "video", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};
     Output preview{*this, "preview", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};

--- a/include/depthai/pipeline/node/DetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/DetectionNetwork.hpp
@@ -25,7 +25,11 @@ class DetectionNetwork : public NeuralNetwork {
     dai::DetectionNetworkProperties properties;
 
    public:
-    Input input{*this, "in", Input::Type::SReceiver, {{DatatypeEnum::Buffer, true}}};
+    /**
+     * Input message with data to be infered upon
+     * Default queue is blocking with size 5
+     */
+    Input input{*this, "in", Input::Type::SReceiver, true, 5, {{DatatypeEnum::Buffer, true}}};
     Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::ImgDetections, false}}};
     Output passthrough{*this, "passthrough", Output::Type::MSender, {{DatatypeEnum::Buffer, true}}};
 

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -25,8 +25,17 @@ class ImageManip : public Node {
 
     ImageManipConfig initialConfig;
 
-    Input inputConfig{*this, "inputConfig", Input::Type::SReceiver, {{DatatypeEnum::ImageManipConfig, true}}};
-    Input inputImage{*this, "inputImage", Input::Type::SReceiver, {{DatatypeEnum::ImgFrame, true}}};
+    /**
+     * Input ImageManipConfig message with ability to modify parameters in runtime
+     * Default queue is blocking with size 8
+     */
+    Input inputConfig{*this, "inputConfig", Input::Type::SReceiver, true, 8, {{DatatypeEnum::ImageManipConfig, true}}};
+
+    /**
+     * Input image to be modified
+     * Default queue is blocking with size 8
+     */
+    Input inputImage{*this, "inputImage", Input::Type::SReceiver, true, 8, {{DatatypeEnum::ImgFrame, true}}};
 
     Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::ImgFrame, true}}};
 

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -26,7 +26,11 @@ class MonoCamera : public Node {
 
     CameraControl initialControl;
 
-    Input inputControl{*this, "inputControl", Input::Type::SReceiver, {{DatatypeEnum::CameraControl, false}}};
+    /**
+     * Input for CameraControl message, which can modify camera parameters in runtime
+     * Default queue is blocking with size 8
+     */
+    Input inputControl{*this, "inputControl", Input::Type::SReceiver, true, 8, {{DatatypeEnum::CameraControl, false}}};
 
     Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};
 

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -36,7 +36,11 @@ class NeuralNetwork : public Node {
    public:
     NeuralNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 
-    Input input{*this, "in", Input::Type::SReceiver, {{DatatypeEnum::Buffer, true}}};
+    /**
+     * Input message with data to be infered upon
+     * Default queue is blocking with size 5
+     */
+    Input input{*this, "in", Input::Type::SReceiver, true, 5, {{DatatypeEnum::Buffer, true}}};
     Output out{*this, "out", Output::Type::MSender, {{DatatypeEnum::NNData, false}}};
     Output passthrough{*this, "passthrough", Output::Type::MSender, {{DatatypeEnum::Buffer, true}}};
 

--- a/include/depthai/pipeline/node/SPIOut.hpp
+++ b/include/depthai/pipeline/node/SPIOut.hpp
@@ -38,7 +38,11 @@ class SPIOut : public Node {
         properties.busId = 0;
     }
 
-    Input input{*this, "in", Input::Type::SReceiver, {{DatatypeEnum::Buffer, true}}};
+    /**
+     * Input for any type of messages to be transfered over SPI stream
+     * Default queue is blocking with size 8
+     */
+    Input input{*this, "in", Input::Type::SReceiver, true, 8, {{DatatypeEnum::Buffer, true}}};
 
     void setStreamName(std::string name) {
         properties.streamName = name;

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -20,8 +20,17 @@ class StereoDepth : public Node {
    public:
     StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 
-    Input left{*this, "left", Input::Type::SReceiver, {{DatatypeEnum::ImgFrame, true}}};
-    Input right{*this, "right", Input::Type::SReceiver, {{DatatypeEnum::ImgFrame, true}}};
+    /**
+     * Input for left ImgFrame of left-right pair
+     * Default queue is non-blocking with size 8
+     */
+    Input left{*this, "left", Input::Type::SReceiver, false, 8, {{DatatypeEnum::ImgFrame, true}}};
+    /**
+     * Input for right ImgFrame of left-right pair
+     * Default queue is non-blocking with size 8
+     */
+    Input right{*this, "right", Input::Type::SReceiver, false, 8, {{DatatypeEnum::ImgFrame, true}}};
+
     Output depth{*this, "depth", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};
     Output disparity{*this, "disparity", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};
     Output syncedLeft{*this, "syncedLeft", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};

--- a/include/depthai/pipeline/node/VideoEncoder.hpp
+++ b/include/depthai/pipeline/node/VideoEncoder.hpp
@@ -19,7 +19,11 @@ class VideoEncoder : public Node {
    public:
     VideoEncoder(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 
-    Input input{*this, "in", Input::Type::SReceiver, {{DatatypeEnum::ImgFrame, true}}};
+    /**
+     * Input for NV12 ImgFrame to be encoded
+     * Default queue is blocking with size set by 'setNumFramesPool' (4).
+     */
+    Input input{*this, "in", Input::Type::SReceiver, true, 4, {{DatatypeEnum::ImgFrame, true}}};
     Output bitstream{*this, "bitstream", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};
 
     // Sets default options for a specified size and profile

--- a/include/depthai/pipeline/node/XLinkOut.hpp
+++ b/include/depthai/pipeline/node/XLinkOut.hpp
@@ -19,13 +19,27 @@ class XLinkOut : public Node {
    public:
     XLinkOut(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 
-    Input input{*this, "in", Input::Type::SReceiver, {{DatatypeEnum::Buffer, true}}};
+    /**
+     * Input for any type of messages to be transfered over XLink stream
+     * Default queue is blocking with size 8
+     */
+    Input input{*this, "in", Input::Type::SReceiver, true, 8, {{DatatypeEnum::Buffer, true}}};
 
     void setStreamName(const std::string& name);
     void setFpsLimit(float fps);
 
+    /**
+     * Specify whether transfer data or only object attributes (metadata)
+     */
+    void setMetadataOnly(bool metadataOnly);
+
     std::string getStreamName() const;
     float getFpsLimit() const;
+
+    /**
+     * Get whether transfer data or only object attributes (metadata)
+     */
+    bool getMetadataOnly() const;
 };
 
 }  // namespace node

--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -15,7 +15,12 @@ tl::optional<OpenVINO::Version> Node::getRequiredOpenVINOVersion() {
     return tl::nullopt;
 }
 
-Pipeline Node::getParentPipeline() const {
+const Pipeline Node::getParentPipeline() const {
+    Pipeline pipeline(std::shared_ptr<PipelineImpl>{parent});
+    return pipeline;
+}
+
+Pipeline Node::getParentPipeline() {
     Pipeline pipeline(std::shared_ptr<PipelineImpl>{parent});
     return pipeline;
 }
@@ -71,7 +76,21 @@ void Node::Input::setBlocking(bool blocking) {
 }
 
 bool Node::Input::getBlocking() const {
-    return blocking;
+    if(blocking) {
+        return *blocking;
+    }
+    return defaultBlocking;
+}
+
+void Node::Input::setQueueSize(int size) {
+    this->queueSize = size;
+}
+
+int Node::Input::getQueueSize() const {
+    if(queueSize) {
+        return *queueSize;
+    }
+    return defaultQueueSize;
 }
 
 }  // namespace dai

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -139,6 +139,7 @@ PipelineSchema PipelineImpl::getPipelineSchema() const {
         for(const auto& input : inputs) {
             NodeIoInfo io;
             io.blocking = input.getBlocking();
+            io.queueSize = input.getQueueSize();
             io.name = input.name;
             switch(input.type) {
                 case Node::Input::Type::MReceiver:
@@ -149,7 +150,7 @@ PipelineSchema PipelineImpl::getPipelineSchema() const {
                     break;
             }
 
-            info.ioInfo.push_back(io);
+            info.ioInfo[io.name] = io;
         }
 
         // Add outputs
@@ -166,11 +167,11 @@ PipelineSchema PipelineImpl::getPipelineSchema() const {
                     break;
             }
 
-            info.ioInfo.push_back(io);
+            info.ioInfo[io.name] = io;
         }
 
         // At the end, add the constructed node information to the schema
-        schema.nodes.push_back(info);
+        schema.nodes[info.id] = info;
     }
 
     // Create 'connections' info

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -19,7 +19,7 @@ ImgFrame::ImgFrame(std::shared_ptr<RawImgFrame> ptr) : Buffer(std::move(ptr)), i
 // getters
 std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestamp() const {
     using namespace std::chrono;
-    return std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration>{seconds(img.ts.sec) + nanoseconds(img.ts.nsec)};
+    return time_point<steady_clock, steady_clock::duration>{seconds(img.ts.sec) + nanoseconds(img.ts.nsec)};
 }
 unsigned int ImgFrame::getInstanceNum() const {
     return img.instanceNum;

--- a/src/pipeline/node/VideoEncoder.cpp
+++ b/src/pipeline/node/VideoEncoder.cpp
@@ -30,6 +30,8 @@ std::shared_ptr<Node> VideoEncoder::clone() {
 // node properties
 void VideoEncoder::setNumFramesPool(int frames) {
     properties.numFramesPool = frames;
+    // Set default input queue size as well
+    input.defaultQueueSize = frames;
 }
 
 int VideoEncoder::getNumFramesPool() const {

--- a/src/pipeline/node/XLinkOut.cpp
+++ b/src/pipeline/node/XLinkOut.cpp
@@ -37,12 +37,20 @@ void XLinkOut::setFpsLimit(float fps) {
     properties.maxFpsLimit = fps;
 }
 
+void XLinkOut::setMetadataOnly(bool metadataOnly) {
+    properties.metadataOnly = metadataOnly;
+}
+
 std::string XLinkOut::getStreamName() const {
     return properties.streamName;
 }
 
 float XLinkOut::getFpsLimit() const {
     return properties.maxFpsLimit;
+}
+
+bool XLinkOut::getMetadataOnly() const {
+    return properties.metadataOnly;
 }
 
 }  // namespace node


### PR DESCRIPTION
Related: https://github.com/luxonis/depthai-shared/pull/21
- Added default input queue sizes
- Added XLinkOut metadataOnly option
- Modified documentation of inputs to reflect their capabilities and defaults
- Added NN sync example using metadataOnly and queue sizes features