### PR TITLE
StereoDepth: fix confidence threshold configuration

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "f34e1ec1450b659bd8ff8383eaff5b7f988cb6fc")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "b71584129b101b30e4632678c19d33b020c04c36")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
The value set using `.setConfidenceThreshold` was later overwritten to 200 by some leftover code from Gen1, that was handling the runtime confidence threshold adjustment.

Note: some of our examples are using `stereo->setConfidenceThreshold(255);` - their behavior may slightly change with this PR (as previously the setting was ignored).

TODO: we need to add an `inputConfig` to StereoDepth, to be able to adjust the confidence threshold and other configs during runtime.