### PR TITLE
Try-catch for queue callbacks

### DIFF
--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -66,7 +66,11 @@ DataOutputQueue::DataOutputQueue(const std::shared_ptr<XLinkConnection>& conn, c
                         std::unique_lock<std::mutex> l(callbacksMtx);
                         for(const auto& kv : callbacks) {
                             const auto& callback = kv.second;
-                            callback(name, data);
+                            try {
+                                callback(name, data);
+                            } catch(const std::exception& ex) {
+                                spdlog::error("Callback with id: {} throwed an exception: {}", kv.first, ex.what());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Added a try catch for callbacks for better error messages.
Before that, the error was caught by outer try-catch block, which presumes errors of XLink communication only and it fails silently.