### PR TITLE
Fix still image output in RGB postprocessing

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "4edb4923933e4cf2750f1958e4dee77de2cdca3f")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "ebd8f842de48304a24a07bb62e7f9b8854e78601")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "30d8539b9a7b6b056cdb9d3deab5036542204dd2")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "4edb4923933e4cf2750f1958e4dee77de2cdca3f")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
In some cases postprocessing failed, due to runtime crop config for video/preview outputs, e.g. 
`Sending new crop - x:  0.03888888888888888  y:  0.6518518518518517`

Tested/reproduced with: `rgb_camera_control` example.