### PR TITLE
Added lossless jpeg encoding

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "303d323e4c63ea6881530e19af79450540df46c7")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "29053c08454ede40ff7315c3340e31a6ae99c7d8")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -14,7 +14,10 @@ namespace node {
  * @brief ColorCamera node. For use with color sensors.
  */
 class ColorCamera : public Node {
+   public:
     using Properties = dai::ColorCameraProperties;
+
+   private:
     Properties properties;
 
     std::string getName() const override;

--- a/include/depthai/pipeline/node/DetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/DetectionNetwork.hpp
@@ -18,7 +18,10 @@ namespace node {
  * @brief DetectionNetwork. Base for different network specializations
  */
 class DetectionNetwork : public NeuralNetwork {
+   public:
     using Properties = dai::DetectionNetworkProperties;
+
+   private:
     std::string getName() const override;
     std::vector<Input> getInputs() override;
     std::vector<Output> getOutputs() override;

--- a/include/depthai/pipeline/node/ImageManip.hpp
+++ b/include/depthai/pipeline/node/ImageManip.hpp
@@ -13,7 +13,10 @@ namespace node {
  * @brief ImageManip node. Capability to crop, resize, warp, ... incoming image frames
  */
 class ImageManip : public Node {
+   public:
     using Properties = dai::ImageManipProperties;
+
+   private:
     Properties properties;
 
     std::string getName() const override;

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -15,7 +15,10 @@ namespace node {
  * @brief MonoCamera node. For use with grayscale sensors.
  */
 class MonoCamera : public Node {
+   public:
     using Properties = dai::MonoCameraProperties;
+
+   private:
     Properties properties;
 
     std::string getName() const override;

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -16,8 +16,10 @@ namespace node {
  * @brief NeuralNetwork node. Runs a neural inference on input data.
  */
 class NeuralNetwork : public Node {
+   public:
     using Properties = dai::NeuralNetworkProperties;
 
+   private:
     Properties properties;
 
     std::string getName() const override;

--- a/include/depthai/pipeline/node/ObjectTracker.hpp
+++ b/include/depthai/pipeline/node/ObjectTracker.hpp
@@ -17,8 +17,10 @@ namespace node {
  * @brief ObjectTracker node. Performs object tracking using Kalman filter and hungarian algorithm.
  */
 class ObjectTracker : public Node {
+   public:
     using Properties = dai::ObjectTrackerProperties;
 
+   private:
     std::string getName() const override;
     std::vector<Input> getInputs() override;
     std::vector<Output> getOutputs() override;

--- a/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
@@ -18,8 +18,10 @@ namespace node {
  * @brief SpatialDetectionNetwork node. Runs a neural inference on input image and calculates spatial location data.
  */
 class SpatialDetectionNetwork : public DetectionNetwork {
+   public:
     using Properties = dai::SpatialDetectionNetworkProperties;
 
+   private:
     std::string getName() const override;
     std::vector<Input> getInputs() override;
     std::vector<Output> getOutputs() override;

--- a/include/depthai/pipeline/node/SpatialLocationCalculator.hpp
+++ b/include/depthai/pipeline/node/SpatialLocationCalculator.hpp
@@ -17,8 +17,10 @@ namespace node {
  * @brief SpatialLocationCalculator node. Calculates spatial location data on a set of ROIs on depth map.
  */
 class SpatialLocationCalculator : public Node {
+   public:
     using Properties = dai::SpatialLocationCalculatorProperties;
 
+   private:
     std::string getName() const override;
     std::vector<Input> getInputs() override;
     std::vector<Output> getOutputs() override;

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -12,7 +12,10 @@ namespace node {
  * @brief StereoDepth node. Compute stereo disparity and depth from left-right image pair.
  */
 class StereoDepth : public Node {
+   public:
     using Properties = dai::StereoDepthProperties;
+
+   private:
     Properties properties;
 
     std::string getName() const override;

--- a/include/depthai/pipeline/node/VideoEncoder.hpp
+++ b/include/depthai/pipeline/node/VideoEncoder.hpp
@@ -12,7 +12,10 @@ namespace node {
  * @brief VideoEncoder node. Encodes frames into MJPEG, H264 or H265.
  */
 class VideoEncoder : public Node {
+   public:
     using Properties = dai::VideoEncoderProperties;
+
+   private:
     Properties properties;
 
     std::string getName() const override;
@@ -70,6 +73,8 @@ class VideoEncoder : public Node {
     /// Set rate control mode
     void setRateControlMode(Properties::RateControlMode mode);
     /// Set encoding profile
+    void setProfile(std::tuple<int, int> size, Properties::Profile profile);
+    /// Set encoding profile
     void setProfile(int width, int height, Properties::Profile profile);
     /// Set output bitrate in bps. Final bitrate depends on rate control mode
     void setBitrate(int bitrate);
@@ -100,6 +105,12 @@ class VideoEncoder : public Node {
     void setQuality(int quality);
 
     /**
+     * Set lossless mode. Applies only to [M]JPEG profile
+     * @param lossless True to enable lossless jpeg encoding, false otherwise
+     */
+    void setLossless(bool lossless);
+
+    /**
      * Sets expected frame rate
      * @param frameRate Frame rate in frames per second
      */
@@ -128,6 +139,8 @@ class VideoEncoder : public Node {
     int getHeight() const;
     /// Get frame rate
     int getFrameRate() const;
+    /// Get lossless mode. Applies only when using [M]JPEG profile.
+    bool getLossless() const;
 };
 
 }  // namespace node

--- a/src/pipeline/node/VideoEncoder.cpp
+++ b/src/pipeline/node/VideoEncoder.cpp
@@ -43,6 +43,10 @@ void VideoEncoder::setRateControlMode(VideoEncoderProperties::RateControlMode mo
     properties.rateCtrlMode = mode;
 }
 
+void VideoEncoder::setProfile(std::tuple<int, int> size, VideoEncoderProperties::Profile profile) {
+    setProfile(std::get<0>(size), std::get<1>(size), profile);
+}
+
 void VideoEncoder::setProfile(int width, int height, VideoEncoderProperties::Profile profile) {
     // Width & height H26x limitations
     if(profile != VideoEncoderProperties::Profile::MJPEG) {
@@ -87,6 +91,10 @@ void VideoEncoder::setNumBFrames(int numBFrames) {
 
 void VideoEncoder::setQuality(int quality) {
     properties.quality = quality;
+}
+
+void VideoEncoder::setLossless(bool lossless) {
+    properties.lossless = lossless;
 }
 
 void VideoEncoder::setFrameRate(int frameRate) {
@@ -188,6 +196,10 @@ void VideoEncoder::setDefaultProfilePreset(int width, int height, float fps, Vid
 
 void VideoEncoder::setDefaultProfilePreset(std::tuple<int, int> size, float fps, VideoEncoderProperties::Profile profile) {
     setDefaultProfilePreset(std::get<0>(size), std::get<1>(size), fps, profile);
+}
+
+bool VideoEncoder::getLossless() const {
+    return properties.lossless;
 }
 
 }  // namespace node


### PR DESCRIPTION
Related: https://github.com/luxonis/depthai-shared/pull/26
Modified `Properties` alias accessor, added a setProfile overload taking size instead of width and height and the API to set lossless jpeg encoding
