### PR TITLE
CMake regression workaround

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -162,26 +162,26 @@ jobs:
       run: echo "$GITHUB_WORKSPACE/depthai_install/bin/" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Build and install
-      run: cmake --build build --parallel --config ${{ matrix.build-type }} --target install
+      run: cmake --build build --config ${{ matrix.build-type }} --target install --parallel
 
     - name: Build and test add_subdirectory
       run: |
         cmake -S tests/integration/ -B tests/integration/build_add_subdirectory -D TEST_FIND_PACKAGE=OFF
-        cmake --build tests/integration/build_add_subdirectory --parallel --config ${{ matrix.build-type }}
+        cmake --build tests/integration/build_add_subdirectory --config ${{ matrix.build-type }} --parallel
         cd tests/integration/build_add_subdirectory
         ctest -C ${{ matrix.build-type }}
      
     - name: Build and test find_package (installed)
       run: |
         cmake -S tests/integration/ -B tests/integration/build_find_package -D TEST_FIND_PACKAGE=ON -D depthai_DIR=$GITHUB_WORKSPACE/depthai_install/lib/cmake/depthai
-        cmake --build tests/integration/build_find_package --parallel --config ${{ matrix.build-type }}
+        cmake --build tests/integration/build_find_package --config ${{ matrix.build-type }} --parallel
         cd tests/integration/build_find_package
         ctest -C ${{ matrix.build-type }}
 
     - name: Build and test find_package (build directory)
       run: |
         cmake -S tests/integration/ -B tests/integration/build_find_package_2 -D TEST_FIND_PACKAGE=ON -D depthai_DIR=$GITHUB_WORKSPACE/build
-        cmake --build tests/integration/build_find_package_2 --parallel --config ${{ matrix.build-type }}
+        cmake --build tests/integration/build_find_package_2 --config ${{ matrix.build-type }} --parallel
         cd tests/integration/build_find_package_2
         ctest -C ${{ matrix.build-type }}
     

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To install specify optional prefix and build target install
 ```
 cmake .. -D CMAKE_INSTALL_PREFIX=[path/to/install/dir]
 cmake --build . --parallel
-cmake --build . --parallel --target install
+cmake --build . --target install --parallel
 ```
 
 ## Running tests


### PR DESCRIPTION
Addresses CMake 3.20 regression in parsing '--parallel' ('-j') option.
https://gitlab.kitware.com/cmake/cmake/-/issues/21966

To be fixed in 3.20.1 version of CMake, but currently GitHub Runners use 3.20.