### PR TITLE
RPC issue fix

### DIFF
--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -25,10 +25,6 @@
 #include "depthai-shared/log/LogLevel.hpp"
 #include "depthai-shared/log/LogMessage.hpp"
 
-// libraries
-#include "nanorpc/core/client.h"
-#include "nanorpc/packer/nlohmann_msgpack.h"
-
 namespace dai {
 
 // Device (RAII), connects to device and maintains watchdog, timesync, ...
@@ -510,8 +506,6 @@ class Device {
     void checkClosed() const;
 
     std::shared_ptr<XLinkConnection> connection;
-    std::unique_ptr<nanorpc::core::client<nanorpc::packer::nlohmann_msgpack>> client;
-    std::mutex rpcMutex;
     std::vector<uint8_t> patchedCmd;
 
     DeviceInfo deviceInfo = {};
@@ -542,9 +536,6 @@ class Device {
     // Logging thread
     std::thread loggingThread;
     std::atomic<bool> loggingRunning{true};
-
-    // RPC stream
-    std::unique_ptr<XLinkStream> rpcStream;
 
     // closed
     std::atomic<bool> closed{false};

--- a/include/depthai/device/DeviceBootloader.hpp
+++ b/include/depthai/device/DeviceBootloader.hpp
@@ -12,10 +12,6 @@
 #include "depthai/xlink/XLinkConnection.hpp"
 #include "depthai/xlink/XLinkStream.hpp"
 
-// libraries
-#include "nanorpc/core/client.h"
-#include "nanorpc/packer/nlohmann_msgpack.h"
-
 // shared
 #include "depthai-bootloader-shared/Memory.hpp"
 #include "depthai-bootloader-shared/Section.hpp"

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -529,7 +529,8 @@ void Device::init2(bool embeddedMvcmd, bool usb2Mode, const std::string& pathToM
     pimpl->rpcStream = std::make_unique<XLinkStream>(*connection, dai::XLINK_CHANNEL_MAIN_RPC, dai::XLINK_USB_BUFFER_MAX_SIZE);
 
     pimpl->rpcClient = std::make_unique<nanorpc::core::client<nanorpc::packer::nlohmann_msgpack>>([this](nanorpc::core::type::buffer request) {
-        // TODO(TheMarpe) - causes issues on Windows
+        // Lock for time of the RPC call, to not mix the responses between calling threads.
+        // Note: might cause issues on Windows on incorrect shutdown. To be investigated
         std::unique_lock<std::mutex> lock(pimpl->rpcMutex);
 
         // Log the request data

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -25,12 +25,11 @@
 #include "utility/Resources.hpp"
 
 // libraries
+#include "nanorpc/core/client.h"
+#include "nanorpc/packer/nlohmann_msgpack.h"
 #include "spdlog/fmt/chrono.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
-#include "nanorpc/core/client.h"
-#include "nanorpc/packer/nlohmann_msgpack.h"
-
 
 namespace dai {
 

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -530,7 +530,7 @@ void Device::init2(bool embeddedMvcmd, bool usb2Mode, const std::string& pathToM
 
     pimpl->rpcClient = std::make_unique<nanorpc::core::client<nanorpc::packer::nlohmann_msgpack>>([this](nanorpc::core::type::buffer request) {
         // TODO(TheMarpe) - causes issues on Windows
-        // std::unique_lock<std::mutex> lock(pimpl->rpcMutex);
+        std::unique_lock<std::mutex> lock(pimpl->rpcMutex);
 
         // Log the request data
         if(spdlog::get_level() == spdlog::level::trace) {


### PR DESCRIPTION
Enables the mutex for the whole duration of the RPC call as they cannot be multiplexed on device side.
Solves issue where on certain occasions thread T1 (watchdog) and thread T2 (getConnectedCameras) both arrived to XLinkReadData at the same time, but took responses of each other instead of their own. That is why the issue signified out of data as watchdog call doesn't return any data, while getConnectedCameras does and it expects to.

Testing on Windows for a while now, but couldn't reproduce the https://github.com/luxonis/depthai-core/issues/79. As the issue is important, and the busy mutex error only happening on destruction of the program and on Windows in Debug mode, I'll proceed with this PR. If the mutex issue starts happening again, will revisit

Also hid the `nanorpc::core::client` dependency and put it in `Device::Impl` instead
  