### PR TITLE
Calib fix

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "6838c4ee7dbf680f7924a85d63b019555bf693e1")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "d604d6076067e2136049ed3e9fbb1d0aa340aa50")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "1b93fa5bce981ec0624688db407231cf8e822b6d")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "6838c4ee7dbf680f7924a85d63b019555bf693e1")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -76,7 +76,7 @@ CalibrationHandler::CalibrationHandler(std::string calibrationDataPath, std::str
         eepromData.cameraData[left].specHfovDeg = boardConfigData.at("board_config").at("left_fov_deg").get<float>();
         eepromData.cameraData[CameraBoardSocket::RGB].specHfovDeg = boardConfigData.at("board_config").at("rgb_fov_deg").get<float>();
 
-        eepromData.cameraData[left].extrinsics.specTranslation.x = - boardConfigData.at("board_config").at("left_to_right_distance_cm").get<float>();
+        eepromData.cameraData[left].extrinsics.specTranslation.x = -boardConfigData.at("board_config").at("left_to_right_distance_cm").get<float>();
         eepromData.cameraData[left].extrinsics.specTranslation.y = 0;
         eepromData.cameraData[left].extrinsics.specTranslation.z = 0;
 
@@ -399,7 +399,8 @@ std::vector<std::vector<float>> CalibrationHandler::computeExtrinsicMatrix(Camer
         throw std::runtime_error("Invalid cameraId input..");
     }
     if(eepromData.cameraData[srcCamera].extrinsics.toCameraSocket == dstCamera) {
-        if(eepromData.cameraData[srcCamera].extrinsics.rotationMatrix.size() == 0 || eepromData.cameraData[srcCamera].extrinsics.toCameraSocket == CameraBoardSocket::AUTO) {
+        if(eepromData.cameraData[srcCamera].extrinsics.rotationMatrix.size() == 0
+           || eepromData.cameraData[srcCamera].extrinsics.toCameraSocket == CameraBoardSocket::AUTO) {
             throw std::runtime_error(
                 "Defined Extrinsic conenction but rotation matrix is not available. Please cross check your calibration data configuration.");
         }

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -76,12 +76,12 @@ CalibrationHandler::CalibrationHandler(std::string calibrationDataPath, std::str
         eepromData.cameraData[left].specHfovDeg = boardConfigData.at("board_config").at("left_fov_deg").get<float>();
         eepromData.cameraData[CameraBoardSocket::RGB].specHfovDeg = boardConfigData.at("board_config").at("rgb_fov_deg").get<float>();
 
-        eepromData.cameraData[left].extrinsics.specTranslation.x = boardConfigData.at("board_config").at("left_to_right_distance_cm").get<float>();
+        eepromData.cameraData[left].extrinsics.specTranslation.x = - boardConfigData.at("board_config").at("left_to_right_distance_cm").get<float>();
         eepromData.cameraData[left].extrinsics.specTranslation.y = 0;
         eepromData.cameraData[left].extrinsics.specTranslation.z = 0;
 
-        eepromData.cameraData[right].extrinsics.specTranslation.x = boardConfigData.at("board_config").at("left_to_rgb_distance_cm").get<float>()
-                                                                    - boardConfigData.at("board_config").at("left_to_right_distance_cm").get<float>();
+        eepromData.cameraData[right].extrinsics.specTranslation.x = boardConfigData.at("board_config").at("left_to_right_distance_cm").get<float>()
+                                                                    - boardConfigData.at("board_config").at("left_to_rgb_distance_cm").get<float>();
         eepromData.cameraData[right].extrinsics.specTranslation.y = 0;
         eepromData.cameraData[right].extrinsics.specTranslation.z = 0;
     } else {

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -343,7 +343,7 @@ std::vector<std::vector<float>> CalibrationHandler::getImuToCameraExtrinsics(Cam
 
     std::vector<std::vector<float>> transformationMatrix = eepromData.imuExtrinsics.rotationMatrix;
     if(useSpecTranslation) {
-        transformationMatrix4[0].push_back(eepromData.cameraData[cameraId].extrinsics.specTranslation.x);
+        transformationMatrix[0].push_back(eepromData.cameraData[cameraId].extrinsics.specTranslation.x);
         transformationMatrix[1].push_back(eepromData.cameraData[cameraId].extrinsics.specTranslation.y);
         transformationMatrix[2].push_back(eepromData.cameraData[cameraId].extrinsics.specTranslation.z);
     } else {
@@ -399,7 +399,7 @@ std::vector<std::vector<float>> CalibrationHandler::computeExtrinsicMatrix(Camer
         throw std::runtime_error("Invalid cameraId input..");
     }
     if(eepromData.cameraData[srcCamera].extrinsics.toCameraSocket == dstCamera) {
-        if(eepromData.cameraData[srcCamera].rotationMatrix.size() == 0 || eepromData.cameraData[srcCamera].toCameraSocket == CameraBoardSocket::AUTO) {
+        if(eepromData.cameraData[srcCamera].extrinsics.rotationMatrix.size() == 0 || eepromData.cameraData[srcCamera].extrinsics.toCameraSocket == CameraBoardSocket::AUTO) {
             throw std::runtime_error(
                 "Defined Extrinsic conenction but rotation matrix is not available. Please cross check your calibration data configuration.");
         }

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -343,7 +343,7 @@ std::vector<std::vector<float>> CalibrationHandler::getImuToCameraExtrinsics(Cam
 
     std::vector<std::vector<float>> transformationMatrix = eepromData.imuExtrinsics.rotationMatrix;
     if(useSpecTranslation) {
-        transformationMatrix[0].push_back(eepromData.cameraData[cameraId].extrinsics.specTranslation.x);
+        transformationMatrix4[0].push_back(eepromData.cameraData[cameraId].extrinsics.specTranslation.x);
         transformationMatrix[1].push_back(eepromData.cameraData[cameraId].extrinsics.specTranslation.y);
         transformationMatrix[2].push_back(eepromData.cameraData[cameraId].extrinsics.specTranslation.z);
     } else {
@@ -399,7 +399,7 @@ std::vector<std::vector<float>> CalibrationHandler::computeExtrinsicMatrix(Camer
         throw std::runtime_error("Invalid cameraId input..");
     }
     if(eepromData.cameraData[srcCamera].extrinsics.toCameraSocket == dstCamera) {
-        if(eepromData.imuExtrinsics.rotationMatrix.size() == 0 || eepromData.imuExtrinsics.toCameraSocket == CameraBoardSocket::AUTO) {
+        if(eepromData.cameraData[srcCamera].rotationMatrix.size() == 0 || eepromData.cameraData[srcCamera].toCameraSocket == CameraBoardSocket::AUTO) {
             throw std::runtime_error(
                 "Defined Extrinsic conenction but rotation matrix is not available. Please cross check your calibration data configuration.");
         }


### PR DESCRIPTION
- Fixes Spatial node zero when baseline is inverted.
- Contains FW fix for Inverted specTranslation
- Extrinsic calculation fix
- V5 Update sign fix