### PR TITLE
fix narrowing compile warnings; mutex lock

### DIFF
--- a/include/depthai/pipeline/node/VideoEncoder.hpp
+++ b/include/depthai/pipeline/node/VideoEncoder.hpp
@@ -101,7 +101,7 @@ class VideoEncoder : public Node {
      * Sets expected frame rate
      * @param frameRate Frame rate in frames per second
      */
-    void setFrameRate(int frameRate);
+    void setFrameRate(float frameRate);
 
     /// Get rate control mode
     Properties::RateControlMode getRateControlMode() const;
@@ -123,7 +123,7 @@ class VideoEncoder : public Node {
     /// Get input height
     int getHeight() const;
     /// Get frame rate
-    int getFrameRate() const;
+    float getFrameRate() const;
 };
 
 }  // namespace node

--- a/src/bspatch/bspatch.c
+++ b/src/bspatch/bspatch.c
@@ -126,12 +126,12 @@ int bspatch_mem(const uint8_t* oldfile_bin, const int64_t oldfile_size, const ui
     uint8_t* p_decompressed_block_end[NUM_BLOCKS] = {NULL, NULL, NULL};
 
     for(int i = 0; i < NUM_BLOCKS; i++) {
-        unsigned int decompressed_size = newsize * 4;
+        unsigned int decompressed_size = (unsigned int)newsize * 4;
         p_decompressed_block_original[i] = malloc(decompressed_size);  // reserve enough memory
 
         int ret = 0;
         if((ret = BZ2_bzBuffToBuffDecompress(
-                (char*)p_decompressed_block_original[i], &decompressed_size, (char*)patchfile_bin + block_offset_bz2[i], block_size_bz2[i], 0, 0))
+                (char*)p_decompressed_block_original[i], &decompressed_size, (char*)patchfile_bin + block_offset_bz2[i], (unsigned int)block_size_bz2[i], 0, 0))
            != BZ_OK) {
             (void)ret;
             error = -1;

--- a/src/device/CallbackHandler.cpp
+++ b/src/device/CallbackHandler.cpp
@@ -37,7 +37,7 @@ CallbackHandler::CallbackHandler(std::shared_ptr<XLinkConnection> conn,
                 stream.write(serialized);
             }
 
-        } catch(const std::exception& ex) {
+        } catch(const std::exception&) {
             // TODO(themarpe) - throw an exception
             assert(0 && "TODO");
         }

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -398,7 +398,7 @@ void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, c
 
     client = std::unique_ptr<nanorpc::core::client<nanorpc::packer::nlohmann_msgpack>>(
         new nanorpc::core::client<nanorpc::packer::nlohmann_msgpack>([this](nanorpc::core::type::buffer request) {
-            std::unique_lock<std::mutex>(this->rpcMutex);
+            std::unique_lock<std::mutex> lock(this->rpcMutex);
 
             // Log the request data
             if(spdlog::get_level() == spdlog::level::trace) {
@@ -419,7 +419,7 @@ void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, c
         while(watchdogRunning) {
             try {
                 client->call("watchdogKeepalive");
-            } catch(const std::exception& ex) {
+            } catch(const std::exception&) {
                 break;
             }
             // Ping with a period half of that of the watchdog timeout
@@ -564,7 +564,7 @@ void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, c
             });
         }
 
-    } catch(const std::exception& ex) {
+    } catch(const std::exception&) {
         // close device (cleanup)
         close();
         // Rethrow original exception

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -98,26 +98,26 @@ std::vector<uint8_t> DeviceBootloader::createDepthaiApplicationPackage(Pipeline&
     // First section, MVCMD, name '__firmware'
     sbr_section_set_name(fwSection, "__firmware");
     sbr_section_set_bootable(fwSection, true);
-    sbr_section_set_size(fwSection, deviceFirmware.size());
-    sbr_section_set_checksum(fwSection, sbr_compute_checksum(deviceFirmware.data(), deviceFirmware.size()));
+    sbr_section_set_size(fwSection, static_cast<uint32_t>(deviceFirmware.size()));
+    sbr_section_set_checksum(fwSection, sbr_compute_checksum(deviceFirmware.data(), static_cast<uint32_t>(deviceFirmware.size())));
     sbr_section_set_offset(fwSection, SBR_RAW_SIZE);
 
     // Second section, pipeline schema, name 'pipeline'
     sbr_section_set_name(pipelineSection, "pipeline");
-    sbr_section_set_size(pipelineSection, pipelineBinary.size());
-    sbr_section_set_checksum(pipelineSection, sbr_compute_checksum(pipelineBinary.data(), pipelineBinary.size()));
+    sbr_section_set_size(pipelineSection, static_cast<uint32_t>(pipelineBinary.size()));
+    sbr_section_set_checksum(pipelineSection, sbr_compute_checksum(pipelineBinary.data(), static_cast<uint32_t>(pipelineBinary.size())));
     sbr_section_set_offset(pipelineSection, getSectionAlignedOffset(fwSection->offset + fwSection->size));
 
     // Third section, assets map, name 'assets'
     sbr_section_set_name(assetsSection, "assets");
-    sbr_section_set_size(assetsSection, assetsBinary.size());
-    sbr_section_set_checksum(assetsSection, sbr_compute_checksum(assetsBinary.data(), assetsBinary.size()));
+    sbr_section_set_size(assetsSection, static_cast<uint32_t>(assetsBinary.size()));
+    sbr_section_set_checksum(assetsSection, sbr_compute_checksum(assetsBinary.data(), static_cast<uint32_t>(assetsBinary.size())));
     sbr_section_set_offset(assetsSection, getSectionAlignedOffset(pipelineSection->offset + pipelineSection->size));
 
     // Fourth section, asset storage, name 'asset_storage'
     sbr_section_set_name(assetStorageSection, "asset_storage");
-    sbr_section_set_size(assetStorageSection, assetStorage.size());
-    sbr_section_set_checksum(assetStorageSection, sbr_compute_checksum(assetStorage.data(), assetStorage.size()));
+    sbr_section_set_size(assetStorageSection, static_cast<uint32_t>(assetStorage.size()));
+    sbr_section_set_checksum(assetStorageSection, sbr_compute_checksum(assetStorage.data(), static_cast<uint32_t>(assetStorage.size())));
     sbr_section_set_offset(assetStorageSection, getSectionAlignedOffset(assetsSection->offset + assetsSection->size));
 
     // TODO(themarpe) - Add additional sections (Pipeline nodes will be able to use sections)
@@ -127,7 +127,7 @@ std::vector<uint8_t> DeviceBootloader::createDepthaiApplicationPackage(Pipeline&
     fwPackage.resize(lastSection->offset + lastSection->size);
 
     // Serialize SBR
-    sbr_serialize(&sbr, fwPackage.data(), fwPackage.size());
+    sbr_serialize(&sbr, fwPackage.data(), static_cast<uint32_t>(fwPackage.size()));
 
     // Write to fwPackage
     for(unsigned i = 0; i < deviceFirmware.size(); i++) fwPackage[fwSection->offset + i] = deviceFirmware[i];
@@ -187,7 +187,7 @@ void DeviceBootloader::init(bool embeddedMvcmd, const std::string& pathToMvcmd) 
         while(watchdogRunning) {
             try {
                 stream.write(watchdogKeepalive);
-            } catch(const std::exception& ex) {
+            } catch(const std::exception&) {
                 break;
             }
             // Ping with a period half of that of the watchdog timeout
@@ -199,7 +199,7 @@ void DeviceBootloader::init(bool embeddedMvcmd, const std::string& pathToMvcmd) 
             stream.write(reset);
             // Dummy read (wait till link falls down)
             stream.readRaw();
-        } catch(const std::exception& error) {
+        } catch(const std::exception&) {
         }  // ignore
 
         // Sleep a bit, so device isn't available anymore
@@ -284,8 +284,8 @@ std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(s
     // send request to FLASH BOOTLOADER
     dai::bootloader::request::UpdateFlash updateFlash;
     updateFlash.storage = dai::bootloader::request::UpdateFlash::SBR;
-    updateFlash.totalSize = package.size();
-    updateFlash.numPackets = ((package.size() - 1) / bootloader::XLINK_STREAM_MAX_SIZE) + 1;
+    updateFlash.totalSize = static_cast<uint32_t>(package.size());
+    updateFlash.numPackets = ((static_cast<uint32_t>(package.size()) - 1) / bootloader::XLINK_STREAM_MAX_SIZE) + 1;
     if(!sendBootloaderRequest(streamId, updateFlash)) return {false, "Couldn't send bootloader flash request"};
 
     // After that send numPackets of data
@@ -333,8 +333,8 @@ std::tuple<bool, std::string> DeviceBootloader::flashBootloader(std::function<vo
     // send request to FLASH BOOTLOADER
     dai::bootloader::request::UpdateFlash updateFlash;
     updateFlash.storage = dai::bootloader::request::UpdateFlash::BOOTLOADER;
-    updateFlash.totalSize = package.size();
-    updateFlash.numPackets = ((package.size() - 1) / bootloader::XLINK_STREAM_MAX_SIZE) + 1;
+    updateFlash.totalSize = static_cast<uint32_t>(package.size());
+    updateFlash.numPackets = ((static_cast<uint32_t>(package.size()) - 1) / bootloader::XLINK_STREAM_MAX_SIZE) + 1;
     if(!sendBootloaderRequest(streamId, updateFlash)) return {false, "Couldn't send bootloader flash request"};
 
     // After that send numPackets of data

--- a/src/opencv/ImgFrame.cpp
+++ b/src/opencv/ImgFrame.cpp
@@ -57,14 +57,14 @@ cv::Mat ImgFrame::getFrame(bool deepCopy) {
 
         case dai::RawImgFrame::Type::BITSTREAM:
         default:
-            size = cv::Size(getData().size(), 1);
+            size = cv::Size(static_cast<int>(getData().size()), 1);
             type = CV_8UC1;
             break;
     }
 
     // Check if enough data
     long requiredSize = CV_ELEM_SIZE(type) * size.area();
-    if((long) img.data.size() < requiredSize) {
+    if((long)img.data.size() < requiredSize) {
         throw std::runtime_error("ImgFrame doesn't have enough data to encode specified frame. Maybe metadataOnly transfer was made?");
     }
     if(getWidth() <= 0 || getHeight() <= 0) {

--- a/src/pipeline/AssetManager.cpp
+++ b/src/pipeline/AssetManager.cpp
@@ -81,7 +81,7 @@ void AssetManager::serialize(Assets& serAssets, std::vector<std::uint8_t>& asset
         }
 
         // calculate offset
-        std::uint32_t offset = storage.size() + toAdd;
+        std::uint32_t offset = static_cast<uint32_t>(storage.size()) + toAdd;
 
         // Add alignment bytes
         storage.resize(storage.size() + toAdd);
@@ -90,7 +90,7 @@ void AssetManager::serialize(Assets& serAssets, std::vector<std::uint8_t>& asset
         storage.insert(storage.end(), a.data.begin(), a.data.end());
 
         // Add to map the currently added asset
-        mutableAssets.set(a.key, offset, a.data.size(), a.alignment);
+        mutableAssets.set(a.key, offset, static_cast<uint32_t>(a.data.size()), a.alignment);
     }
 
     assetStorage = std::move(storage);

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -87,7 +87,7 @@ void ImageManipConfig::setRotationDegrees(float deg) {
 }
 
 void ImageManipConfig::setRotationRadians(float rad) {
-    static constexpr float rad2degFactor = 180 / M_PI;
+    static constexpr float rad2degFactor = static_cast<float>(180 / M_PI);
     setRotationDegrees(rad * rad2degFactor);
 }
 

--- a/src/pipeline/datatype/NNData.cpp
+++ b/src/pipeline/datatype/NNData.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<RawBuffer> NNData::serialize() const {
         info.dataType = dataType;
         info.numDimensions = 0;
         info.name = kv.first;
-        info.offset = offset;
+        info.offset = static_cast<unsigned int>(offset);
         rawNn.tensors.push_back(info);
     }
 
@@ -88,7 +88,7 @@ std::shared_ptr<RawBuffer> NNData::serialize() const {
         info.dataType = dataType;
         info.numDimensions = 0;
         info.name = kv.first;
-        info.offset = offset;
+        info.offset = static_cast<unsigned int>(offset);
         rawNn.tensors.push_back(info);
     }
 
@@ -117,7 +117,7 @@ void NNData::setLayer(const std::string& name, std::vector<float> data) {
 void NNData::setLayer(const std::string& name, std::vector<double> data) {
     fp16Data[name] = std::vector<std::uint16_t>(data.size());
     for(unsigned i = 0; i < data.size(); i++) {
-        fp16Data[name][i] = fp16_ieee_from_fp32_value(data[i]);
+        fp16Data[name][i] = fp16_ieee_from_fp32_value(static_cast<float>(data[i]));
     }
 }
 

--- a/src/pipeline/datatype/StreamPacketParser.cpp
+++ b/src/pipeline/datatype/StreamPacketParser.cpp
@@ -165,7 +165,7 @@ std::vector<std::uint8_t> serializeData(const std::shared_ptr<RawBuffer>& data) 
     std::vector<std::uint8_t> metadata;
     DatatypeEnum datatype;
     data->serialize(metadata, datatype);
-    uint32_t metadataSize = metadata.size();
+    uint32_t metadataSize = static_cast<uint32_t>(metadata.size());
 
     // 4B datatype & 4B metadata size
     std::uint8_t leDatatype[4];

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -1,4 +1,8 @@
+// First, as other headers may include <cmath>
+#define _USE_MATH_DEFINES
 #include "depthai/pipeline/node/ColorCamera.hpp"
+
+#include <cmath>
 
 #include "spdlog/fmt/fmt.h"
 
@@ -270,8 +274,8 @@ void ColorCamera::setSensorCrop(float x, float y) {
 std::tuple<float, float> ColorCamera::getSensorCrop() const {
     // AUTO - center crop by default
     if(properties.sensorCropX == ColorCameraProperties::AUTO || properties.sensorCropY == ColorCameraProperties::AUTO) {
-        float x = ((getResolutionWidth() - getVideoWidth()) / 2) / getResolutionWidth();
-        float y = ((getResolutionHeight() - getVideoHeight()) / 2) / getResolutionHeight();
+        float x = std::floor(((getResolutionWidth() - getVideoWidth()) / 2.0f) / getResolutionWidth());
+        float y = std::floor(((getResolutionHeight() - getVideoHeight()) / 2.0f) / getResolutionHeight());
         return {x, y};
     }
     return {properties.sensorCropX, properties.sensorCropY};

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -66,7 +66,7 @@ NeuralNetwork::BlobAssetInfo NeuralNetwork::loadBlob(const std::string& path) {
     // Set properties URI to asset:id/blob
     BlobAssetInfo blobInfo;
     blobInfo.uri = std::string("asset:") + assetKey;
-    blobInfo.size = blobAsset.data.size();
+    blobInfo.size = static_cast<uint32_t>(blobAsset.data.size());
 
     return blobInfo;
 }

--- a/src/pipeline/node/VideoEncoder.cpp
+++ b/src/pipeline/node/VideoEncoder.cpp
@@ -89,7 +89,7 @@ void VideoEncoder::setQuality(int quality) {
     properties.quality = quality;
 }
 
-void VideoEncoder::setFrameRate(int frameRate) {
+void VideoEncoder::setFrameRate(float frameRate) {
     properties.frameRate = frameRate;
 }
 
@@ -133,7 +133,7 @@ int VideoEncoder::getHeight() const {
     return std::get<1>(getSize());
 }
 
-int VideoEncoder::getFrameRate() const {
+float VideoEncoder::getFrameRate() const {
     return properties.frameRate;
 }
 
@@ -154,7 +154,7 @@ void VideoEncoder::setDefaultProfilePreset(int width, int height, float fps, Vid
         case VideoEncoderProperties::Profile::H264_MAIN:
         case VideoEncoderProperties::Profile::H265_MAIN: {
             // By default set keyframe frequency to equal fps
-            properties.keyframeFrequency = fps;
+            properties.keyframeFrequency = static_cast<int32_t>(fps);
 
             // Approximate bitrate on input w/h and fps
             constexpr float ESTIMATION_FPS = 30.0f;
@@ -164,16 +164,16 @@ void VideoEncoder::setDefaultProfilePreset(int width, int height, float fps, Vid
             const int pixelArea = width * height;
             if(pixelArea <= 1280 * 720 * AREA_MUL) {
                 // 720p
-                setBitrate((4000 * 1000 / ESTIMATION_FPS) * fps);
+                setBitrate(static_cast<int>((4000 * 1000 / ESTIMATION_FPS) * fps));
             } else if(pixelArea <= 1920 * 1080 * AREA_MUL) {
                 // 1080p
-                setBitrate((8500 * 1000 / ESTIMATION_FPS) * fps);
+                setBitrate(static_cast<int>((8500 * 1000 / ESTIMATION_FPS) * fps));
             } else if(pixelArea <= 2560 * 1440 * AREA_MUL) {
                 // 1440p
-                setBitrate((14000 * 1000 / ESTIMATION_FPS) * fps);
+                setBitrate(static_cast<int>((14000 * 1000 / ESTIMATION_FPS) * fps));
             } else {
                 // 4K
-                setBitrate((20000 * 1000 / ESTIMATION_FPS) * fps);
+                setBitrate(static_cast<int>((20000 * 1000 / ESTIMATION_FPS) * fps));
             }
         } break;
 

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -39,7 +39,7 @@ DeviceInfo::DeviceInfo(const char* mxId) : DeviceInfo(std::string(mxId)) {}
 
 std::string DeviceInfo::getMxId() const {
     std::string mxId = "";
-    int len = std::strlen(desc.name);
+    int len = static_cast<int>(std::strlen(desc.name));
     for(int i = 0; i < len; i++) {
         if(desc.name[i] == '-') break;
         mxId += desc.name[i];
@@ -89,7 +89,7 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
         suitableDevice.protocol = X_LINK_ANY_PROTOCOL;
         suitableDevice.platform = X_LINK_ANY_PLATFORM;
 
-        auto status = XLinkFindAllSuitableDevices(state, suitableDevice, deviceDescAll.data(), deviceDescAll.size(), &numdev);
+        auto status = XLinkFindAllSuitableDevices(state, suitableDevice, deviceDescAll.data(), static_cast<unsigned int>(deviceDescAll.size()), &numdev);
         if(status != X_LINK_SUCCESS) throw std::runtime_error("Couldn't retrieve all connected devices");
 
         for(unsigned i = 0; i < numdev; i++) {
@@ -202,7 +202,7 @@ bool XLinkConnection::bootAvailableDevice(const deviceDesc_t& deviceToBoot, cons
 }
 
 bool XLinkConnection::bootAvailableDevice(const deviceDesc_t& deviceToBoot, std::vector<std::uint8_t>& mvcmd) {
-    auto status = XLinkBootMemory(&deviceToBoot, mvcmd.data(), mvcmd.size());
+    auto status = XLinkBootMemory(&deviceToBoot, mvcmd.data(), static_cast<unsigned long>(mvcmd.size()));
     return status == X_LINK_SUCCESS;
 }
 


### PR DESCRIPTION
Partially fixes https://github.com/luxonis/depthai-core/issues/71

The PR does not include the unsafe function usage (e.g. strncpy) that @themarpe wrote they want to resolve. I see opportunities to move away from unsafe c-strings. Alternatives are string spans, zstring, std::string, std::array, etc. I highly recommend moving away from c-strings; buffer/string handling is one of the most common security vulnerabilities and I believe the current thinking is any performance gain from raw c-strings are no longer relevant. http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#slstr-string

The changes in this PR are usually the smallest changes needed to compile without warnings using this project's cmake. There is unsafe code and I do not address that in this PR. For example, in bspatch.c lines 129,134 -or- DeviceBootloader.cpp lines 101,102,107,... are warnings of narrowing integers (int64_t->unsigned int, size_t->uint32_t, etc.) This are all possible loss/corrupt of data, loss of precision, etc. The changes I made remove the compile warnings. However, the problems causing the warning still exist. It is still possible to overflow, wraparound, loose precision, etc. To fix the underlying problem requires work that cascades wider. I'm confident these underlying issues are fixable, but outside the scope of this PR without further discussion. This means that the code is often just as "unsafe" as it was before. If you want to fix all these, we should discuss enough examples so that I understand your project's philosophy and can apply wider fixes.

I did not add/use GSL. I think it might be useful in your project, but I chose to use other methods to fix for now.

I did not fix warnings in the hunter managed FP16 project.,

I have a question. I have not fixed the cmake warning in CMakeLists.txt line 30 `set(DEPTHAI_VERSION ${PROJECT_VERSION} PARENT_SCOPE)`. The warning is `CMake Warning (dev) at CMakeLists.txt:30 (set):Cannot set "DEPTHAI_VERSION": current scope has no parent.` My question is...what is the goal with that set(DEPTHAI_VERSION)? If it is for this project to declare its version, then this is not the cmake way to do it. Instead, creating a version config file is relatively easing using the helper functions https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html and that version config file will set variables that can be read in a consistent way, uses in package version checks, etc. What is your project's intention here?

Device.cpp line 401. I added a variable name for the lock. This means...the previous code *did not* lock the mutex. Technically it locked it for only line 401 as the lock was created and destroyed on that one line. 🎯This looks like important critical path code so locking the mutex where it was never locked before is exposing bugs elsewhere as I document in issue #79.

I see a lot of int<->float conversions for framerate in VideoEncoder.cpp. Seems like something could be unified. For example: `VideoEncoder::setDefaultProfilePreset(float fps)`, calls `setFrameRate(int fps)`, which sets `float dai::VideoEncoderProperties::frameRate`. float->int->float has multiple layers of precision loss and unneeded cpu cycles.