### PR TITLE
SpatialCalculator fixes

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "9703def7e436298c86dfbe1204a6ae4181784047")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "b19b9704cef5386f341fd4a4210b2ec003efc704")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "917e9ba1fd597c382132a354c8eed4a9d99a6e9a")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "9703def7e436298c86dfbe1204a6ae4181784047")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "0dbf0da19ba172efeabbc6b7a3bfac184cc22876")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "917e9ba1fd597c382132a354c8eed4a9d99a6e9a")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "b19b9704cef5386f341fd4a4210b2ec003efc704")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "595330292c4bd1955e4e8046b0f42af2dba4b124")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
FW fixes:
-workaround for stereo/subpixel [BUG](https://github.com/luxonis/depthai-core/pull/82), only for SpatialCalculator
-fix of calculated average depth

Added a new field to spatial calculator output: `depthAveragePixelCount`