### PR TITLE
Gen2 Camera driver fix

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")  
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "0149933b6f845f30b6d68defd59ca6f52bdaa78c")          
+set(DEPTHAI_DEVICE_SIDE_COMMIT "1908ffea799ff0a7fe355b4597cb49344951cdd0")          
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Fixes crash when there is high system load (for example with 26_3_spatial_yolo)