### PR TITLE
FP16 without git clone

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -64,3 +64,14 @@ hunter_config(
         ENABLE_ZLIB=OFF
         ENABLE_ZSTD=OFF
 )
+
+# Luxonis FP16 fork which doesn't use git cloning for its dependencies
+hunter_config(
+    FP16
+    VERSION "luxonis-0.0.0"
+    URL "https://github.com/luxonis/FP16/archive/c911175d2717e562976e606c6e5f799bf40cf94e.tar.gz"
+    SHA1 "40e9723c87c2fe21781132c0f2f8b90338500e32"
+    CMAKE_ARGS
+        FP16_BUILD_BENCHMARKS=OFF
+        FP16_BUILD_TESTS=OFF
+)


### PR DESCRIPTION
Resolves the following issue: https://github.com/piwheels/packages/issues/207

Uses a fork of FP16 which does not do git clone for its psimd dependency, but instead downloads an archive.

The test (for python bindings) can be carried out using the following command with updated core submodule:
`GIT_ALLOW_PROTOCOL=file HUNTER_ROOT=~/.hunter_no_git python3 -m pip wheel . -w wheelhouse`

