### PR TITLE
DataInputQueue nullptr check

### DIFF
--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -248,6 +248,7 @@ std::string DataInputQueue::getName() const {
 
 void DataInputQueue::send(const std::shared_ptr<RawBuffer>& rawMsg) {
     if(!running) throw std::runtime_error(exceptionMessage.c_str());
+    if(!rawMsg) throw std::invalid_argument("Message passed is not valid (nullptr)");
 
     // Check if stream receiver has enough space for this message
     if(rawMsg->data.size() > maxDataSize) {
@@ -257,6 +258,7 @@ void DataInputQueue::send(const std::shared_ptr<RawBuffer>& rawMsg) {
     queue.push(rawMsg);
 }
 void DataInputQueue::send(const std::shared_ptr<ADatatype>& msg) {
+    if(!msg) throw std::invalid_argument("Message passed is not valid (nullptr)");
     send(msg->serialize());
 }
 
@@ -266,6 +268,7 @@ void DataInputQueue::send(const ADatatype& msg) {
 
 bool DataInputQueue::send(const std::shared_ptr<RawBuffer>& rawMsg, std::chrono::milliseconds timeout) {
     if(!running) throw std::runtime_error(exceptionMessage.c_str());
+    if(!rawMsg) throw std::invalid_argument("Message passed is not valid (nullptr)");
 
     // Check if stream receiver has enough space for this message
     if(rawMsg->data.size() > maxDataSize) {
@@ -276,6 +279,7 @@ bool DataInputQueue::send(const std::shared_ptr<RawBuffer>& rawMsg, std::chrono:
 }
 
 bool DataInputQueue::send(const std::shared_ptr<ADatatype>& msg, std::chrono::milliseconds timeout) {
+    if(!msg) throw std::invalid_argument("Message passed is not valid (nullptr)");
     return send(msg->serialize(), timeout);
 }
 


### PR DESCRIPTION
This checks if a nullptr was passed to `send` method of DataInputQueue and which also applies to `None` being passed from Python bindings  