### PR TITLE
Updated XLink library - Fix stream desync issue

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a365ab1f9d9b9a44afb00bb648e3bceb730fe797")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "b67b3af1c574af8cbaee61c56f7aeafb06ba0411")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -7,9 +7,9 @@ hunter_config(
 
 hunter_config(
     XLink
-    VERSION "luxonis-2021.2-develop"
-    URL "https://github.com/luxonis/XLink/archive/ee361ecba950335390ad539e509f8ab96313b6b4.tar.gz"
-    SHA1 "72108319bf2289d91157a3933663ed5fb2b6eb18"
+    VERSION "luxonis-2021.2-stream_desync_fix"
+    URL "https://github.com/luxonis/XLink/archive/d1e65a2acd6259875fa2a7a4098e3a6305d7b43f.tar.gz"
+    SHA1 "c0497d07b3dea46a740c102312da4176d06d6d43"
 )
 
 hunter_config(
@@ -34,33 +34,33 @@ hunter_config(
     URL "https://github.com/luxonis/libarchive/archive/cf2caf0588fc5e2af22cae37027d3ff6902e096f.tar.gz"
     SHA1 "e99477d32ce14292fe652dc5f4f460d3af8fbc93"
     CMAKE_ARGS
-        ENABLE_ACL=OFF                                           
-        ENABLE_BZip2=OFF                                          
-        ENABLE_CAT=OFF                                          
-        ENABLE_CAT_SHARED=OFF                                          
-        ENABLE_CNG=OFF                                          
-        ENABLE_COVERAGE=OFF                                          
-        ENABLE_CPIO=OFF                                          
-        ENABLE_CPIO_SHARED=OFF                                          
-        ENABLE_EXPAT=OFF                                          
-        ENABLE_ICONV=OFF                                          
-        ENABLE_INSTALL=ON                                          
-        ENABLE_LIBB2=OFF                                          
-        ENABLE_LIBXML2=OFF                                          
-        ENABLE_LZ4=OFF                                          
-        ENABLE_LZMA=ON                                           
-        ENABLE_LZO=OFF                                          
-        ENABLE_LibGCC=OFF                                          
-        ENABLE_MBEDTLS=OFF                                          
-        ENABLE_NETTLE=OFF                                          
-        ENABLE_OPENSSL=OFF                                          
-        ENABLE_PCREPOSIX=OFF                                          
-        ENABLE_SAFESEH=AUTO                                         
-        ENABLE_TAR=OFF                                           
-        ENABLE_TAR_SHARED=OFF                                          
-        ENABLE_TEST=OFF                                          
-        ENABLE_WERROR=OFF                                           
-        ENABLE_XATTR=OFF                                          
-        ENABLE_ZLIB=OFF                                          
+        ENABLE_ACL=OFF
+        ENABLE_BZip2=OFF
+        ENABLE_CAT=OFF
+        ENABLE_CAT_SHARED=OFF
+        ENABLE_CNG=OFF
+        ENABLE_COVERAGE=OFF
+        ENABLE_CPIO=OFF
+        ENABLE_CPIO_SHARED=OFF
+        ENABLE_EXPAT=OFF
+        ENABLE_ICONV=OFF
+        ENABLE_INSTALL=ON
+        ENABLE_LIBB2=OFF
+        ENABLE_LIBXML2=OFF
+        ENABLE_LZ4=OFF
+        ENABLE_LZMA=ON
+        ENABLE_LZO=OFF
+        ENABLE_LibGCC=OFF
+        ENABLE_MBEDTLS=OFF
+        ENABLE_NETTLE=OFF
+        ENABLE_OPENSSL=OFF
+        ENABLE_PCREPOSIX=OFF
+        ENABLE_SAFESEH=AUTO
+        ENABLE_TAR=OFF
+        ENABLE_TAR_SHARED=OFF
+        ENABLE_TEST=OFF
+        ENABLE_WERROR=OFF
+        ENABLE_XATTR=OFF
+        ENABLE_ZLIB=OFF
         ENABLE_ZSTD=OFF
 )

--- a/include/depthai/common/CameraBoardSocket.hpp
+++ b/include/depthai/common/CameraBoardSocket.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ostream>
+
 #include "depthai-shared/common/CameraBoardSocket.hpp"
 
 namespace dai {

--- a/include/depthai/common/UsbSpeed.hpp
+++ b/include/depthai/common/UsbSpeed.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ostream>
+
 #include "depthai-shared/common/UsbSpeed.hpp"
 
 namespace dai {

--- a/include/depthai/pipeline/datatype/Tracklets.hpp
+++ b/include/depthai/pipeline/datatype/Tracklets.hpp
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include <vector>
+#include <ostream>
 
 #include "depthai-shared/datatype/RawTracklets.hpp"
 #include "depthai/pipeline/datatype/Buffer.hpp"


### PR DESCRIPTION
This PR updates XLink library with desync issue resolved and also removes the manual sleeps and mutexes on OpenStream and CloseStream operations.

To change before actual merge - Hunter name of library to point to commit on `develop` branch now that `stream_desync_fix` is merged