### PR TITLE
Update catch2 package to 2.13.7

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -85,3 +85,10 @@ hunter_config(
     CMAKE_ARGS
         BACKWARD_TESTS=OFF
 )
+
+hunter_config(
+    Catch2
+    VERSION "2.13.7"
+    URL "https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.7.tar.gz"
+    SHA1 "fa8f14ccf852413d3c6d3999145ada934d37d773"
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ include(CTest)
 enable_testing()
 
 # Add catch2 for writing tests
-hunter_add_package(Catch)
+hunter_add_package(Catch2)
 find_package(Catch2 CONFIG REQUIRED)
 
 # Macro for adding new tests


### PR DESCRIPTION
After updating to Ubuntu 21.10 the tests didn't build due to an error of newer glibc.
Tracked issue for more details:
https://github.com/catchorg/Catch2/issues/2178

It was fixed in 2.13.5 release.
