### PR TITLE
Add EdgeDetector node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ add_library(${TARGET_CORE_NAME}
     src/pipeline/node/SpatialLocationCalculator.cpp
     src/pipeline/node/ObjectTracker.cpp
     src/pipeline/node/IMU.cpp
+    src/pipeline/node/EdgeDetector.cpp
     src/pipeline/datatype/Buffer.cpp
     src/pipeline/datatype/ImgFrame.cpp
     src/pipeline/datatype/ImageManipConfig.cpp
@@ -171,6 +172,7 @@ add_library(${TARGET_CORE_NAME}
     src/pipeline/datatype/Tracklets.cpp
     src/pipeline/datatype/IMUData.cpp
     src/pipeline/datatype/StereoDepthConfig.cpp
+    src/pipeline/datatype/EdgeDetectorConfig.cpp
     src/utility/Initialization.cpp
     src/utility/Resources.cpp
     src/xlink/XLinkConnection.cpp

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "ea7640f757decf7003fb8c33f11e54b4e9501d1f")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "8799da1399f0c44d62e93060d06cf5471cd9f430")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "8799da1399f0c44d62e93060d06cf5471cd9f430")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "9a5b24699ef3c80e5022aa056510044ce89df059")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a365ab1f9d9b9a44afb00bb648e3bceb730fe797")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "f1e762e07e82cbe991b74404c00c365cab6f72db")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -264,6 +264,8 @@ target_compile_definitions(object_tracker_video PRIVATE BLOB_PATH="${person_dete
 
 dai_add_example(queue_add_callback src/queue_add_callback.cpp ON)
 
+dai_add_example(edge_detector src/edge_detector.cpp ON)
+
 # Calibration Read and write samples
 dai_add_example(calibration_flash src/calibration_flash.cpp OFF)
 dai_add_example(calibration_flash_version5 src/calibration_flash_v5.cpp OFF)

--- a/examples/src/edge_detector.cpp
+++ b/examples/src/edge_detector.cpp
@@ -1,0 +1,118 @@
+#include <iostream>
+
+#include "utility.hpp"
+
+// Inludes common necessary includes for development using depthai library
+#include "depthai/depthai.hpp"
+
+static std::atomic<bool> newConfig{false};
+
+int main() {
+    using namespace std;
+
+    // Create pipeline
+    dai::Pipeline pipeline;
+
+    // Define sources and outputs
+    auto camRgb = pipeline.create<dai::node::ColorCamera>();
+    auto monoLeft = pipeline.create<dai::node::MonoCamera>();
+    auto monoRight = pipeline.create<dai::node::MonoCamera>();
+
+    auto edgeDetectorLeft = pipeline.create<dai::node::EdgeDetector>();
+    auto edgeDetectorRight = pipeline.create<dai::node::EdgeDetector>();
+    auto edgeDetectorRgb = pipeline.create<dai::node::EdgeDetector>();
+
+    auto xoutEdgeLeft = pipeline.create<dai::node::XLinkOut>();
+    auto xoutEdgeRight = pipeline.create<dai::node::XLinkOut>();
+    auto xoutEdgeRgb = pipeline.create<dai::node::XLinkOut>();
+    auto xinEdgeCfg = pipeline.create<dai::node::XLinkIn>();
+
+    const auto edgeLeftStr = "edge left";
+    const auto edgeRightStr = "edge right";
+    const auto edgeRgbStr = "edge rgb";
+    const auto edgeCfgStr = "edge cfg";
+
+    xoutEdgeLeft->setStreamName(edgeLeftStr);
+    xoutEdgeRight->setStreamName(edgeRightStr);
+    xoutEdgeRgb->setStreamName(edgeRgbStr);
+    xinEdgeCfg->setStreamName(edgeCfgStr);
+
+    // Properties
+    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+
+    monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
+    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
+    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+
+    edgeDetectorRgb->setMaxOutputFrameSize(camRgb->getVideoWidth() * camRgb->getVideoHeight());
+
+    // Linking
+    monoLeft->out.link(edgeDetectorLeft->inputImage);
+    monoRight->out.link(edgeDetectorRight->inputImage);
+    camRgb->video.link(edgeDetectorRgb->inputImage);
+
+    edgeDetectorLeft->outputImage.link(xoutEdgeLeft->input);
+    edgeDetectorRight->outputImage.link(xoutEdgeRight->input);
+    edgeDetectorRgb->outputImage.link(xoutEdgeRgb->input);
+
+    xinEdgeCfg->out.link(edgeDetectorLeft->inputConfig);
+    xinEdgeCfg->out.link(edgeDetectorRight->inputConfig);
+    xinEdgeCfg->out.link(edgeDetectorRgb->inputConfig);
+
+    // Connect to device and start pipeline
+    dai::Device device(pipeline);
+
+    // Output queue will be used to get the depth frames from the outputs defined above
+    auto edgeLeftQueue = device.getOutputQueue(edgeLeftStr, 8, false);
+    auto edgeRightQueue = device.getOutputQueue(edgeRightStr, 8, false);
+    auto edgeRgbQueue = device.getOutputQueue(edgeRgbStr, 8, false);
+    auto edgeCfgQueue = device.getInputQueue(edgeCfgStr);
+
+    std::cout << "Switch between sobel filter kernels using keys '1' and '2'" << std::endl;
+
+    while(true) {
+        auto edgeLeft = edgeLeftQueue->get<dai::ImgFrame>();
+        auto edgeRight = edgeRightQueue->get<dai::ImgFrame>();
+        auto edgeRgb = edgeRgbQueue->get<dai::ImgFrame>();
+
+        cv::Mat edgeLeftFrame = edgeLeft->getFrame();
+        cv::Mat edgeRightFrame = edgeRight->getFrame();
+        cv::Mat edgeRgbFrame = edgeRgb->getFrame();
+
+        // Show the frame
+        cv::imshow(edgeLeftStr, edgeLeftFrame);
+        cv::imshow(edgeRightStr, edgeRightFrame);
+        cv::imshow(edgeRgbStr, edgeRgbFrame);
+
+        int key = cv::waitKey(1);
+        switch(key) {
+            case 'q':
+                return 0;
+                break;
+
+            case '1': {
+                std::cout << "Switching sobel filter kernel." << std::endl;
+                dai::EdgeDetectorConfig cfg;
+                std::vector<std::vector<int>> sobelHorizontalKernel = {{1, 0, -1}, {2, 0, -2}, {1, 0, -1}};
+                std::vector<std::vector<int>> sobelVerticalKernel = {{1, 2, 1}, {0, 0, 0}, {-1, -2, -1}};
+                cfg.setSobelFilterKernels(sobelHorizontalKernel, sobelVerticalKernel);
+                edgeCfgQueue->send(cfg);
+            } break;
+
+            case '2': {
+                std::cout << "Switching sobel filter kernel." << std::endl;
+                dai::EdgeDetectorConfig cfg;
+                std::vector<std::vector<int>> sobelHorizontalKernel = {{3, 0, -3}, {10, 0, -10}, {3, 0, -3}};
+                std::vector<std::vector<int>> sobelVerticalKernel = {{3, 10, 3}, {0, 0, 0}, {-3, -10, -3}};
+                cfg.setSobelFilterKernels(sobelHorizontalKernel, sobelVerticalKernel);
+                edgeCfgQueue->send(cfg);
+            } break;
+
+            default:
+                break;
+        }
+    }
+    return 0;
+}

--- a/examples/src/edge_detector.cpp
+++ b/examples/src/edge_detector.cpp
@@ -60,7 +60,7 @@ int main() {
     // Connect to device and start pipeline
     dai::Device device(pipeline);
 
-    // Output queue will be used to get the depth frames from the outputs defined above
+    // Output/input queues
     auto edgeLeftQueue = device.getOutputQueue(edgeLeftStr, 8, false);
     auto edgeRightQueue = device.getOutputQueue(edgeRightStr, 8, false);
     auto edgeRgbQueue = device.getOutputQueue(edgeRgbStr, 8, false);

--- a/include/depthai/pipeline/datatype/EdgeDetectorConfig.hpp
+++ b/include/depthai/pipeline/datatype/EdgeDetectorConfig.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "depthai-shared/datatype/RawEdgeDetectorConfig.hpp"
+#include "depthai/pipeline/datatype/Buffer.hpp"
+
+namespace dai {
+
+/**
+ * EdgeDetectorConfig message. Carries sobel edge filter config.
+ */
+class EdgeDetectorConfig : public Buffer {
+    std::shared_ptr<RawBuffer> serialize() const override;
+    RawEdgeDetectorConfig& cfg;
+
+   public:
+    /**
+     * Construct EdgeDetectorConfig message.
+     */
+    EdgeDetectorConfig();
+    explicit EdgeDetectorConfig(std::shared_ptr<RawEdgeDetectorConfig> ptr);
+    virtual ~EdgeDetectorConfig() = default;
+
+    /**
+     * Set sobel filter horizontal and vertical 3x3 kernels
+     * @param horizontalKernel Used for horizontal gradiant computation in 3x3 Sobel filter
+     * @param verticalKernel Used for vertical gradiant computation in 3x3 Sobel filter
+     */
+    void setSobelFilterKernels(const std::vector<std::vector<int>>& horizontalKernel, const std::vector<std::vector<int>>& verticalKernel);
+
+    /**
+     * Retrieve configuration data for EdgeDetector
+     * @returns Vector of configuration parameters for ROIs (region of interests)
+     */
+    EdgeDetectorConfigData getConfigData() const;
+};
+
+}  // namespace dai

--- a/include/depthai/pipeline/node/EdgeDetector.hpp
+++ b/include/depthai/pipeline/node/EdgeDetector.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <depthai/pipeline/Node.hpp>
+
+// standard
+#include <fstream>
+
+// shared
+#include <depthai-shared/properties/EdgeDetectorProperties.hpp>
+
+#include "depthai/pipeline/datatype/EdgeDetectorConfig.hpp"
+
+namespace dai {
+namespace node {
+
+/**
+ * @brief EdgeDetector node. Performs edge detection using 3x3 Sobel filter
+ */
+class EdgeDetector : public Node {
+   public:
+    using Properties = dai::EdgeDetectorProperties;
+
+   private:
+    std::string getName() const override;
+    std::vector<Input> getInputs() override;
+    std::vector<Output> getOutputs() override;
+    nlohmann::json getProperties() override;
+    std::shared_ptr<Node> clone() override;
+
+    std::shared_ptr<RawEdgeDetectorConfig> rawConfig;
+    Properties properties;
+
+   public:
+    EdgeDetector(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
+
+    /**
+     * Initial config to use for edge detection.
+     */
+    EdgeDetectorConfig initialConfig;
+
+    /**
+     * Input EdgeDetectorConfig message with ability to modify parameters in runtime.
+     * Default queue is non-blocking with size 4.
+     */
+    Input inputConfig{*this, "inputConfig", Input::Type::SReceiver, false, 4, {{DatatypeEnum::EdgeDetectorConfig, false}}};
+    /**
+     * Input image on which edge detection is performed.
+     * Default queue is non-blocking with size 4.
+     */
+    Input inputImage{*this, "inputImage", Input::Type::SReceiver, false, 4, {{DatatypeEnum::ImgFrame, false}}};
+
+    /**
+     * Outputs image frame with detected edges
+     */
+    Output outputImage{*this, "outputImage", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};
+
+    // Functions to set properties
+    /**
+     * Specify whether or not wait until configuration message arrives to inputConfig Input.
+     * @param wait True to wait for configuration message, false otherwise.
+     */
+    void setWaitForConfigInput(bool wait);
+
+    /**
+     * Specify number of frames in pool.
+     * @param numFramesPool How many frames should the pool have
+     */
+    void setNumFramesPool(int numFramesPool);
+
+    /**
+     * Specify maximum size of output image.
+     * @param maxFrameSize Maximum frame size in bytes
+     */
+    void setMaxOutputFrameSize(int maxFrameSize);
+};
+
+}  // namespace node
+}  // namespace dai

--- a/include/depthai/pipeline/nodes.hpp
+++ b/include/depthai/pipeline/nodes.hpp
@@ -3,6 +3,7 @@
 // all the nodes
 #include "node/ColorCamera.hpp"
 #include "node/DetectionNetwork.hpp"
+#include "node/EdgeDetector.hpp"
 #include "node/IMU.hpp"
 #include "node/ImageManip.hpp"
 #include "node/MonoCamera.hpp"

--- a/src/pipeline/datatype/EdgeDetectorConfig.cpp
+++ b/src/pipeline/datatype/EdgeDetectorConfig.cpp
@@ -1,0 +1,22 @@
+#include "depthai/pipeline/datatype/EdgeDetectorConfig.hpp"
+
+namespace dai {
+
+std::shared_ptr<RawBuffer> EdgeDetectorConfig::serialize() const {
+    return raw;
+}
+
+EdgeDetectorConfig::EdgeDetectorConfig() : Buffer(std::make_shared<RawEdgeDetectorConfig>()), cfg(*dynamic_cast<RawEdgeDetectorConfig*>(raw.get())) {}
+EdgeDetectorConfig::EdgeDetectorConfig(std::shared_ptr<RawEdgeDetectorConfig> ptr)
+    : Buffer(std::move(ptr)), cfg(*dynamic_cast<RawEdgeDetectorConfig*>(raw.get())) {}
+
+void EdgeDetectorConfig::setSobelFilterKernels(const std::vector<std::vector<int>>& horizontalKernel, const std::vector<std::vector<int>>& verticalKernel) {
+    cfg.config.sobelFilterHorizontalKernel = horizontalKernel;
+    cfg.config.sobelFilterVerticalKernel = verticalKernel;
+}
+
+EdgeDetectorConfigData EdgeDetectorConfig::getConfigData() const {
+    return cfg.config;
+}
+
+}  // namespace dai

--- a/src/pipeline/datatype/StreamPacketParser.cpp
+++ b/src/pipeline/datatype/StreamPacketParser.cpp
@@ -120,7 +120,7 @@ std::shared_ptr<RawBuffer> parsePacket(streamPacketDesc_t* packet) {
             break;
 
         case DatatypeEnum::SpatialLocationCalculatorConfig:
-            return parseDatatype<RawSpatialLocations>(jser, data);
+            return parseDatatype<RawSpatialLocationCalculatorConfig>(jser, data);
             break;
 
         case DatatypeEnum::Tracklets:

--- a/src/pipeline/datatype/StreamPacketParser.cpp
+++ b/src/pipeline/datatype/StreamPacketParser.cpp
@@ -14,6 +14,7 @@
 #include "depthai/pipeline/datatype/ADatatype.hpp"
 #include "depthai/pipeline/datatype/Buffer.hpp"
 #include "depthai/pipeline/datatype/CameraControl.hpp"
+#include "depthai/pipeline/datatype/EdgeDetectorConfig.hpp"
 #include "depthai/pipeline/datatype/IMUData.hpp"
 #include "depthai/pipeline/datatype/ImageManipConfig.hpp"
 #include "depthai/pipeline/datatype/ImgDetections.hpp"
@@ -30,6 +31,7 @@
 #include "depthai-shared/datatype/DatatypeEnum.hpp"
 #include "depthai-shared/datatype/RawBuffer.hpp"
 #include "depthai-shared/datatype/RawCameraControl.hpp"
+#include "depthai-shared/datatype/RawEdgeDetectorConfig.hpp"
 #include "depthai-shared/datatype/RawIMUData.hpp"
 #include "depthai-shared/datatype/RawImageManipConfig.hpp"
 #include "depthai-shared/datatype/RawImgDetections.hpp"
@@ -128,8 +130,13 @@ std::shared_ptr<RawBuffer> parsePacket(streamPacketDesc_t* packet) {
         case DatatypeEnum::IMUData:
             return parseDatatype<RawIMUData>(jser, data);
             break;
+
         case DatatypeEnum::StereoDepthConfig:
             return parseDatatype<RawStereoDepthConfig>(jser, data);
+            break;
+
+        case DatatypeEnum::EdgeDetectorConfig:
+            return parseDatatype<RawEdgeDetectorConfig>(jser, data);
             break;
     }
 
@@ -205,6 +212,10 @@ std::shared_ptr<ADatatype> parsePacketToADatatype(streamPacketDesc_t* packet) {
 
         case DatatypeEnum::StereoDepthConfig:
             return std::make_shared<StereoDepthConfig>(parseDatatype<RawStereoDepthConfig>(jser, data));
+            break;
+
+        case DatatypeEnum::EdgeDetectorConfig:
+            return std::make_shared<EdgeDetectorConfig>(parseDatatype<RawEdgeDetectorConfig>(jser, data));
             break;
     }
 

--- a/src/pipeline/node/EdgeDetector.cpp
+++ b/src/pipeline/node/EdgeDetector.cpp
@@ -1,0 +1,48 @@
+#include "depthai/pipeline/node/EdgeDetector.hpp"
+
+#include "spdlog/fmt/fmt.h"
+
+namespace dai {
+namespace node {
+
+EdgeDetector::EdgeDetector(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : Node(par, nodeId), rawConfig(std::make_shared<RawEdgeDetectorConfig>()), initialConfig(rawConfig) {}
+
+std::string EdgeDetector::getName() const {
+    return "EdgeDetector";
+}
+
+std::vector<Node::Output> EdgeDetector::getOutputs() {
+    return {outputImage};
+}
+
+std::vector<Node::Input> EdgeDetector::getInputs() {
+    return {inputConfig, inputImage};
+}
+
+nlohmann::json EdgeDetector::getProperties() {
+    nlohmann::json j;
+    properties.initialConfig = *rawConfig;
+    nlohmann::to_json(j, properties);
+    return j;
+}
+
+// Node properties configuration
+void EdgeDetector::setWaitForConfigInput(bool wait) {
+    properties.inputConfigSync = wait;
+}
+
+void EdgeDetector::setNumFramesPool(int numFramesPool) {
+    properties.numFramesPool = numFramesPool;
+}
+
+void EdgeDetector::setMaxOutputFrameSize(int maxFrameSize) {
+    properties.outputFrameSize = maxFrameSize;
+}
+
+std::shared_ptr<Node> EdgeDetector::clone() {
+    return std::make_shared<std::decay<decltype(*this)>::type>(*this);
+}
+
+}  // namespace node
+}  // namespace dai


### PR DESCRIPTION
Uses HW 3x3 Sobel filter on myriadX.

Example `edge_detector.cpp` runs edge detection on 3 frames, left, right, RGB (NV12).
Edge filter config (kernel parameters) can be switched at runtime using keys 1 and 2.

Also includes a fix for recent calibration changes, where if EEPROM is empty or invalid stereo baseline/fov is not set to default, but to invalid value, resulting in bad depth frame.

![image](https://user-images.githubusercontent.com/60790666/123497573-f0b67700-d636-11eb-8d2b-8aaddf277faa.png)


Implements: https://github.com/luxonis/depthai/issues/247

Related PR: https://github.com/luxonis/depthai-shared/pull/41