### PR TITLE
RGB - Mono capture time sync

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "04b3c29581c258502fb50540f3954bd49aac7f90")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "dd9a974d93b0951de921c9223c434f8ce1960699")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -45,6 +45,12 @@ class ImgFrame : public Buffer {
     std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
 
     /**
+     * Retrieves image timestamp directly captured from device's monotonic clock,
+     * not synchronized to host time. Used mostly for debugging
+     */
+    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
+
+    /**
      * Retrieves instance number
      */
     unsigned int getInstanceNum() const;

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -40,32 +40,32 @@ class ImgFrame : public Buffer {
 
     // getters
     /**
-     * Retrievies image timestamp related to steady_clock / time.monotonic
+     * Retrieves image timestamp related to steady_clock / time.monotonic
      */
     std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
 
     /**
-     * Retrievies instance number
+     * Retrieves instance number
      */
     unsigned int getInstanceNum() const;
 
     /**
-     * Retrievies image category
+     * Retrieves image category
      */
     unsigned int getCategory() const;
 
     /**
-     * Retrievies image sequence number
+     * Retrieves image sequence number
      */
     unsigned int getSequenceNum() const;
 
     /**
-     * Retrievies image width in pixels
+     * Retrieves image width in pixels
      */
     unsigned int getWidth() const;
 
     /**
-     * Retrievies image height in pixels
+     * Retrieves image height in pixels
      */
     unsigned int getHeight() const;
 

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -21,6 +21,10 @@ std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::du
     using namespace std::chrono;
     return time_point<steady_clock, steady_clock::duration>{seconds(img.ts.sec) + nanoseconds(img.ts.nsec)};
 }
+std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestampDevice() const {
+    using namespace std::chrono;
+    return time_point<steady_clock, steady_clock::duration>{seconds(img.tsDevice.sec) + nanoseconds(img.tsDevice.nsec)};
+}
 unsigned int ImgFrame::getInstanceNum() const {
     return img.instanceNum;
 }


### PR DESCRIPTION
Updated firmware, implementing RGB - Mono sync: capture time and sequence numbers, using a soft sync mechanism that adjusts the RGB frame time based on the capture timestamp difference between RGB and Mono cameras. Enabled automatically when one or both Mono cameras are used, and when all cameras have the same FPS configured.

The initial difference between capture timestamps should usually be less than 1ms, and over the course of first 15 frames or less should get down to max 0.1 .. 0.15 ms. 
Currently a drift is observed if the configured FPS is larger than 33, to be fixed.

Add ImgFrame::getTimestampDevice():

> Retrieves image timestamp directly captured from device's monotonic clock,
> not synchronized to host time. Used mostly for debugging

Related PR: https://github.com/luxonis/depthai-shared/pull/44
