### PR TITLE
Jetson-compile-error-fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ if(POLICY CMP0028)
 endif()
 
 # Set to export compile commands for tools like clang-tidy and format
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Add module path


### PR DESCRIPTION
Added `position independent code` option to overcome compilation error on jetson.