### PR TITLE
Device API improvements

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "b71584129b101b30e4632678c19d33b020c04c36")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "024f66e3c54509867585c4079c949b57ac9d8bdf")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,6 +3,7 @@ option(DEPTHAI_TEST_EXAMPLES "Test examples - examples will be ran as a part of 
 
 # Dependencies
 find_package(OpenCV REQUIRED)
+find_package(Sanitizers)
 
 # Create utility library
 add_library(utility src/utility.cpp)
@@ -13,13 +14,16 @@ macro(dai_add_example example_name example_src)
     add_executable("${example_name}" "${example_src}")
     target_link_libraries("${example_name}" PRIVATE utility depthai::opencv ${OpenCV_LIBS})
 
+    # Add sanitizers for example
+    add_sanitizers(${example_name})
+
     # Add to clangformat target
     target_clangformat_setup(${example_name} "")
 
     # parse the rest of the arguments
     set(arguments ${ARGV})
     list(REMOVE_AT arguments 0 1)
-    
+
     # If 'DEPTHAI_TEST_EXAMPLES' is ON, then examples will be part of the test suite
     if(DEPTHAI_TEST_EXAMPLES)
         add_test(NAME ${example_name} COMMAND ${CMAKE_COMMAND}
@@ -28,16 +32,13 @@ macro(dai_add_example example_name example_src)
         )
 
         # Sets a regex catching any logged warnings, errors or critical (coming either from device or host)
-        set_tests_properties (${example_name} PROPERTIES FAIL_REGULAR_EXPRESSION "\\[warning\\];\\[error\\];\\[critical\\]") 
-            
-        # Add sanitizers for tests as well
-        add_sanitizers(${example_name})
+        set_tests_properties (${example_name} PROPERTIES FAIL_REGULAR_EXPRESSION "\\[warning\\];\\[error\\];\\[critical\\]")
 
         # Add ubsan halt on error
         set_tests_properties(${example_name} PROPERTIES ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1")
 
     endif()
-endmacro() 
+endmacro()
 
 # Create a custom target which runs all examples for 10 seconds max, and check if they executed without errors
 

--- a/examples/src/camera_mobilenet_example.cpp
+++ b/examples/src/camera_mobilenet_example.cpp
@@ -58,10 +58,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     cv::Mat frame;
     auto preview = d.getOutputQueue("preview");

--- a/examples/src/camera_mobilenet_sync_example.cpp
+++ b/examples/src/camera_mobilenet_sync_example.cpp
@@ -56,7 +56,6 @@ int main(int argc, char** argv) {
 
     // Connect to device and start pipeline
     dai::Device device(pipeline);
-    device.startPipeline();
 
     // Create input & output queues
     auto previewQueue = device.getOutputQueue("preview");

--- a/examples/src/camera_preview_example.cpp
+++ b/examples/src/camera_preview_example.cpp
@@ -28,8 +28,18 @@ int main() {
     using namespace std;
 
     dai::Pipeline p = createCameraPipeline();
-    dai::Device d(p);
-    d.startPipeline();
+
+    // Start the pipeline
+    dai::Device d;
+
+    cout << "Connected cameras: ";
+    for(const auto& cam : d.getConnectedCameras()){
+        cout << static_cast<int>(cam) << " ";
+    }
+    cout << endl;
+
+    // Start the pipeline
+    d.startPipeline(p);
 
     cv::Mat frame;
     auto preview = d.getOutputQueue("preview");

--- a/examples/src/camera_video_example.cpp
+++ b/examples/src/camera_video_example.cpp
@@ -31,10 +31,8 @@ int main() {
     // Create pipeline
     dai::Pipeline p = createCameraFullPipeline();
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     cv::Mat frame;
     auto video = d.getOutputQueue("video");

--- a/examples/src/color_camera_control_example.cpp
+++ b/examples/src/color_camera_control_example.cpp
@@ -63,7 +63,7 @@ int main() {
     videoEncoder->bitstream.link(videoMjpegOut->input);
     stillEncoder->bitstream.link(stillMjpegOut->input);
 
-    // Connect to device
+    // Connect and start the pipeline
     dai::Device dev(pipeline);
 
     // Create data queues
@@ -72,9 +72,6 @@ int main() {
     auto previewQueue = dev.getOutputQueue("preview");
     auto videoQueue = dev.getOutputQueue("video");
     auto stillQueue = dev.getOutputQueue("still");
-
-    // Start pipeline
-    dev.startPipeline();
 
     // Max crop_x & crop_y
     float max_crop_x = (colorCam->getResolutionWidth() - colorCam->getVideoWidth()) / (float)colorCam->getResolutionWidth();

--- a/examples/src/device_queue_event_example.cpp
+++ b/examples/src/device_queue_event_example.cpp
@@ -36,10 +36,8 @@ int main(int argc, char** argv) {
     colorCam->preview.link(xout2->input);
     videnc->bitstream.link(xout->input);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     // Sets queues size and behaviour
     d.getOutputQueue("mjpeg", 8, false);

--- a/examples/src/h264_encoding_example.cpp
+++ b/examples/src/h264_encoding_example.cpp
@@ -43,10 +43,8 @@ int main(int argc, char** argv) {
     colorCam->preview.link(xout2->input);
     videnc->bitstream.link(xout->input);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto myfile = std::fstream(h264Path, std::ios::out | std::ios::binary);
 

--- a/examples/src/image_manip_example.cpp
+++ b/examples/src/image_manip_example.cpp
@@ -55,7 +55,6 @@ int main() {
 
     // Connect to device and start pipeline
     dai::Device device(pipeline);
-    device.startPipeline();
 
     // Create input & output queues
     auto previewQueue = device.getOutputQueue("preview", 8, false);

--- a/examples/src/image_manip_warp_example.cpp
+++ b/examples/src/image_manip_warp_example.cpp
@@ -85,7 +85,6 @@ int main() {
 
     // Connect to device and start pipeline
     dai::Device device(pipeline);
-    device.startPipeline();
 
     // Create input & output queues
     auto previewQueue = device.getOutputQueue("preview", 8, false);

--- a/examples/src/mjpeg_encoding_example.cpp
+++ b/examples/src/mjpeg_encoding_example.cpp
@@ -36,10 +36,8 @@ int main(int argc, char** argv) {
     colorCam->preview.link(xout2->input);
     videnc->bitstream.link(xout->input);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto mjpegQueue = d.getOutputQueue("mjpeg", 8, false);
     auto previewQueue = d.getOutputQueue("preview", 8, false);

--- a/examples/src/mobilenet_device_side_decoding_example.cpp
+++ b/examples/src/mobilenet_device_side_decoding_example.cpp
@@ -63,10 +63,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto preview = d.getOutputQueue("preview", 4, false);
     auto detections = d.getOutputQueue("detections", 4, false);

--- a/examples/src/mono_camera_example.cpp
+++ b/examples/src/mono_camera_example.cpp
@@ -30,10 +30,8 @@ int main() {
     // Create pipeline
     dai::Pipeline p = createMonoPipeline();
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     cv::Mat frame;
     auto monoQueue = d.getOutputQueue("mono");

--- a/examples/src/object_tracker_example.cpp
+++ b/examples/src/object_tracker_example.cpp
@@ -71,10 +71,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto preview = d.getOutputQueue("preview", 4, false);
     auto tracklets = d.getOutputQueue("tracklets", 4, false);

--- a/examples/src/opencv_support_example.cpp
+++ b/examples/src/opencv_support_example.cpp
@@ -34,11 +34,8 @@ int main() {
     // Create pipeline
     dai::Pipeline p = createCameraFullPipeline();
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-
-    // Start the pipeline
-    d.startPipeline();
 
     auto video = d.getOutputQueue("video");
     auto preview = d.getOutputQueue("preview");

--- a/examples/src/spatial_location_calculator_example.cpp
+++ b/examples/src/spatial_location_calculator_example.cpp
@@ -68,9 +68,8 @@ int main() {
     spatialDataCalculator->out.link(xoutSpatialData->input);
     xinSpatialCalcConfig->out.link(spatialDataCalculator->inputConfig);
 
-    // CONNECT TO DEVICE
+    // Connect and start the pipeline
     dai::Device d(p);
-    d.startPipeline();
 
     auto depthQueue = d.getOutputQueue("depth", 8, false);
     auto spatialCalcQueue = d.getOutputQueue("spatialData", 8, false);

--- a/examples/src/spatial_mobilenet_example.cpp
+++ b/examples/src/spatial_mobilenet_example.cpp
@@ -61,10 +61,11 @@ dai::Pipeline createNNPipeline(std::string nnPath) {
 
     // Link plugins CAM -> NN -> XLINK
     colorCam->preview.link(spatialDetectionNetwork->input);
-    if(syncNN)
+    if(syncNN) {
         spatialDetectionNetwork->passthrough.link(xoutRgb->input);
-    else
+    } else {
         colorCam->preview.link(xoutRgb->input);
+    }
 
     spatialDetectionNetwork->out.link(xoutNN->input);
     spatialDetectionNetwork->boundingBoxMapping.link(xoutBoundingBoxDepthMapping->input);
@@ -91,10 +92,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto preview = d.getOutputQueue("preview", 4, false);
     auto detections = d.getOutputQueue("detections", 4, false);

--- a/examples/src/spatial_mobilenet_mono_example.cpp
+++ b/examples/src/spatial_mobilenet_mono_example.cpp
@@ -63,10 +63,11 @@ dai::Pipeline createNNPipeline(std::string nnPath) {
 
     // Link plugins CAM -> NN -> XLINK
     imageManip->out.link(spatialDetectionNetwork->input);
-    if(syncNN)
+    if(syncNN) {
         spatialDetectionNetwork->passthrough.link(xlinkOut->input);
-    else
+    } else {
         imageManip->out.link(xlinkOut->input);
+    }
 
     spatialDetectionNetwork->out.link(nnOut->input);
     spatialDetectionNetwork->boundingBoxMapping.link(depthRoiMap->input);
@@ -93,10 +94,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto preview = d.getOutputQueue("preview", 4, false);
     auto detections = d.getOutputQueue("detections", 4, false);

--- a/examples/src/spatial_object_tracker_example.cpp
+++ b/examples/src/spatial_object_tracker_example.cpp
@@ -94,10 +94,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto preview = d.getOutputQueue("preview", 4, false);
     auto tracklets = d.getOutputQueue("tracklets", 4, false);

--- a/examples/src/spatial_tiny_yolo_example.cpp
+++ b/examples/src/spatial_tiny_yolo_example.cpp
@@ -75,10 +75,11 @@ dai::Pipeline createNNPipeline(std::string nnPath) {
 
     // Link plugins CAM -> NN -> XLINK
     colorCam->preview.link(spatialDetectionNetwork->input);
-    if(syncNN)
+    if(syncNN) {
         spatialDetectionNetwork->passthrough.link(xoutRgb->input);
-    else
+    } else {
         colorCam->preview.link(xoutRgb->input);
+    }
 
     spatialDetectionNetwork->out.link(xoutNN->input);
     spatialDetectionNetwork->boundingBoxMapping.link(xoutBoundingBoxDepthMapping->input);
@@ -105,10 +106,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto preview = d.getOutputQueue("preview", 4, false);
     auto detections = d.getOutputQueue("detections", 4, false);

--- a/examples/src/stereo_example.cpp
+++ b/examples/src/stereo_example.cpp
@@ -87,9 +87,8 @@ int main() {
         monoRight->out.link(xoutRight->input);
     }
 
-    // CONNECT TO DEVICE
+    // Connect and start the pipeline
     dai::Device d(p);
-    d.startPipeline();
 
     auto leftQueue = d.getOutputQueue("left", 8, false);
     auto rightQueue = d.getOutputQueue("right", 8, false);

--- a/examples/src/system_information_example.cpp
+++ b/examples/src/system_information_example.cpp
@@ -25,7 +25,7 @@ int main() {
     sysLog->out.link(xout->input);
 
     // Connect to device
-    dai::Device device(pipeline);
+    dai::Device device;
 
     // Create 'sysinfo' queue
     auto queue = device.getOutputQueue("sysinfo");
@@ -38,7 +38,7 @@ int main() {
     printf("Cmx used / total - %.2f / %.2f MiB\n", cmx.used / (1024.0f * 1024.0f), cmx.total / (1024.0f * 1024.0f));
 
     // Start pipeline
-    device.startPipeline();
+    device.startPipeline(pipeline);
 
     while(1) {
         auto sysInfo = queue->get<dai::SystemInformation>();

--- a/examples/src/tiny_yolo_v3_device_side_decoding_example.cpp
+++ b/examples/src/tiny_yolo_v3_device_side_decoding_example.cpp
@@ -76,10 +76,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto preview = d.getOutputQueue("preview", 4, false);
     auto detections = d.getOutputQueue("detections", 4, false);

--- a/examples/src/tiny_yolo_v4_device_side_decoding_example.cpp
+++ b/examples/src/tiny_yolo_v4_device_side_decoding_example.cpp
@@ -81,10 +81,8 @@ int main(int argc, char** argv) {
     // Create pipeline
     dai::Pipeline p = createNNPipeline(nnPath);
 
-    // Connect to device with above created pipeline
+    // Connect and start the pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     auto preview = d.getOutputQueue("preview", 4, false);
     auto detections = d.getOutputQueue("detections", 4, false);

--- a/examples/src/webcam_mobilenet_example.cpp
+++ b/examples/src/webcam_mobilenet_example.cpp
@@ -50,8 +50,6 @@ int main(int argc, char** argv) {
 
     // Connect to device with above created pipeline
     dai::Device d(p);
-    // Start the pipeline
-    d.startPipeline();
 
     cv::Mat frame;
     auto in = d.getInputQueue("nn_in");

--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -209,7 +209,7 @@ class Device {
      *
      * @return true if pipeline started, false otherwise
      */
-    bool startPipeline();
+    [[deprecated("Device(pipeline) starts the pipeline automatically. See Device() and startPipeline(pipeline) otherwise")]] bool startPipeline();
 
     /**
      * Starts the execution of a given pipeline
@@ -467,7 +467,7 @@ class Device {
     // private static
     void init(OpenVINO::Version version, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd);
     void init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd);
-    void init2(bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd);
+    void init2(bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd, tl::optional<const Pipeline&> pipeline);
     void checkClosed() const;
 
     std::shared_ptr<XLinkConnection> connection;
@@ -514,9 +514,7 @@ class Device {
     class Impl;
     Pimpl<Impl> pimpl;
 
-    // Serialized pipeline
-    bool hasPipeline = false;
-    Pipeline pipeline;
+    // OpenVINO version device was booted with
     OpenVINO::Version openvinoVersion;
 };
 

--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -16,6 +16,7 @@
 #include "depthai/xlink/XLinkStream.hpp"
 
 // shared
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai-shared/common/ChipTemperature.hpp"
 #include "depthai-shared/common/CpuUsage.hpp"
 #include "depthai-shared/common/MemoryInfo.hpp"
@@ -141,6 +142,57 @@ class Device {
     Device(const Pipeline& pipeline, const DeviceInfo& devInfo, const std::string& pathToCmd);
 
     /**
+     * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
+     * @param version - OpenVINO version which the device will be booted with. Default is Pipeline::DEFAULT_OPENVINO_VERSION
+     */
+    explicit Device(OpenVINO::Version version = Pipeline::DEFAULT_OPENVINO_VERSION);
+
+    /**
+     * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
+     * @param version - OpenVINO version which the device will be booted with
+     * @param usb2Mode - Boot device using USB2 mode firmware
+     */
+    Device(OpenVINO::Version version, bool usb2Mode);
+
+    /**
+     * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
+     * @param version - OpenVINO version which the device will be booted with
+     * @param pathToCmd - Path to custom device firmware
+     */
+    Device(OpenVINO::Version version, const char* pathToCmd);
+
+    /**
+     * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
+     * @param version - OpenVINO version which the device will be booted with
+     * @param pathToCmd - Path to custom device firmware
+     */
+    Device(OpenVINO::Version version, const std::string& pathToCmd);
+
+    /**
+     * Connects to device specified by devInfo.
+     * @param version - OpenVINO version which the device will be booted with
+     * @param devInfo - DeviceInfo which specifies which device to connect to
+     * @param usb2Mode - Boot device using USB2 mode firmware
+     */
+    Device(OpenVINO::Version version, const DeviceInfo& devInfo, bool usb2Mode = false);
+
+    /**
+     * Connects to device specified by devInfo.
+     * @param version - OpenVINO version which the device will be booted with
+     * @param devInfo - DeviceInfo which specifies which device to connect to
+     * @param pathToCmd - Path to custom device firmware
+     */
+    Device(OpenVINO::Version version, const DeviceInfo& devInfo, const char* pathToCmd);
+
+    /**
+     * Connects to device specified by devInfo.
+     * @param version - OpenVINO version which the device will be booted with
+     * @param devInfo - DeviceInfo which specifies which device to connect to
+     * @param usb2Mode - Path to custom device firmware
+     */
+    Device(OpenVINO::Version version, const DeviceInfo& devInfo, const std::string& pathToCmd);
+
+    /**
      * Device destructor. Closes the connection and data queues.
      */
     ~Device();
@@ -158,6 +210,14 @@ class Device {
      * @return true if pipeline started, false otherwise
      */
     bool startPipeline();
+
+    /**
+     * Starts the execution of a given pipeline
+     * @param pipeline OpenVINO version of the pipeline must match the one which the device was booted with.
+     *
+     * @return true if pipeline started, false otherwise
+     */
+    bool startPipeline(const Pipeline& pipeline);
 
     /**
      * Sets the devices logging severity level. This level affects which logs are transfered from device to host.
@@ -336,6 +396,13 @@ class Device {
     std::string getQueueEvent(std::chrono::microseconds timeout = std::chrono::microseconds(-1));
 
     /**
+     * Get cameras that are connected to the device
+     *
+     * @return Vector of connected cameras
+     */
+    std::vector<CameraBoardSocket> getConnectedCameras();
+
+    /**
      * Retrieves current DDR memory information from device
      *
      * @return Used, remaining and total ddr memory
@@ -398,7 +465,9 @@ class Device {
 
    private:
     // private static
+    void init(OpenVINO::Version version, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd);
     void init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd);
+    void init2(bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd);
     void checkClosed() const;
 
     std::shared_ptr<XLinkConnection> connection;
@@ -446,10 +515,9 @@ class Device {
     Pimpl<Impl> pimpl;
 
     // Serialized pipeline
-    PipelineSchema schema;
-    Assets assets;
-    std::vector<std::uint8_t> assetStorage;
-    OpenVINO::Version version;
+    bool hasPipeline = false;
+    Pipeline pipeline;
+    OpenVINO::Version openvinoVersion;
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -21,6 +21,11 @@ class PipelineImpl {
     friend class Pipeline;
     friend class Node;
 
+   public:
+    PipelineImpl() = default;
+    PipelineImpl(const PipelineImpl&) = default;
+
+   private:
     // static functions
     static bool isSamePipeline(const Node::Output& out, const Node::Input& in);
     static bool canConnect(const Node::Output& out, const Node::Input& in);
@@ -94,6 +99,9 @@ class Pipeline {
      */
     Pipeline();
     explicit Pipeline(const std::shared_ptr<PipelineImpl>& pimpl);
+
+    /// Clone the pipeline (Creates a copy)
+    Pipeline clone() const;
 
     /// Default Pipeline openvino version
     constexpr static auto DEFAULT_OPENVINO_VERSION = PipelineImpl::DEFAULT_OPENVINO_VERSION;
@@ -205,6 +213,11 @@ class Pipeline {
     /// Set a specific OpenVINO version to use with this pipeline
     void setOpenVINOVersion(OpenVINO::Version version) {
         impl()->forceRequiredOpenVINOVersion = version;
+    }
+
+    /// Get required OpenVINO version to run this pipeline
+    OpenVINO::Version getOpenVINOVersion() const {
+        return impl()->getPipelineOpenVINOVersion();
     }
 };
 

--- a/include/depthai/pipeline/node/DetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/DetectionNetwork.hpp
@@ -21,16 +21,16 @@ class DetectionNetwork : public NeuralNetwork {
    public:
     using Properties = dai::DetectionNetworkProperties;
 
-   private:
     std::string getName() const override;
-    std::vector<Input> getInputs() override;
     std::vector<Output> getOutputs() override;
-    nlohmann::json getProperties() override;
+    std::vector<Input> getInputs() override;
 
    protected:
     DetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
     Properties properties;
     virtual Properties& getPropertiesRef() override;
+    nlohmann::json getProperties() override;
+    std::shared_ptr<Node> clone() override;
 
    public:
     /**
@@ -62,6 +62,9 @@ class DetectionNetwork : public NeuralNetwork {
  * @brief MobileNetDetectionNetwork node. Parses MobileNet results
  */
 class MobileNetDetectionNetwork : public DetectionNetwork {
+   protected:
+    std::shared_ptr<Node> clone() override;
+
    public:
     MobileNetDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 };
@@ -70,6 +73,9 @@ class MobileNetDetectionNetwork : public DetectionNetwork {
  * @brief YoloDetectionNetwork node. Parses Yolo results
  */
 class YoloDetectionNetwork : public DetectionNetwork {
+   protected:
+    std::shared_ptr<Node> clone() override;
+
    public:
     YoloDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -19,16 +19,17 @@ class NeuralNetwork : public Node {
    public:
     using Properties = dai::NeuralNetworkProperties;
 
-   private:
-    Properties properties;
-
     std::string getName() const override;
     std::vector<Output> getOutputs() override;
     std::vector<Input> getInputs() override;
+
+   protected:
     nlohmann::json getProperties() override;
     std::shared_ptr<Node> clone() override;
     tl::optional<OpenVINO::Version> getRequiredOpenVINOVersion() override;
-    // void loadAssets(AssetManager& assetManager) override;
+
+   private:
+    Properties properties;
 
    protected:
     struct BlobAssetInfo {

--- a/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
@@ -21,16 +21,16 @@ class SpatialDetectionNetwork : public DetectionNetwork {
    public:
     using Properties = dai::SpatialDetectionNetworkProperties;
 
-   private:
     std::string getName() const override;
     std::vector<Input> getInputs() override;
     std::vector<Output> getOutputs() override;
-    nlohmann::json getProperties() override;
 
    protected:
     SpatialDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
     Properties properties;
     virtual Properties& getPropertiesRef() override;
+    nlohmann::json getProperties() override;
+    std::shared_ptr<Node> clone() override;
 
    public:
     /**
@@ -94,6 +94,9 @@ class SpatialDetectionNetwork : public DetectionNetwork {
  * MobileNetSpatialDetectionNetwork. Mobilenet-SSD based network with spatial location data.
  */
 class MobileNetSpatialDetectionNetwork : public SpatialDetectionNetwork {
+   protected:
+    std::shared_ptr<Node> clone() override;
+
    public:
     MobileNetSpatialDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 };
@@ -102,6 +105,9 @@ class MobileNetSpatialDetectionNetwork : public SpatialDetectionNetwork {
  * YoloSpatialDetectionNetwork. (tiny)Yolov3/v4 based network with spatial location data.
  */
 class YoloSpatialDetectionNetwork : public SpatialDetectionNetwork {
+   protected:
+    std::shared_ptr<Node> clone() override;
+
    public:
     YoloSpatialDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
     /// Set num classes

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -264,6 +264,60 @@ Device::Device(const Pipeline& pipeline, bool usb2Mode) {
     init(pipeline, true, usb2Mode, "");
 }
 
+Device::Device(OpenVINO::Version version, const DeviceInfo& devInfo, bool usb2Mode) : deviceInfo(devInfo) {
+    init(version, true, usb2Mode, "");
+}
+
+Device::Device(OpenVINO::Version version, const DeviceInfo& devInfo, const char* pathToCmd) : deviceInfo(devInfo) {
+    init(version, false, false, std::string(pathToCmd));
+}
+
+Device::Device(OpenVINO::Version version, const DeviceInfo& devInfo, const std::string& pathToCmd) : deviceInfo(devInfo) {
+    init(version, false, false, pathToCmd);
+}
+
+Device::Device(OpenVINO::Version version) {
+    // Searches for any available device for 'default' timeout
+
+    bool found = false;
+    std::tie(found, deviceInfo) = getAnyAvailableDevice();
+
+    // If no device found, throw
+    if(!found) throw std::runtime_error("No available devices");
+    init(version, true, false, "");
+}
+
+Device::Device(OpenVINO::Version version, const char* pathToCmd) {
+    // Searches for any available device for 'default' timeout
+
+    bool found = false;
+    std::tie(found, deviceInfo) = getAnyAvailableDevice();
+
+    // If no device found, throw
+    if(!found) throw std::runtime_error("No available devices");
+    init(version, false, false, std::string(pathToCmd));
+}
+
+Device::Device(OpenVINO::Version version, const std::string& pathToCmd) {
+    // Searches for any available device for 'default' timeout
+    bool found = false;
+    std::tie(found, deviceInfo) = getAnyAvailableDevice();
+
+    // If no device found, throw
+    if(!found) throw std::runtime_error("No available devices");
+    init(version, false, false, pathToCmd);
+}
+
+Device::Device(OpenVINO::Version version, bool usb2Mode) {
+    // Searches for any available device for 'default' timeout
+    bool found = false;
+    std::tie(found, deviceInfo) = getAnyAvailableDevice();
+
+    // If no device found, throw
+    if(!found) throw std::runtime_error("No available devices");
+    init(version, true, usb2Mode, "");
+}
+
 void Device::close() {
     // Only allow to close once
     if(closed.exchange(true)) return;
@@ -317,20 +371,39 @@ Device::~Device() {
     close();
 }
 
+void Device::init(OpenVINO::Version version, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd) {
+    // Initalize depthai library if not already
+    initialize();
+
+    // Specify the OpenVINO version
+    openvinoVersion = version;
+    hasPipeline = false;
+
+    spdlog::debug("Device - OpenVINO version: {}", OpenVINO::getVersionName(openvinoVersion));
+
+    init2(embeddedMvcmd, usb2Mode, pathToMvcmd);
+}
+
 void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd) {
     // Initalize depthai library if not already
     initialize();
 
-    // Mark the OpenVINO version and serialize the pipeline
-    pipeline.serialize(schema, assets, assetStorage, version);
+    // Mark the OpenVINO version and make a copy of the pipeline
+    this->pipeline = pipeline.clone();
+    openvinoVersion = this->pipeline.getOpenVINOVersion();
+    hasPipeline = true;
 
-    spdlog::debug("Device - pipeline serialized, OpenVINO version: {}", OpenVINO::getVersionName(version));
+    spdlog::debug("Device - pipeline serialized, OpenVINO version: {}", OpenVINO::getVersionName(openvinoVersion));
 
+    init2(embeddedMvcmd, usb2Mode, pathToMvcmd);
+}
+
+void Device::init2(bool embeddedMvcmd, bool usb2Mode, const std::string& pathToMvcmd) {
     // Set logging pattern of device (device id + shared pattern)
     pimpl->setPattern(fmt::format("[{}] {}", deviceInfo.getMxId(), LOG_DEFAULT_PATTERN));
 
     // Get embedded mvcmd
-    std::vector<std::uint8_t> embeddedFw = Resources::getInstance().getDeviceFirmware(usb2Mode, version);
+    std::vector<std::uint8_t> embeddedFw = Resources::getInstance().getDeviceFirmware(usb2Mode, openvinoVersion);
 
     // Init device (if bootloader, handle correctly - issue USB boot command)
     if(deviceInfo.state == X_LINK_UNBOOTED) {
@@ -520,50 +593,6 @@ void Device::init(const Pipeline& pipeline, bool embeddedMvcmd, bool usb2Mode, c
 
         // Sets system inforation logging rate. By default 1s
         setSystemInformationLoggingRate(DEFAULT_SYSTEM_INFORMATION_LOGGING_RATE_HZ);
-
-        // Open queues upfront, let queues know about data sizes (input queues)
-        // Go through Pipeline and check for 'XLinkIn' and 'XLinkOut' nodes
-        // and create corresponding default queues for them
-        for(const auto& kv : pipeline.getNodeMap()) {
-            const auto& node = kv.second;
-            const auto& xlinkIn = std::dynamic_pointer_cast<const node::XLinkIn>(node);
-            if(xlinkIn == nullptr) {
-                continue;
-            }
-            // Create DataInputQueue's
-            inputQueueMap[xlinkIn->getStreamName()] = std::make_shared<DataInputQueue>(connection, xlinkIn->getStreamName());
-            // set max data size, for more verbosity
-            inputQueueMap[xlinkIn->getStreamName()]->setMaxDataSize(xlinkIn->getMaxDataSize());
-        }
-        for(const auto& kv : pipeline.getNodeMap()) {
-            const auto& node = kv.second;
-            const auto& xlinkOut = std::dynamic_pointer_cast<const node::XLinkOut>(node);
-            if(xlinkOut == nullptr) {
-                continue;
-            }
-
-            auto streamName = xlinkOut->getStreamName();
-            // Create DataOutputQueue's
-            outputQueueMap[streamName] = std::make_shared<DataOutputQueue>(connection, streamName);
-
-            // Add callback for events
-            callbackIdMap[streamName] = outputQueueMap[streamName]->addCallback([this](std::string queueName, std::shared_ptr<ADatatype>) {
-                // Lock first
-                std::unique_lock<std::mutex> lock(eventMtx);
-
-                // Check if size is equal or greater than EVENT_QUEUE_MAXIMUM_SIZE
-                if(eventQueue.size() >= EVENT_QUEUE_MAXIMUM_SIZE) {
-                    auto numToRemove = eventQueue.size() - EVENT_QUEUE_MAXIMUM_SIZE + 1;
-                    eventQueue.erase(eventQueue.begin(), eventQueue.begin() + numToRemove);
-                }
-
-                // Add to the end of event queue
-                eventQueue.push_back(queueName);
-
-                // notify the rest
-                eventCv.notify_all();
-            });
-        }
 
     } catch(const std::exception&) {
         // close device (cleanup)
@@ -756,6 +785,12 @@ std::string Device::getQueueEvent(std::chrono::microseconds timeout) {
     return getQueueEvent(getOutputQueueNames(), timeout);
 }
 
+std::vector<CameraBoardSocket> Device::getConnectedCameras() {
+    checkClosed();
+
+    return client->call("getConnectedCameras").as<std::vector<CameraBoardSocket>>();
+}
+
 // Convinience functions for querying current system information
 MemoryInfo Device::getDdrMemoryUsage() {
     checkClosed();
@@ -872,10 +907,84 @@ float Device::getSystemInformationLoggingRate() {
 }
 
 bool Device::startPipeline() {
+    // Check if has serialized pipeline
+    if(!hasPipeline) {
+        throw std::runtime_error("No pipeline given");
+    }
+
+    // Start the pipeline
+    bool ret = startPipeline(pipeline);
+    if(ret) {
+        // Remove the copy of the pipeline now as its not needed anymore
+        pipeline = Pipeline(nullptr);
+    }
+
+    // Return result of starting the pipeline
+    return ret;
+}
+
+bool Device::startPipeline(const Pipeline& pipeline) {
     checkClosed();
 
     // first check if pipeline is not already started
-    if(isPipelineRunning()) return false;
+    if(isPipelineRunning()) {
+        throw std::runtime_error("Pipeline is already running");
+    }
+
+    PipelineSchema schema;
+    Assets assets;
+    std::vector<std::uint8_t> assetStorage;
+
+    // Mark the OpenVINO version and serialize the pipeline
+    OpenVINO::Version pipelineOpenvinoVersion;
+    pipeline.serialize(schema, assets, assetStorage, pipelineOpenvinoVersion);
+    if(openvinoVersion != pipelineOpenvinoVersion) {
+        throw std::runtime_error("Device booted with different OpenVINO version that pipeline requires");
+    }
+
+    // Open queues upfront, let queues know about data sizes (input queues)
+    // Go through Pipeline and check for 'XLinkIn' and 'XLinkOut' nodes
+    // and create corresponding default queues for them
+    for(const auto& kv : pipeline.getNodeMap()) {
+        const auto& node = kv.second;
+        const auto& xlinkIn = std::dynamic_pointer_cast<const node::XLinkIn>(node);
+        if(xlinkIn == nullptr) {
+            continue;
+        }
+        // Create DataInputQueue's
+        inputQueueMap[xlinkIn->getStreamName()] = std::make_shared<DataInputQueue>(connection, xlinkIn->getStreamName());
+        // set max data size, for more verbosity
+        inputQueueMap[xlinkIn->getStreamName()]->setMaxDataSize(xlinkIn->getMaxDataSize());
+    }
+    for(const auto& kv : pipeline.getNodeMap()) {
+        const auto& node = kv.second;
+        const auto& xlinkOut = std::dynamic_pointer_cast<const node::XLinkOut>(node);
+        if(xlinkOut == nullptr) {
+            continue;
+        }
+
+        auto streamName = xlinkOut->getStreamName();
+        // Create DataOutputQueue's
+        outputQueueMap[streamName] = std::make_shared<DataOutputQueue>(connection, streamName);
+
+        // Add callback for events
+        callbackIdMap[streamName] = outputQueueMap[streamName]->addCallback([this](std::string queueName, std::shared_ptr<ADatatype>) {
+            // Lock first
+            std::unique_lock<std::mutex> lock(eventMtx);
+
+            // Check if size is equal or greater than EVENT_QUEUE_MAXIMUM_SIZE
+            if(eventQueue.size() >= EVENT_QUEUE_MAXIMUM_SIZE) {
+                auto numToRemove = eventQueue.size() - EVENT_QUEUE_MAXIMUM_SIZE + 1;
+                eventQueue.erase(eventQueue.begin(), eventQueue.begin() + numToRemove);
+            }
+
+            // Add to the end of event queue
+            eventQueue.push_back(queueName);
+
+            // notify the rest
+            eventCv.notify_all();
+        });
+    }
 
     // if debug
     if(spdlog::get_level() == spdlog::level::debug) {
@@ -897,7 +1006,7 @@ bool Device::startPipeline() {
 
         // Transfer the whole assetStorage in a separate thread
         const std::string streamAssetStorage = "__stream_asset_storage";
-        std::thread t1([this, &streamAssetStorage]() {
+        std::thread t1([this, &streamAssetStorage, &assetStorage]() {
             XLinkStream stream(*connection, streamAssetStorage, XLINK_USB_BUFFER_MAX_SIZE);
             int64_t offset = 0;
             do {

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -593,7 +593,9 @@ void Device::init2(bool embeddedMvcmd, bool usb2Mode, const std::string& pathToM
 
         // Starts pipeline if given
         if(pipeline) {
-            startPipeline(*pipeline);
+            if(!startPipeline(*pipeline)){
+                throw std::runtime_error("Couldn't start the pipeline");
+            }
         }
 
     } catch(const std::exception&) {

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -22,20 +22,27 @@ Pipeline::Pipeline() : pimpl(std::make_shared<PipelineImpl>()) {
     initialize();
 }
 
-/*
-Pipeline::Pipeline(const Pipeline& p){
-    pimpl = std::make_shared<PipelineImpl>();
+Pipeline Pipeline::clone() const {
+    // TODO(themarpe) - Copy assets
 
+    Pipeline clone;
+
+    // Make a copy of PipelineImpl
+    clone.pimpl = std::make_shared<PipelineImpl>(*impl());
+
+    // All IDs remain the same, just switch out the actual nodes with copies
     // Copy all nodes
-    pimpl->globalProperties = p.getGlobalProperties();
-    pimpl->nodes.reserve(p.pimpl->nodes.size());
-    for(const auto& n : p.pimpl->nodes){
-        auto clone = n->clone();
-        clone->parent = std::weak_ptr<PipelineImpl>(pimpl);
-        pimpl->nodes.push_back(clone);
+    for(const auto& kv : impl()->nodeMap) {
+        const auto& id = kv.first;
+
+        // Swap out with a copy
+        clone.pimpl->nodeMap[id] = impl()->nodeMap.at(id)->clone();
+        // Set parent to be the new pipeline
+        clone.pimpl->nodeMap[id]->parent = std::weak_ptr<PipelineImpl>(clone.pimpl);
     }
+
+    return clone;
 }
-*/
 
 Pipeline::Pipeline(const std::shared_ptr<PipelineImpl>& pimpl) {
     this->pimpl = pimpl;

--- a/src/pipeline/node/DetectionNetwork.cpp
+++ b/src/pipeline/node/DetectionNetwork.cpp
@@ -29,6 +29,10 @@ DetectionNetwork::Properties& DetectionNetwork::getPropertiesRef() {
     return properties;
 }
 
+std::shared_ptr<Node> DetectionNetwork::clone() {
+    return std::make_shared<std::decay<decltype(*this)>::type>(*this);
+}
+
 nlohmann::json DetectionNetwork::getProperties() {
     nlohmann::json j;
     nlohmann::to_json(j, properties);
@@ -44,6 +48,10 @@ void DetectionNetwork::setConfidenceThreshold(float thresh) {
 //--------------------------------------------------------------------
 MobileNetDetectionNetwork::MobileNetDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : DetectionNetwork(par, nodeId) {
     getPropertiesRef().nnFamily = DetectionNetworkType::MOBILENET;
+}
+
+std::shared_ptr<Node> MobileNetDetectionNetwork::clone() {
+    return std::make_shared<std::decay<decltype(*this)>::type>(*this);
 }
 
 //--------------------------------------------------------------------
@@ -71,6 +79,10 @@ void YoloDetectionNetwork::setAnchorMasks(std::map<std::string, std::vector<int>
 
 void YoloDetectionNetwork::setIouThreshold(float thresh) {
     getPropertiesRef().iouThreshold = thresh;
+}
+
+std::shared_ptr<Node> YoloDetectionNetwork::clone() {
+    return std::make_shared<std::decay<decltype(*this)>::type>(*this);
 }
 
 }  // namespace node

--- a/src/pipeline/node/SpatialDetectionNetwork.cpp
+++ b/src/pipeline/node/SpatialDetectionNetwork.cpp
@@ -13,6 +13,10 @@ namespace node {
 //--------------------------------------------------------------------
 SpatialDetectionNetwork::SpatialDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : DetectionNetwork(par, nodeId) {}
 
+std::shared_ptr<Node> SpatialDetectionNetwork::clone() {
+    return std::make_shared<std::decay<decltype(*this)>::type>(*this);
+}
+
 std::string SpatialDetectionNetwork::getName() const {
     return "SpatialDetectionNetwork";
 }
@@ -55,11 +59,19 @@ MobileNetSpatialDetectionNetwork::MobileNetSpatialDetectionNetwork(const std::sh
     getPropertiesRef().nnFamily = DetectionNetworkType::MOBILENET;
 }
 
+std::shared_ptr<Node> MobileNetSpatialDetectionNetwork::clone() {
+    return std::make_shared<std::decay<decltype(*this)>::type>(*this);
+}
+
 //--------------------------------------------------------------------
 // YOLO
 //--------------------------------------------------------------------
 YoloSpatialDetectionNetwork::YoloSpatialDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : SpatialDetectionNetwork(par, nodeId) {
     getPropertiesRef().nnFamily = DetectionNetworkType::YOLO;
+}
+
+std::shared_ptr<Node> YoloSpatialDetectionNetwork::clone() {
+    return std::make_shared<std::decay<decltype(*this)>::type>(*this);
 }
 
 void YoloSpatialDetectionNetwork::setNumClasses(const int numClasses) {

--- a/tests/src/color_camera_node_test.cpp
+++ b/tests/src/color_camera_node_test.cpp
@@ -39,7 +39,6 @@ int main() {
 
         if(found) {
             dai::Device d(p, deviceInfo);
-            d.startPipeline();
 
             auto previewQueue = d.getOutputQueue("preview", 8, true);
 

--- a/tests/src/image_manip_node_test.cpp
+++ b/tests/src/image_manip_node_test.cpp
@@ -41,7 +41,6 @@ int main() {
 
         if(found) {
             dai::Device d(p, deviceInfo);
-            d.startPipeline();
 
             auto in = d.getInputQueue("in");
             auto out = d.getOutputQueue("out");

--- a/tests/src/neural_network_test.cpp
+++ b/tests/src/neural_network_test.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Neural network node data checks") {
 
     auto pipeline = createNeuralNetworkPipeline();
 
-    dai::Device device(pipeline);
+    dai::Device device(pipeline.getOpenVINOVersion());
 
     std::atomic<bool> receivedLogMessage{false};
 
@@ -55,7 +55,7 @@ TEST_CASE("Neural network node data checks") {
     });
 
     // Start pipeline and feed correct sized data in various forms (Planar BGR 300*300*3 for mobilenet)
-    device.startPipeline();
+    device.startPipeline(pipeline);
 
     // Iterate 10 times
     for(int i = 0; i < 10; i++) {


### PR DESCRIPTION
Major changes:
 - Modified behavior of Device(pipeline) - this now starts the pipeline implicitly.
 - Added (back) startPipeline(pipeline) which can start a pipeline if device was booted with Device() or Device(openvinoVersion) constructor
 - Deprecated startPipeline() function
 - Added getConnectedCameras() function to be able to query connected cameras and start different pipeline without reconnecting to the device.
 
Minor changes:
 - Refactored all examples to remove deprecated startPipeline()
 - Fixed missing Node clone methods on some classes
 - WIP: Pipeline cloning - missing asset cloning.
 - Fixed sanitizers on examples when not set as testing
 