### PR TITLE
Close queues when closing the device

### DIFF
--- a/include/depthai/device/DataQueue.hpp
+++ b/include/depthai/device/DataQueue.hpp
@@ -41,6 +41,16 @@ class DataOutputQueue {
     ~DataOutputQueue();
 
     /**
+     * Check whether queue is closed
+     */
+    bool isClosed() const;
+
+    /**
+     * Closes the queue and underlying thread
+     */
+    void close();
+
+    /**
      * Sets queue behavior when full (maxSize)
      *
      * @param blocking Specifies if block or overwrite the oldest message in the queue
@@ -338,6 +348,16 @@ class DataInputQueue {
    public:
     DataInputQueue(const std::shared_ptr<XLinkConnection>& conn, const std::string& streamName, unsigned int maxSize = 16, bool blocking = true);
     ~DataInputQueue();
+
+    /**
+     * Check whether queue is closed
+     */
+    bool isClosed() const;
+
+    /**
+     * Closes the queue and underlying thread
+     */
+    void close();
 
     /**
      * Sets maximum message size. If message is larger than specified, then an exception is issued.

--- a/include/depthai/device/DataQueue.hpp
+++ b/include/depthai/device/DataQueue.hpp
@@ -46,7 +46,7 @@ class DataOutputQueue {
     bool isClosed() const;
 
     /**
-     * Closes the queue and underlying thread
+     * Closes the queue and the underlying thread
      */
     void close();
 
@@ -355,7 +355,7 @@ class DataInputQueue {
     bool isClosed() const;
 
     /**
-     * Closes the queue and underlying thread
+     * Closes the queue and the underlying thread
      */
     void close();
 

--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -82,7 +82,7 @@ DataOutputQueue::DataOutputQueue(const std::shared_ptr<XLinkConnection>& conn, c
 }
 
 bool DataOutputQueue::isClosed() const {
-    return running;
+    return !running;
 }
 
 void DataOutputQueue::close() {
@@ -214,7 +214,7 @@ DataInputQueue::DataInputQueue(const std::shared_ptr<XLinkConnection>& conn, con
 }
 
 bool DataInputQueue::isClosed() const {
-    return running;
+    return !running;
 }
 
 void DataInputQueue::close() {

--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -80,6 +80,15 @@ DataOutputQueue::DataOutputQueue(const std::shared_ptr<XLinkConnection>& conn, c
     });
 }
 
+bool DataOutputQueue::isClosed() const {
+    return running;
+}
+
+void DataOutputQueue::close() {
+    running = false;
+    queue.destruct();
+}
+
 DataOutputQueue::~DataOutputQueue() {
     spdlog::debug("DataOutputQueue ({}) about to be destructed...", name);
     // Set reading thread to stop
@@ -196,6 +205,15 @@ DataInputQueue::DataInputQueue(const std::shared_ptr<XLinkConnection>& conn, con
         queue.destruct();
         running = false;
     });
+}
+
+bool DataInputQueue::isClosed() const {
+    return running;
+}
+
+void DataInputQueue::close() {
+    running = false;
+    queue.destruct();
 }
 
 DataInputQueue::~DataInputQueue() {

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -339,7 +339,9 @@ void Device::close() {
     connection->close();
     connection = nullptr;
 
-    // Clear queues
+    // Close and clear queues
+    for(auto& kv : outputQueueMap) kv.second->close();
+    for(auto& kv : inputQueueMap) kv.second->close();
     outputQueueMap.clear();
     inputQueueMap.clear();
 


### PR DESCRIPTION
When device is closed, the queues should be as well. The issues arises as same link id is used for next XLink connection and old `XLinkStream` handles close stream of the new connection 