### PR TITLE
Change enumerated product name to Luxonis Device / Luxonis Bootloader

### DIFF
--- a/cmake/Depthai/DepthaiBootloaderConfig.cmake
+++ b/cmake/Depthai/DepthaiBootloaderConfig.cmake
@@ -2,4 +2,4 @@
 set(DEPTHAI_BOOTLOADER_MATURITY "release")  
 
 # "version if applicable"
-set(DEPTHAI_BOOTLOADER_VERSION "0.0.10")
+set(DEPTHAI_BOOTLOADER_VERSION "0.0.11")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "f2d0313939538c4dfa40fa142e22a6d9ea227393")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "37a2c71ec7b87b24fba7d6c018c701acf662c077")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
The usb device will be enumarated as:
![image](https://user-images.githubusercontent.com/60790666/108715869-16662f00-7524-11eb-8831-c94c9a690651.png)


Note: On MacOS/Windows a restart might be necessary to see the changes.