### PR TITLE
Gen2: improve image resize (ColorCamera / ImageManip)

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "4549a0e785f7e3a5d79481c05112e5f78ceb5e4e")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "5e4974e930f4ecbe1bf718463f6a5da664e68788")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "37a2c71ec7b87b24fba7d6c018c701acf662c077")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "4549a0e785f7e3a5d79481c05112e5f78ceb5e4e")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
For example, resizing `1920 x 1080` to `300 x 300`, keeping aspect ratio (not squishing the image):
```
- before: scale with Num/Denom = 3 / 10 -> 576 x 324 -> center crop with some vertical content loss
- now:    scale with Num/Denom = 5 / 18 -> 534 x 300 -> center crop with no vertical content loss
```
There is still a hardware limitation for the range of scaling factors:
- Numerator: `1..16`
- Denominator: `1..63`

Also currently there is a granularity applied to the image height, of 4 lines. If the requested size height is not multiple of 4, or if the scaling ratio doesn't fit in the available factor values, a small cropping can occur.