### PR TITLE
Stereo crash workaround

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a858d35dbe1574fc02e590ae04524ade7b5bf0ba")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a2baa42ba41f7b79dcbee987b34f24da075de196")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Workaround for stereo subpixel/extended mode crash at the expense of system performance.
We are working on a proper fix.