### PR TITLE
Alpha: NN performance improvement

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "917e9ba1fd597c382132a354c8eed4a9d99a6e9a")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "9f9ef06d8a62beaed41414cf9f6f7b5645b8aa31")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
This is an ALPHA code for experimental purposes.

Improves NN (and system) performance by up to `60%` in some cases, when there is high system load. For example when 4k RGB + 800p enabled in `26_1_spatial_mobilenet.py` we gain  +9 fps (15 vs 24), CPU load: -20% LRT (57 vs 37), +6% (62 vs 69) LOS.

In more simple cases, for example `08_rgb_mobilenet.py` the NN is 13-15% faster.


Known issues:
Stereo subpixel mode doesn't work properly.

Feel free to report other issues too.