### PR TITLE
StereoDepth: mesh rectification, disp/depth configurable resolution

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "556a856e85570e0d874d19b305a0080a8f1f58bf")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "d8957a2c362ed9fbe46a4dcdce5f1224e20ae726")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "cd125785287b9416c5c31afb3790e30c92d855b0")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "cae5765151ebd8dbf24c6dbd772a9bf67d935a48")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "4d2e72e667d1449b755413658440a1d48bc59d91")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "3941335896a9ff2b83b3d20bd1d62fed82a543d7")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "3941335896a9ff2b83b3d20bd1d62fed82a543d7")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "cd125785287b9416c5c31afb3790e30c92d855b0")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/src/rgb_depth_aligned.cpp
+++ b/examples/src/rgb_depth_aligned.cpp
@@ -9,6 +9,8 @@
 // Optional. If set (true), the ColorCamera is downscaled from 1080p to 720p.
 // Otherwise (false), the aligned depth is automatically upscaled to 1080p
 static std::atomic<bool> downscaleColor{true};
+static constexpr int fps = 30;
+static constexpr auto monoRes = dai::MonoCameraProperties::SensorResolution::THE_400_P;
 
 int main() {
     using namespace std;
@@ -34,15 +36,18 @@ int main() {
     // Properties
     camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+    camRgb->setFps(fps);
     if(downscaleColor) camRgb->setIspScale(2, 3);
     // For now, RGB needs fixed focus to properly align with depth.
     // This value was used during calibration
     camRgb->initialControl.setManualFocus(135);
 
-    left->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
+    left->setResolution(monoRes);
     left->setBoardSocket(dai::CameraBoardSocket::LEFT);
-    right->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
+    left->setFps(fps);
+    right->setResolution(monoRes);
     right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    right->setFps(fps);
 
     stereo->setConfidenceThreshold(200);
     // LR-check is required for depth alignment

--- a/examples/src/rgb_depth_aligned.cpp
+++ b/examples/src/rgb_depth_aligned.cpp
@@ -10,6 +10,7 @@
 // Otherwise (false), the aligned depth is automatically upscaled to 1080p
 static std::atomic<bool> downscaleColor{true};
 static constexpr int fps = 30;
+// The disparity is computed at this resolution, then upscaled to RGB resolution
 static constexpr auto monoRes = dai::MonoCameraProperties::SensorResolution::THE_400_P;
 
 int main() {
@@ -49,7 +50,7 @@ int main() {
     right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
     right->setFps(fps);
 
-    stereo->setConfidenceThreshold(200);
+    stereo->setConfidenceThreshold(230);
     // LR-check is required for depth alignment
     stereo->setLeftRightCheck(true);
     stereo->setDepthAlign(dai::CameraBoardSocket::RGB);

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -95,6 +95,28 @@ class StereoDepth : public Node {
     void setEmptyCalibration();
 
     /**
+     * Specify local filesystem paths to the mesh calibration files for 'left' and 'right' inputs.
+     * When a mesh calibration is set, it overrides the camera intrinsics/extrinsics matrices.
+     * Mesh format: a sequence of (y,x) points as 'float' with coordinates from the input image
+     * to be mapped in the output. The mesh can be subsampled, configured by `setMeshStep`.
+     * With a 1280x800 resolution and the default (16,16) step, the required mesh size is:
+     * width: 1280 / 16 + 1 = 81
+     * height: 800 / 16 + 1 = 51
+     */
+    void loadMeshFiles(const std::string& pathLeft, const std::string& pathRight);
+
+    /**
+     * Specify mesh calibration data for 'left' and 'right' inputs, as vectors of bytes.
+     * See `loadMeshFiles` for the expected data format
+     */
+    void loadMeshData(const std::vector<std::uint8_t>& dataLeft, const std::vector<std::uint8_t>& dataRight);
+
+    /**
+     * Set the distance between mesh points. Default: (16, 16)
+     */
+    void setMeshStep(int width, int height);
+
+    /**
      * Specify input resolution size
      *
      * Optional if MonoCamera exists, otherwise necessary

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -96,11 +96,15 @@ class StereoDepth : public Node {
 
     /**
      * Specify local filesystem paths to the mesh calibration files for 'left' and 'right' inputs.
+     *
      * When a mesh calibration is set, it overrides the camera intrinsics/extrinsics matrices.
      * Mesh format: a sequence of (y,x) points as 'float' with coordinates from the input image
      * to be mapped in the output. The mesh can be subsampled, configured by `setMeshStep`.
+     *
      * With a 1280x800 resolution and the default (16,16) step, the required mesh size is:
+     *
      * width: 1280 / 16 + 1 = 81
+     *
      * height: 800 / 16 + 1 = 51
      */
     void loadMeshFiles(const std::string& pathLeft, const std::string& pathRight);
@@ -128,7 +132,7 @@ class StereoDepth : public Node {
      *
      * Currently only applicable when aligning to RGB camera
      */
-    void setOutputResolution(int width, int height);
+    void setOutputSize(int width, int height);
 
     /**
      * @param median Set kernel size for disparity/depth median filtering, or disable

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -135,6 +135,12 @@ class StereoDepth : public Node {
     void setOutputSize(int width, int height);
 
     /**
+     * Specifies whether the frames resized by `setOutputSize` should preserve aspect ratio,
+     * with potential cropping when enabled. Default `true`
+     */
+    void setOutputKeepAspectRatio(bool keep);
+
+    /**
      * @param median Set kernel size for disparity/depth median filtering, or disable
      */
     void setMedianFilter(Properties::MedianFilter median);

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -102,6 +102,13 @@ class StereoDepth : public Node {
     void setInputResolution(int width, int height);
 
     /**
+     * Specify disparity/depth output resolution size, implemented by scaling.
+     *
+     * Currently only applicable when aligning to RGB camera
+     */
+    void setOutputResolution(int width, int height);
+
+    /**
      * @param median Set kernel size for disparity/depth median filtering, or disable
      */
     void setMedianFilter(Properties::MedianFilter median);

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -61,6 +61,49 @@ void StereoDepth::setEmptyCalibration(void) {
     properties.calibration = empty;
 }
 
+void StereoDepth::loadMeshData(const std::vector<std::uint8_t>& dataLeft, const std::vector<std::uint8_t>& dataRight) {
+    if (dataLeft.size() != dataRight.size()) {
+        throw std::runtime_error("StereoDepth | left and right mesh sizes must match");
+    }
+
+    Asset meshAsset;
+    std::string assetKey;
+    meshAsset.alignment = 64;
+
+    meshAsset.data = dataLeft;
+    assetKey = "meshLeft";
+    assetManager.set(assetKey, meshAsset);
+    properties.mesh.meshLeftUri = std::string("asset:") + assetKey;
+
+    meshAsset.data = dataRight;
+    assetKey = "meshRight";
+    assetManager.set(assetKey, meshAsset);
+    properties.mesh.meshRightUri = std::string("asset:") + assetKey;
+
+    properties.mesh.meshSize = meshAsset.data.size();
+}
+
+void StereoDepth::loadMeshFiles(const std::string& pathLeft, const std::string& pathRight) {
+    std::ifstream streamLeft(pathLeft, std::ios::binary);
+    if(!streamLeft.is_open()) {
+        throw std::runtime_error("StereoDepth | Cannot open mesh at path: " + pathLeft);
+    }
+    std::vector<std::uint8_t> dataLeft = std::vector<std::uint8_t>(std::istreambuf_iterator<char>(streamLeft), {});
+
+    std::ifstream streamRight(pathRight, std::ios::binary);
+    if(!streamRight.is_open()) {
+        throw std::runtime_error("StereoDepth | Cannot open mesh at path: " + pathRight);
+    }
+    std::vector<std::uint8_t> dataRight = std::vector<std::uint8_t>(std::istreambuf_iterator<char>(streamRight), {});
+
+    loadMeshData(dataLeft, dataRight);
+}
+
+void StereoDepth::setMeshStep(int width, int height) {
+    properties.mesh.stepWidth = width;
+    properties.mesh.stepHeight = height;
+}
+
 void StereoDepth::setInputResolution(int width, int height) {
     properties.width = width;
     properties.height = height;

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -65,6 +65,10 @@ void StereoDepth::setInputResolution(int width, int height) {
     properties.width = width;
     properties.height = height;
 }
+void StereoDepth::setOutputResolution(int width, int height) {
+    properties.outWidth = width;
+    properties.outHeight = height;
+}
 void StereoDepth::setMedianFilter(Properties::MedianFilter median) {
     properties.median = median;
 }

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -101,6 +101,9 @@ void StereoDepth::setOutputSize(int width, int height) {
     properties.outWidth = width;
     properties.outHeight = height;
 }
+void StereoDepth::setOutputKeepAspectRatio(bool keep) {
+    properties.outKeepAspectRatio = keep;
+}
 void StereoDepth::setMedianFilter(Properties::MedianFilter median) {
     properties.median = median;
 }

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -97,7 +97,7 @@ void StereoDepth::setInputResolution(int width, int height) {
     properties.width = width;
     properties.height = height;
 }
-void StereoDepth::setOutputResolution(int width, int height) {
+void StereoDepth::setOutputSize(int width, int height) {
     properties.outWidth = width;
     properties.outHeight = height;
 }

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -51,7 +51,7 @@ void StereoDepth::setEmptyCalibration(void) {
 }
 
 void StereoDepth::loadMeshData(const std::vector<std::uint8_t>& dataLeft, const std::vector<std::uint8_t>& dataRight) {
-    if (dataLeft.size() != dataRight.size()) {
+    if(dataLeft.size() != dataRight.size()) {
         throw std::runtime_error("StereoDepth | left and right mesh sizes must match");
     }
 


### PR DESCRIPTION
- StereoDepth mesh rectification support, mainly for fisheye camera usecase. The left and right meshes (files or byte arrays) need to be configured in the pipeline.
- disparity/depth configurable output resolution, by rescaling the output. Available for now only when RGB-depth alignment is enabled (a warning is issued otherwise). For example, aligning ColorCamera `preview` and `disparity`/`depth` is possible as:
```
// Center cropping with no distortion
colorCamera->setPreviewKeepAspectRatio(true)  // Also default
colorCamera->setPreviewSize(300, 300)
stereoDepth->setOutputKeepAspectRatio(true)   // Also default
stereoDepth->setOutputSize(300, 300)
```
or
```
// No cropping on ColorCamera (the image will get squished). 
// Slight cropping may be applied to disparity/depth to get it aligned, as the RGB FOV is narrower
colorCamera->setPreviewKeepAspectRatio(false)
colorCamera->setPreviewSize(300, 300)
stereoDepth->setOutputKeepAspectRatio(false)
stereoDepth->setOutputSize(300, 300)
```

- `rgb_depth_aligned` example: lower mono camera resolution for now: 720p -> 400p, to fix the lag, while keeping 30fps. The alignment will be further optimized in the future.

Related PR: https://github.com/luxonis/depthai-shared/pull/36