### PR TITLE
Configure XLink chunk size

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "82c6726ce9e296908763395bcd49a6631d33de08")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "c582aef4d821c9a664b503699706ed44e7da718c")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "eb3b3cfd94b306ae38f114c1c98b090cb3fe2671")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "82c6726ce9e296908763395bcd49a6631d33de08")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "c582aef4d821c9a664b503699706ed44e7da718c")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "1928f3407397272cc9736aedcca667c6c7419057")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -253,6 +253,22 @@ class DeviceBase {
     LogLevel getLogLevel();
 
     /**
+     * Sets the chunk size for splitting device-sent XLink packets. A larger value could
+     * increase performance, and 0 disables chunking. A negative value is ignored.
+     * Device defaults are configured per protocol, currently 64*1024 for both USB and Ethernet.
+     *
+     * @param sizeBytes XLink chunk size in bytes
+     */
+    void setXLinkChunkSize(int sizeBytes);
+
+    /**
+     * Gets current XLink chunk size.
+     *
+     * @returns XLink chunk size in bytes
+     */
+    int getXLinkChunkSize();
+
+    /**
      * Get the Device Info object o the device which is currently running
      *
      * @return DeviceInfo of the current device in execution

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -36,6 +36,7 @@ class PipelineImpl {
     PipelineSchema getPipelineSchema() const;
     OpenVINO::Version getPipelineOpenVINOVersion() const;
     void setCameraTuningBlobPath(const std::string& path);
+    void setXlinkChunkSize(int sizeBytes);
 
     // Access to nodes
     std::vector<std::shared_ptr<const Node>> getAllNodes() const;
@@ -239,6 +240,15 @@ class Pipeline {
     /// Set a camera IQ (Image Quality) tuning blob, used for all cameras
     void setCameraTuningBlobPath(const std::string& path) {
         impl()->setCameraTuningBlobPath(path);
+    }
+
+    /**
+     * Set chunk size for splitting device-sent XLink packets, in bytes. A larger value could
+     * increase performance, with 0 disabling chunking. A negative value won't modify the
+     * device defaults - configured per protocol, currently 64*1024 for both USB and Ethernet.
+     */
+    void setXlinkChunkSize(int sizeBytes) {
+        impl()->setXlinkChunkSize(sizeBytes);
     }
 };
 

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -36,7 +36,7 @@ class PipelineImpl {
     PipelineSchema getPipelineSchema() const;
     OpenVINO::Version getPipelineOpenVINOVersion() const;
     void setCameraTuningBlobPath(const std::string& path);
-    void setXlinkChunkSize(int sizeBytes);
+    void setXLinkChunkSize(int sizeBytes);
 
     // Access to nodes
     std::vector<std::shared_ptr<const Node>> getAllNodes() const;
@@ -247,8 +247,8 @@ class Pipeline {
      * increase performance, with 0 disabling chunking. A negative value won't modify the
      * device defaults - configured per protocol, currently 64*1024 for both USB and Ethernet.
      */
-    void setXlinkChunkSize(int sizeBytes) {
-        impl()->setXlinkChunkSize(sizeBytes);
+    void setXLinkChunkSize(int sizeBytes) {
+        impl()->setXLinkChunkSize(sizeBytes);
     }
 };
 

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -722,6 +722,18 @@ LogLevel DeviceBase::getLogLevel() {
     return pimpl->rpcClient->call("getLogLevel").as<LogLevel>();
 }
 
+void DeviceBase::setXLinkChunkSize(int sizeBytes) {
+    checkClosed();
+
+    pimpl->rpcClient->call("setXLinkChunkSize", sizeBytes);
+}
+
+int DeviceBase::getXLinkChunkSize() {
+    checkClosed();
+
+    return pimpl->rpcClient->call("getXLinkChunkSize").as<int>();
+}
+
 DeviceInfo DeviceBase::getDeviceInfo() {
     return deviceInfo;
 }

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -245,6 +245,10 @@ void PipelineImpl::setCameraTuningBlobPath(const std::string& path) {
     globalProperties.cameraTuningBlobSize = asset->data.size();
 }
 
+void PipelineImpl::setXlinkChunkSize(int sizeBytes) {
+    globalProperties.xlinkChunkSize = sizeBytes;
+}
+
 // Remove node capability
 void PipelineImpl::remove(std::shared_ptr<Node> toRemove) {
     // Search for this node in 'nodes' vector.

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -245,7 +245,7 @@ void PipelineImpl::setCameraTuningBlobPath(const std::string& path) {
     globalProperties.cameraTuningBlobSize = asset->data.size();
 }
 
-void PipelineImpl::setXlinkChunkSize(int sizeBytes) {
+void PipelineImpl::setXLinkChunkSize(int sizeBytes) {
     globalProperties.xlinkChunkSize = sizeBytes;
 }
 


### PR DESCRIPTION
Adding new API:

    /**
     * Set chunk size for splitting device-sent XLink packets, in bytes. A larger value could
     * increase performance, with 0 disabling chunking. A negative value won't modify the
     * device defaults - configured per protocol, currently 64*1024 for both USB and Ethernet.
     */
    void Pipeline::setXlinkChunkSize(int sizeBytes);

The defaults on device side were not changed, as it might be possible (mainly for USB case) that increasing the chunk size won't work with certain hosts / OSes.

For USB, if supported by the host, best performance would be achieved with:  `pipeline.setXlinkChunkSize(0);`
This should increase the max available USB bandwidth and reduce the device CPU load (less overhead from splitting).

Related PR: https://github.com/luxonis/depthai-shared/pull/53