### PR TITLE
Add support for 5x5 bilateral filter in stereo depth; add runtime con…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(${TARGET_CORE_NAME}
     src/pipeline/datatype/SpatialLocationCalculatorConfig.cpp
     src/pipeline/datatype/Tracklets.cpp
     src/pipeline/datatype/IMUData.cpp
+    src/pipeline/datatype/StereoDepthConfig.cpp
     src/utility/Initialization.cpp
     src/utility/Resources.cpp
     src/xlink/XLinkConnection.cpp

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "e67dee8bba18786b8fabe8fe212455481ca5c8b3")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "169d63f7c4360e0a1ad9de6917ce734d97113a75")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "80d7184640c65a88a807b744c9623da8058f890b")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "82144ce72c305a2e9217ccf8691a378d9de8cb94")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "169d63f7c4360e0a1ad9de6917ce734d97113a75")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "b149bfe8bdd5d364a637ee8a776733a7500830ca")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "82144ce72c305a2e9217ccf8691a378d9de8cb94")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "3df098eb3fa3d0bf6c53291f9b5e2d892ac33d28")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "4666e26b9165df43dfb1e9c106fcdf5edf672af7")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a365ab1f9d9b9a44afb00bb648e3bceb730fe797")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "fdd5602fb29eb803b46bf3989800d2c26cb6ee5e")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "e67dee8bba18786b8fabe8fe212455481ca5c8b3")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "2603807d71a7b959a1d089037d14c8ab7fbd85b8")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "4666e26b9165df43dfb1e9c106fcdf5edf672af7")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "ae8bf7da955812cbd33b0d7e6c190bab8b918517")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "2603807d71a7b959a1d089037d14c8ab7fbd85b8")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "9628a4701a703d4654d2e965bbfcb74b6cee4915")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "80d7184640c65a88a807b744c9623da8058f890b")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "b149bfe8bdd5d364a637ee8a776733a7500830ca")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "ae8bf7da955812cbd33b0d7e6c190bab8b918517")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/src/depth_crop_control.cpp
+++ b/examples/src/depth_crop_control.cpp
@@ -40,7 +40,7 @@ int main() {
 
     manip->initialConfig.setCropRect(topLeft.x, topLeft.y, bottomRight.x, bottomRight.y);
     manip->setMaxOutputFrameSize(monoRight->getResolutionHeight() * monoRight->getResolutionWidth() * 3);
-    stereo->setConfidenceThreshold(200);
+    stereo->initialConfig.setConfidenceThreshold(200);
 
     // Linking
     configIn->out.link(manip->inputConfig);

--- a/examples/src/depth_preview.cpp
+++ b/examples/src/depth_preview.cpp
@@ -29,9 +29,9 @@ int main() {
     monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
 
     // Create a node that will produce the depth map (using disparity output as it's easier to visualize depth this way)
-    depth->setConfidenceThreshold(200);
+    depth->initialConfig.setConfidenceThreshold(200);
     // Options: MEDIAN_OFF, KERNEL_3x3, KERNEL_5x5, KERNEL_7x7 (default)
-    depth->setMedianFilter(dai::MedianFilter::KERNEL_7x7);
+    depth->initialConfig.setMedianFilter(dai::MedianFilter::KERNEL_7x7);
     depth->setLeftRightCheck(lr_check);
     depth->setExtendedDisparity(extended_disparity);
     depth->setSubpixel(subpixel);

--- a/examples/src/mono_depth_mobilenetssd.cpp
+++ b/examples/src/mono_depth_mobilenetssd.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
     monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
     // Produce the depth map (using disparity output as it's easier to visualize depth this way)
-    stereo->setConfidenceThreshold(255);
+    stereo->initialConfig.setConfidenceThreshold(255);
     stereo->setRectifyEdgeFillColor(0);  // Black, to better see the cutout from rectification (black stripe on the edges)
     // Convert the grayscale frame into the nn-acceptable form
     manip->initialConfig.setResize(300, 300);

--- a/examples/src/rgb_depth_aligned.cpp
+++ b/examples/src/rgb_depth_aligned.cpp
@@ -50,7 +50,7 @@ int main() {
     right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
     right->setFps(fps);
 
-    stereo->setConfidenceThreshold(230);
+    stereo->initialConfig.setConfidenceThreshold(230);
     // LR-check is required for depth alignment
     stereo->setLeftRightCheck(true);
     stereo->setDepthAlign(dai::CameraBoardSocket::RGB);

--- a/examples/src/rgb_encoding_mono_mobilenet_depth.cpp
+++ b/examples/src/rgb_encoding_mono_mobilenet_depth.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
     videoEncoder->setDefaultProfilePreset(1920, 1080, 30, dai::VideoEncoderProperties::Profile::H265_MAIN);
 
     // Note: the rectified streams are horizontally mirrored by default
-    depth->setConfidenceThreshold(255);
+    depth->initialConfig.setConfidenceThreshold(255);
     depth->setRectifyMirrorFrame(false);
     depth->setRectifyEdgeFillColor(0);  // Black, to better see the cutout
 

--- a/examples/src/spatial_location_calculator.cpp
+++ b/examples/src/spatial_location_calculator.cpp
@@ -38,7 +38,7 @@ int main() {
     bool lrcheck = false;
     bool subpixel = false;
 
-    stereo->setConfidenceThreshold(255);
+    stereo->initialConfig.setConfidenceThreshold(255);
     stereo->setLeftRightCheck(lrcheck);
     stereo->setSubpixel(subpixel);
 

--- a/examples/src/spatial_mobilenet.cpp
+++ b/examples/src/spatial_mobilenet.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv) {
     monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
 
     // Setting node configs
-    stereo->setConfidenceThreshold(255);
+    stereo->initialConfig.setConfidenceThreshold(255);
 
     spatialDetectionNetwork->setBlobPath(nnPath);
     spatialDetectionNetwork->setConfidenceThreshold(0.5f);

--- a/examples/src/spatial_mobilenet_mono.cpp
+++ b/examples/src/spatial_mobilenet_mono.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv) {
     monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
 
     // StereoDepth
-    stereo->setConfidenceThreshold(255);
+    stereo->initialConfig.setConfidenceThreshold(255);
 
     // Define a neural network that will make predictions based on the source frames
     spatialDetectionNetwork->setConfidenceThreshold(0.5f);

--- a/examples/src/spatial_object_tracker.cpp
+++ b/examples/src/spatial_object_tracker.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
     monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
 
     /// setting node configs
-    stereo->setConfidenceThreshold(255);
+    stereo->initialConfig.setConfidenceThreshold(255);
 
     spatialDetectionNetwork->setBlobPath(nnPath);
     spatialDetectionNetwork->setConfidenceThreshold(0.5f);

--- a/examples/src/spatial_tiny_yolo.cpp
+++ b/examples/src/spatial_tiny_yolo.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
     monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
 
     /// setting node configs
-    stereo->setConfidenceThreshold(255);
+    stereo->initialConfig.setConfidenceThreshold(255);
 
     spatialDetectionNetwork->setBlobPath(nnPath);
     spatialDetectionNetwork->setConfidenceThreshold(0.5f);

--- a/examples/src/stereo_depth_video.cpp
+++ b/examples/src/stereo_depth_video.cpp
@@ -47,7 +47,7 @@ int main() {
 
     if(withDepth) {
         // StereoDepth
-        stereo->setConfidenceThreshold(200);
+        stereo->initialConfig.setConfidenceThreshold(200);
         stereo->setRectifyEdgeFillColor(0);  // black, to better see the cutout
         // stereo->loadCalibrationFile("../../../../depthai/resources/depthai.calib");
         // stereo->setInputResolution(1280, 720);

--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -45,13 +45,22 @@ class StereoDepthConfig : public Buffer {
     /**
      * A larger value of the parameter means that farther colors within the pixel neighborhood will be mixed together,
      * resulting in larger areas of semi-equal color.
-     * @param sigma Set sigma value for 5x5 bilateral filter
+     * @param sigma Set sigma value for 5x5 bilateral filter. 0..65535
      */
     void setBilateralFilterSigma(uint16_t sigma);
     /**
      * Get sigma value for 5x5 bilateral filter
      */
     uint16_t getBilateralFilterSigma() const;
+
+    /**
+     * @param threshold Set threshold for left-right, right-left disparity map combine, 0..255
+     */
+    void setLeftRightCheckThreshold(int threshold);
+    /**
+     * Get threshold for left-right check combine
+     */
+    int getLeftRightCheckThreshold() const;
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "depthai-shared/datatype/RawStereoDepthConfig.hpp"
+#include "depthai/pipeline/datatype/Buffer.hpp"
+
+namespace dai {
+
+/**
+ * StereoDepthConfig message.
+ */
+class StereoDepthConfig : public Buffer {
+    std::shared_ptr<RawBuffer> serialize() const override;
+    RawStereoDepthConfig& cfg;
+
+   public:
+    /**
+     * Construct StereoDepthConfig message.
+     */
+    StereoDepthConfig();
+    explicit StereoDepthConfig(std::shared_ptr<RawStereoDepthConfig> ptr);
+    virtual ~StereoDepthConfig() = default;
+
+    void setConfidenceThreshold(int confThr);
+    void setMedianFilter(StereoDepthConfigData::MedianFilter median);
+    void setBilateralFilterSigma(uint16_t sigma);
+};
+
+}  // namespace dai

--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -23,9 +23,35 @@ class StereoDepthConfig : public Buffer {
     explicit StereoDepthConfig(std::shared_ptr<RawStereoDepthConfig> ptr);
     virtual ~StereoDepthConfig() = default;
 
+    /**
+     * Confidence threshold for disparity calculation
+     * @param confThr Confidence threshold value 0..255
+     */
     void setConfidenceThreshold(int confThr);
-    void setMedianFilter(StereoDepthConfigData::MedianFilter median);
+    /**
+     * Get confidence threshold for disparity calculation
+     */
+    int getConfidenceThreshold() const;
+
+    /**
+     * @param median Set kernel size for disparity/depth median filtering, or disable
+     */
+    void setMedianFilter(dai::MedianFilter median);
+    /**
+     * Get median filter setting
+     */
+    dai::MedianFilter getMedianFilter() const;
+
+    /**
+     * A larger value of the parameter means that farther colors within the pixel neighborhood will be mixed together,
+     * resulting in larger areas of semi-equal color.
+     * @param sigma Set sigma value for 5x5 bilateral filter
+     */
     void setBilateralFilterSigma(uint16_t sigma);
+    /**
+     * Get sigma value for 5x5 bilateral filter
+     */
+    uint16_t getBilateralFilterSigma() const;
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -4,6 +4,7 @@
 
 // shared
 #include "depthai-shared/properties/StereoDepthProperties.hpp"
+#include "depthai/pipeline/datatype/StereoDepthConfig.hpp"
 
 namespace dai {
 namespace node {
@@ -23,9 +24,21 @@ class StereoDepth : public Node {
     std::vector<Input> getInputs() override;
     nlohmann::json getProperties() override;
     std::shared_ptr<Node> clone() override;
+    std::shared_ptr<RawStereoDepthConfig> rawConfig;
 
    public:
     StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
+
+    /**
+     * Initial config to use when calculating spatial location data.
+     */
+    StereoDepthConfig initialConfig;
+
+    /**
+     * Input StereoDepthConfig message with ability to modify parameters in runtime.
+     * Default queue is non-blocking with size 4.
+     */
+    Input inputConfig{*this, "inputConfig", Input::Type::SReceiver, false, 4, {{DatatypeEnum::StereoDepthConfig, false}}};
 
     /**
      * Input for left ImgFrame of left-right pair

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -105,7 +105,7 @@ class StereoDepth : public Node {
      * Specify that a passthrough/dummy calibration should be used,
      * when input frames are already rectified (e.g. sourced from recordings on the host)
      */
-    void setEmptyCalibration();
+    [[deprecated("Use 'Stereo::setRectification(false)' instead")]] void setEmptyCalibration();
 
     /**
      * Specify local filesystem paths to the mesh calibration files for 'left' and 'right' inputs.
@@ -174,6 +174,11 @@ class StereoDepth : public Node {
      * @param confThr Confidence threshold value 0..255
      */
     void setConfidenceThreshold(int confThr);
+
+    /**
+     * Rectify input images or not.
+     */
+    void setRectification(bool enable);
 
     /**
      * Computes and combines disparities in both L-R and R-L directions, and combine them.

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -30,7 +30,7 @@ class StereoDepth : public Node {
     StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
 
     /**
-     * Initial config to use when calculating spatial location data.
+     * Initial config to use for StereoDepth.
      */
     StereoDepthConfig initialConfig;
 
@@ -156,7 +156,7 @@ class StereoDepth : public Node {
     /**
      * @param median Set kernel size for disparity/depth median filtering, or disable
      */
-    void setMedianFilter(dai::MedianFilter median);
+    [[deprecated("Use 'initialConfig.setMedianFilter()' instead")]] void setMedianFilter(dai::MedianFilter median);
 
     /**
      * @param align Set the disparity/depth alignment: centered (between the 'left' and 'right' inputs),
@@ -173,7 +173,7 @@ class StereoDepth : public Node {
      * Confidence threshold for disparity calculation
      * @param confThr Confidence threshold value 0..255
      */
-    void setConfidenceThreshold(int confThr);
+    [[deprecated("Use 'initialConfig.setConfidenceThreshold()' instead")]] void setConfidenceThreshold(int confThr);
 
     /**
      * Rectify input images or not.

--- a/src/pipeline/datatype/StereoDepthConfig.cpp
+++ b/src/pipeline/datatype/StereoDepthConfig.cpp
@@ -14,7 +14,7 @@ void StereoDepthConfig::setConfidenceThreshold(int confThr) {
     cfg.config.confidenceThreshold = confThr;
 }
 
-void StereoDepthConfig::setMedianFilter(StereoDepthConfigData::MedianFilter median) {
+void StereoDepthConfig::setMedianFilter(dai::MedianFilter median) {
     cfg.config.median = median;
 }
 

--- a/src/pipeline/datatype/StereoDepthConfig.cpp
+++ b/src/pipeline/datatype/StereoDepthConfig.cpp
@@ -14,12 +14,24 @@ void StereoDepthConfig::setConfidenceThreshold(int confThr) {
     cfg.config.confidenceThreshold = confThr;
 }
 
+int StereoDepthConfig::getConfidenceThreshold() const {
+    return cfg.config.confidenceThreshold;
+}
+
 void StereoDepthConfig::setMedianFilter(dai::MedianFilter median) {
     cfg.config.median = median;
 }
 
+dai::MedianFilter StereoDepthConfig::getMedianFilter() const {
+    return cfg.config.median;
+}
+
 void StereoDepthConfig::setBilateralFilterSigma(uint16_t sigma) {
     cfg.config.bilateralSigmaValue = sigma;
+}
+
+uint16_t StereoDepthConfig::getBilateralFilterSigma() const {
+    return cfg.config.bilateralSigmaValue;
 }
 
 }  // namespace dai

--- a/src/pipeline/datatype/StereoDepthConfig.cpp
+++ b/src/pipeline/datatype/StereoDepthConfig.cpp
@@ -1,0 +1,25 @@
+#include "depthai/pipeline/datatype/StereoDepthConfig.hpp"
+
+namespace dai {
+
+std::shared_ptr<RawBuffer> StereoDepthConfig::serialize() const {
+    return raw;
+}
+
+StereoDepthConfig::StereoDepthConfig() : Buffer(std::make_shared<RawStereoDepthConfig>()), cfg(*dynamic_cast<RawStereoDepthConfig*>(raw.get())) {}
+StereoDepthConfig::StereoDepthConfig(std::shared_ptr<RawStereoDepthConfig> ptr)
+    : Buffer(std::move(ptr)), cfg(*dynamic_cast<RawStereoDepthConfig*>(raw.get())) {}
+
+void StereoDepthConfig::setConfidenceThreshold(int confThr) {
+    cfg.config.confidenceThreshold = confThr;
+}
+
+void StereoDepthConfig::setMedianFilter(StereoDepthConfigData::MedianFilter median) {
+    cfg.config.median = median;
+}
+
+void StereoDepthConfig::setBilateralFilterSigma(uint16_t sigma) {
+    cfg.config.bilateralSigmaValue = sigma;
+}
+
+}  // namespace dai

--- a/src/pipeline/datatype/StereoDepthConfig.cpp
+++ b/src/pipeline/datatype/StereoDepthConfig.cpp
@@ -34,4 +34,12 @@ uint16_t StereoDepthConfig::getBilateralFilterSigma() const {
     return cfg.config.bilateralSigmaValue;
 }
 
+void StereoDepthConfig::setLeftRightCheckThreshold(int threshold) {
+    cfg.config.leftRightCheckThreshold = threshold;
+}
+
+int StereoDepthConfig::getLeftRightCheckThreshold() const {
+    return cfg.config.leftRightCheckThreshold;
+}
+
 }  // namespace dai

--- a/src/pipeline/datatype/StreamPacketParser.cpp
+++ b/src/pipeline/datatype/StreamPacketParser.cpp
@@ -22,6 +22,7 @@
 #include "depthai/pipeline/datatype/SpatialImgDetections.hpp"
 #include "depthai/pipeline/datatype/SpatialLocationCalculatorConfig.hpp"
 #include "depthai/pipeline/datatype/SpatialLocationCalculatorData.hpp"
+#include "depthai/pipeline/datatype/StereoDepthConfig.hpp"
 #include "depthai/pipeline/datatype/SystemInformation.hpp"
 #include "depthai/pipeline/datatype/Tracklets.hpp"
 
@@ -37,6 +38,7 @@
 #include "depthai-shared/datatype/RawSpatialImgDetections.hpp"
 #include "depthai-shared/datatype/RawSpatialLocationCalculatorConfig.hpp"
 #include "depthai-shared/datatype/RawSpatialLocations.hpp"
+#include "depthai-shared/datatype/RawStereoDepthConfig.hpp"
 #include "depthai-shared/datatype/RawSystemInformation.hpp"
 #include "depthai-shared/datatype/RawTracklets.hpp"
 
@@ -126,6 +128,9 @@ std::shared_ptr<RawBuffer> parsePacket(streamPacketDesc_t* packet) {
         case DatatypeEnum::IMUData:
             return parseDatatype<RawIMUData>(jser, data);
             break;
+        case DatatypeEnum::StereoDepthConfig:
+            return parseDatatype<RawStereoDepthConfig>(jser, data);
+            break;
     }
 
     throw std::runtime_error("Bad packet, couldn't parse");
@@ -196,6 +201,10 @@ std::shared_ptr<ADatatype> parsePacketToADatatype(streamPacketDesc_t* packet) {
 
         case DatatypeEnum::IMUData:
             return std::make_shared<IMUData>(parseDatatype<RawIMUData>(jser, data));
+            break;
+
+        case DatatypeEnum::StereoDepthConfig:
+            return std::make_shared<StereoDepthConfig>(parseDatatype<RawStereoDepthConfig>(jser, data));
             break;
     }
 

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -46,7 +46,7 @@ void StereoDepth::loadCalibrationFile(const std::string& path) {
 
 void StereoDepth::setEmptyCalibration(void) {
     // Special case: a single element
-    const std::vector<std::uint8_t> empty = {0};
+    const std::vector<std::uint8_t> empty = {};
     properties.calibration = empty;
 }
 

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -47,9 +47,8 @@ void StereoDepth::loadCalibrationFile(const std::string& path) {
 }
 
 void StereoDepth::setEmptyCalibration(void) {
-    // Special case: a single element
-    const std::vector<std::uint8_t> empty = {};
-    properties.calibration = empty;
+    setRectification(false);
+    spdlog::warn("{} is deprecated. This function call can be replaced by Stereo::setRectification(false). ", __func__);
 }
 
 void StereoDepth::loadMeshData(const std::vector<std::uint8_t>& dataLeft, const std::vector<std::uint8_t>& dataRight) {
@@ -107,10 +106,8 @@ void StereoDepth::setOutputKeepAspectRatio(bool keep) {
     properties.outKeepAspectRatio = keep;
 }
 void StereoDepth::setMedianFilter(dai::MedianFilter median) {
-    StereoDepthConfigData::MedianFilter cfgMedian = static_cast<StereoDepthConfigData::MedianFilter>(median);
-    initialConfig.setMedianFilter(cfgMedian);
+    initialConfig.setMedianFilter(median);
     properties.initialConfig = *rawConfig;
-    ;
 }
 void StereoDepth::setDepthAlign(Properties::DepthAlign align) {
     properties.depthAlign = align;
@@ -123,7 +120,9 @@ void StereoDepth::setDepthAlign(CameraBoardSocket camera) {
 void StereoDepth::setConfidenceThreshold(int confThr) {
     initialConfig.setConfidenceThreshold(confThr);
     properties.initialConfig = *rawConfig;
-    ;
+}
+void StereoDepth::setRectification(bool enable) {
+    properties.enableRectification = enable;
 }
 void StereoDepth::setLeftRightCheck(bool enable) {
     properties.enableLeftRightCheck = enable;

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -8,7 +8,8 @@
 namespace dai {
 namespace node {
 
-StereoDepth::StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : Node(par, nodeId) {
+StereoDepth::StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : Node(par, nodeId), rawConfig(std::make_shared<RawStereoDepthConfig>()), initialConfig(rawConfig) {
     // 'properties' defaults already set
 }
 
@@ -21,11 +22,12 @@ std::vector<Node::Output> StereoDepth::getOutputs() {
 }
 
 std::vector<Node::Input> StereoDepth::getInputs() {
-    return {left, right};
+    return {inputConfig, left, right};
 }
 
 nlohmann::json StereoDepth::getProperties() {
     nlohmann::json j;
+    properties.initialConfig = *rawConfig;
     nlohmann::to_json(j, properties);
     return j;
 }
@@ -55,7 +57,10 @@ void StereoDepth::setInputResolution(int width, int height) {
     properties.height = height;
 }
 void StereoDepth::setMedianFilter(Properties::MedianFilter median) {
-    properties.median = median;
+    StereoDepthConfigData::MedianFilter cfgMedian = static_cast<StereoDepthConfigData::MedianFilter>(median);
+    initialConfig.setMedianFilter(cfgMedian);
+    properties.initialConfig = *rawConfig;
+    ;
 }
 void StereoDepth::setDepthAlign(Properties::DepthAlign align) {
     properties.depthAlign = align;
@@ -66,7 +71,9 @@ void StereoDepth::setDepthAlign(CameraBoardSocket camera) {
     properties.depthAlignCamera = camera;
 }
 void StereoDepth::setConfidenceThreshold(int confThr) {
-    properties.confidenceThreshold = confThr;
+    initialConfig.setConfidenceThreshold(confThr);
+    properties.initialConfig = *rawConfig;
+    ;
 }
 void StereoDepth::setLeftRightCheck(bool enable) {
     properties.enableLeftRightCheck = enable;


### PR DESCRIPTION
…figurability for stereo depth confidence threshold/bilateral filter sigma value.

In the future we will add more config options like: switching depth mode at runtime, configurable stereo match parameters (census kernel settings) etc.

Related PR: https://github.com/luxonis/depthai-shared/pull/39