### PR TITLE
Fix build with older Visual Studio - M_PI undeclared

### DIFF
--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1,6 +1,7 @@
+#define _USE_MATH_DEFINES
+
 #include "device/CalibrationHandler.hpp"
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
Move `#define _USE_MATH_DEFINES` at the top of the file, as other (system) headers could include `<cmath>`
Fixing build with Visual Studio 15 2017 Win64:
`error C2065: 'M_PI': undeclared identifier`

https://discord.com/channels/790680891252932659/798284448323731456/899110756413489212