### PR TITLE
Added getting calculated FOV from intrinsics

### DIFF
--- a/examples/src/calibration_reader.cpp
+++ b/examples/src/calibration_reader.cpp
@@ -13,9 +13,9 @@ void printMatrix(std::vector<std::vector<float>> matrix) {
     for(auto row : matrix) {
         out += "[";
         for(auto val : row) out += to_string(val) + ", ";
-        out = out.substr(0, out.size()-2) + "]\n";
+        out = out.substr(0, out.size() - 2) + "]\n";
     }
-    out = out.substr(0, out.size()-1) + "]\n\n";
+    out = out.substr(0, out.size() - 1) + "]\n\n";
     cout << out;
 }
 int main(int argc, char** argv) {
@@ -38,7 +38,8 @@ int main(int argc, char** argv) {
 
     cout << "Stereo baseline distance: " << calibData.getBaselineDistance() << " cm" << endl;
 
-    cout << "Mono FOV from camera specs: " << calibData.getFov(dai::CameraBoardSocket::LEFT) << ", calculated FOV: " << calibData.getFov(dai::CameraBoardSocket::LEFT, false) << endl;
+    cout << "Mono FOV from camera specs: " << calibData.getFov(dai::CameraBoardSocket::LEFT)
+         << ", calculated FOV: " << calibData.getFov(dai::CameraBoardSocket::LEFT, false) << endl;
 
     cout << "Intrinsics from getCameraIntrinsics function full resolution:" << endl;
     intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT);

--- a/examples/src/calibration_reader.cpp
+++ b/examples/src/calibration_reader.cpp
@@ -7,6 +7,17 @@
 #include "depthai-shared/common/EepromData.hpp"
 #include "depthai/depthai.hpp"
 
+void printMatrix(std::vector<std::vector<float>> matrix) {
+    using namespace std;
+    std::string out = "[";
+    for(auto row : matrix) {
+        out += "[";
+        for(auto val : row) out += to_string(val) + ", ";
+        out = out.substr(0, out.size()-2) + "]\n";
+    }
+    out = out.substr(0, out.size()-1) + "]\n\n";
+    cout << out;
+}
 int main(int argc, char** argv) {
     using namespace std;
 
@@ -18,92 +29,54 @@ int main(int argc, char** argv) {
     std::vector<std::vector<float>> intrinsics;
     int width, height;
 
-    cout << "Intrinsics from defaultIntrinsics function" << endl;
+    cout << "Intrinsics from defaultIntrinsics function:" << endl;
     std::tie(intrinsics, width, height) = calibData.getDefaultIntrinsics(dai::CameraBoardSocket::RIGHT);
+    printMatrix(intrinsics);
 
-    for(auto row : intrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
+    cout << "Width: " << width << endl;
+    cout << "Height: " << height << endl;
 
-    cout << "Width -> " << width << endl;
-    cout << "Height -> " << height << endl;
+    cout << "Stereo baseline distance: " << calibData.getBaselineDistance() << " cm" << endl;
 
-    cout << "Stereo baseline distance -> " << calibData.getBaselineDistance() << " cm" << endl;
+    cout << "Mono FOV from camera specs: " << calibData.getFov(dai::CameraBoardSocket::LEFT) << ", calculated FOV: " << calibData.getFov(dai::CameraBoardSocket::LEFT, false) << endl;
 
-    cout << "Intrinsics from getCameraIntrinsics function full resolution ->" << endl;
+    cout << "Intrinsics from getCameraIntrinsics function full resolution:" << endl;
     intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT);
+    printMatrix(intrinsics);
 
-    for(auto row : intrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
-
-    cout << "Intrinsics from getCameraIntrinsics function 1280 x 720  ->" << endl;
+    cout << "Intrinsics from getCameraIntrinsics function 1280 x 720:" << endl;
     intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT, 1280, 720);
+    printMatrix(intrinsics);
 
-    for(auto row : intrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
-
-    cout << "Intrinsics from getCameraIntrinsics function 720 x 450 ->" << endl;
+    cout << "Intrinsics from getCameraIntrinsics function 720 x 450:" << endl;
     intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT, 720);
+    printMatrix(intrinsics);
 
-    for(auto row : intrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
-
-    cout << "Intrinsics from getCameraIntrinsics function 600 x 1280 ->" << endl;
+    cout << "Intrinsics from getCameraIntrinsics function 600 x 1280:" << endl;
     intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT, 600, 1280);
-
-    for(auto row : intrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
+    printMatrix(intrinsics);
 
     std::vector<std::vector<float>> extrinsics;
 
-    cout << "Extrinsics from left->right test ->" << endl;
+    cout << "Extrinsics from left->right test:" << endl;
     extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::LEFT, dai::CameraBoardSocket::RIGHT);
+    printMatrix(extrinsics);
 
-    for(auto row : extrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
-
-    cout << "Extrinsics from right->left test ->" << endl;
+    cout << "Extrinsics from right->left test:" << endl;
     extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::RIGHT, dai::CameraBoardSocket::LEFT);
+    printMatrix(extrinsics);
 
-    for(auto row : extrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
-
-    cout << "Extrinsics from right->rgb test ->" << endl;
+    cout << "Extrinsics from right->rgb test:" << endl;
     extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::RIGHT, dai::CameraBoardSocket::RGB);
+    printMatrix(extrinsics);
 
-    for(auto row : extrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
-
-    cout << "Extrinsics from rgb->right test ->" << endl;
+    cout << "Extrinsics from rgb->right test:" << endl;
     extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::RGB, dai::CameraBoardSocket::RIGHT);
+    printMatrix(extrinsics);
 
-    for(auto row : extrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
-
-    cout << "Extrinsics from left->rgb test ->" << endl;
+    cout << "Extrinsics from left->rgb test:" << endl;
     extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::LEFT, dai::CameraBoardSocket::RGB);
-
-    for(auto row : extrinsics) {
-        for(auto val : row) cout << val << "  ";
-        cout << endl;
-    }
+    printMatrix(extrinsics);
 
     return 0;
 }

--- a/examples/src/calibration_reader.cpp
+++ b/examples/src/calibration_reader.cpp
@@ -18,6 +18,7 @@ void printMatrix(std::vector<std::vector<float>> matrix) {
     out = out.substr(0, out.size() - 1) + "]\n\n";
     cout << out;
 }
+
 int main(int argc, char** argv) {
     using namespace std;
 

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -145,9 +145,10 @@ class CalibrationHandler {
      *  Get the Fov of the camera
      *
      * @param cameraId of the camera of which we are fetching fov.
+     * @param useSpec Disabling this bool will calculate the fov based on intrinsics (focal length, image width), instead of getting it from the camera specs
      * @return field of view of the camera with given cameraId.
      */
-    float getFov(CameraBoardSocket cameraId);
+    float getFov(CameraBoardSocket cameraId, bool useSpec = true);
 
     /**
      *  Get the lens position of the given camera

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1,5 +1,6 @@
 #include "device/CalibrationHandler.hpp"
 
+#include <cmath>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -13,7 +14,6 @@
 #include "nlohmann/json.hpp"
 #include "spdlog/spdlog.h"
 #include "utility/matrixOps.hpp"
-#include <math.h>
 
 namespace dai {
 
@@ -254,18 +254,18 @@ std::vector<float> CalibrationHandler::getDistortionCoefficients(CameraBoardSock
 }
 
 float CalibrationHandler::getFov(CameraBoardSocket cameraId, bool useSpec) {
-    if (useSpec) {
-        if(eepromData.cameraData.find(cameraId) == eepromData.cameraData.end())
-            throw std::runtime_error("There is no Camera data available corresponding to the the requested cameraID");
+    if(eepromData.cameraData.find(cameraId) == eepromData.cameraData.end())
+        throw std::runtime_error("There is no Camera data available corresponding to the the requested cameraID");
 
+    if(useSpec) {
         return eepromData.cameraData[cameraId].specHfovDeg;
     }
     // Calculate fov from intrinsics
     std::vector<std::vector<float>> intrinsics;
     int width, height;
-    std::tie(intrinsics, width, height) = CalibrationHandler::getDefaultIntrinsics(dai::CameraBoardSocket::LEFT);
+    std::tie(intrinsics, width, height) = CalibrationHandler::getDefaultIntrinsics(cameraId);
     auto focalLength = intrinsics[0][0];
-    return 2 * 180 / M_PI * atan(width * 0.5 / focalLength);
+    return 2 * 180 / M_PI * atan(width * 0.5f / focalLength);
 }
 
 uint8_t CalibrationHandler::getLensPosition(CameraBoardSocket cameraId) {

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1,5 +1,6 @@
 #include "device/CalibrationHandler.hpp"
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
Output from the example about FOV:
`Mono FOV from camera specs: 71.86, calculated FOV: 73.0632`

Matrix printing in example:
```Extrinsics from rgb->right test:
[[0.999971, 0.007518, -0.001316, -3.748613]
[-0.007519, 0.999971, -0.000848, 0.061079]
[0.001310, 0.000858, 0.999999, 0.105437]
[0.000000, 0.000000, 0.000000, 1.000000]]

Extrinsics from left->rgb test:
[[0.999886, -0.008687, -0.012368, -3.802770]
[0.008607, 0.999942, -0.006518, -0.054966]
[0.012424, 0.006411, 0.999902, -0.070479]
[0.000000, 0.000000, 0.000000, 1.000000]]
```