### PR TITLE
Support for OAK-D-Lite

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "3bb469fa08b7b0abc4353cd27219521dfd763a9d")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "4354b366954d3c743e387b058e4bc369a6d0e758")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "4354b366954d3c743e387b058e4bc369a6d0e758")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "b527d5470e4f736edecd9c8afbc8b67641cafe1e")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/ColorCamera/rgb_camera_control.cpp
+++ b/examples/ColorCamera/rgb_camera_control.cpp
@@ -53,8 +53,8 @@ int main() {
     // Properties
     camRgb->setVideoSize(640, 360);
     camRgb->setPreviewSize(300, 300);
-    videoEncoder->setDefaultProfilePreset(camRgb->getVideoSize(), camRgb->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
-    stillEncoder->setDefaultProfilePreset(camRgb->getStillSize(), 1, dai::VideoEncoderProperties::Profile::MJPEG);
+    videoEncoder->setDefaultProfilePreset(camRgb->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
+    stillEncoder->setDefaultProfilePreset(1, dai::VideoEncoderProperties::Profile::MJPEG);
 
     // Linking
     camRgb->video.link(videoEncoder->input);

--- a/examples/Script/script_http_server.cpp
+++ b/examples/Script/script_http_server.cpp
@@ -14,7 +14,7 @@ int main() {
     auto cam = pipeline.create<dai::node::ColorCamera>();
 
     auto jpeg = pipeline.create<dai::node::VideoEncoder>();
-    jpeg->setDefaultProfilePreset(cam->getVideoSize(), cam->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
+    jpeg->setDefaultProfilePreset(cam->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
 
     // Script node
     auto script = pipeline.create<dai::node::Script>();

--- a/examples/Script/script_mjpeg_server.cpp
+++ b/examples/Script/script_mjpeg_server.cpp
@@ -14,7 +14,7 @@ int main() {
     auto cam = pipeline.create<dai::node::ColorCamera>();
 
     auto jpeg = pipeline.create<dai::node::VideoEncoder>();
-    jpeg->setDefaultProfilePreset(cam->getVideoSize(), cam->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
+    jpeg->setDefaultProfilePreset(cam->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
     cam->video.link(jpeg->input);
 
     // Script node

--- a/examples/VideoEncoder/disparity_encoding.cpp
+++ b/examples/VideoEncoder/disparity_encoding.cpp
@@ -36,7 +36,7 @@ int main() {
     monoRight->out.link(stereo->right);
 
     auto videoEnc = pipeline.create<dai::node::VideoEncoder>();
-    videoEnc->setDefaultProfilePreset(monoLeft->getResolutionSize(), monoLeft->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
+    videoEnc->setDefaultProfilePreset(monoLeft->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
     stereo->disparity.link(videoEnc->input);
 
     auto xout = pipeline.create<dai::node::XLinkOut>();

--- a/examples/VideoEncoder/encoding_max_limit.cpp
+++ b/examples/VideoEncoder/encoding_max_limit.cpp
@@ -41,9 +41,9 @@ int main() {
     monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
 
     // Setting to 26fps will trigger error
-    ve1->setDefaultProfilePreset(1280, 720, 25, dai::VideoEncoderProperties::Profile::H264_MAIN);
-    ve2->setDefaultProfilePreset(3840, 2160, 25, dai::VideoEncoderProperties::Profile::H265_MAIN);
-    ve3->setDefaultProfilePreset(1280, 720, 25, dai::VideoEncoderProperties::Profile::H264_MAIN);
+    ve1->setDefaultProfilePreset(25, dai::VideoEncoderProperties::Profile::H264_MAIN);
+    ve2->setDefaultProfilePreset(25, dai::VideoEncoderProperties::Profile::H265_MAIN);
+    ve3->setDefaultProfilePreset(25, dai::VideoEncoderProperties::Profile::H264_MAIN);
 
     // Linking
     monoLeft->out.link(ve1->input);

--- a/examples/VideoEncoder/mjpeg_encoding_example.cpp
+++ b/examples/VideoEncoder/mjpeg_encoding_example.cpp
@@ -25,7 +25,7 @@ int main() {
     camRgb->setInterleaved(true);
 
     // VideoEncoder
-    videnc->setDefaultProfilePreset(1920, 1080, 30, dai::VideoEncoderProperties::Profile::MJPEG);
+    videnc->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::MJPEG);
 
     // Linking
     camRgb->video.link(videnc->input);

--- a/examples/VideoEncoder/rgb_encoding.cpp
+++ b/examples/VideoEncoder/rgb_encoding.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     // Properties
     camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_4_K);
-    videoEnc->setDefaultProfilePreset(3840, 2160, 30, dai::VideoEncoderProperties::Profile::H265_MAIN);
+    videoEnc->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);
 
     // Linking
     camRgb->video.link(videoEnc->input);

--- a/examples/VideoEncoder/rgb_full_resolution_saver.cpp
+++ b/examples/VideoEncoder/rgb_full_resolution_saver.cpp
@@ -23,7 +23,7 @@ int main() {
     // Properties
     camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_4_K);
-    videoEnc->setDefaultProfilePreset(camRgb->getVideoSize(), camRgb->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
+    videoEnc->setDefaultProfilePreset(camRgb->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
 
     // Linking
     camRgb->video.link(xoutRgb->input);

--- a/examples/VideoEncoder/rgb_mono_encoding.cpp
+++ b/examples/VideoEncoder/rgb_mono_encoding.cpp
@@ -38,9 +38,9 @@ int main() {
     monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
     monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
     // Create encoders, one for each camera, consuming the frames and encoding them using H.264 / H.265 encoding
-    ve1->setDefaultProfilePreset(1280, 720, 30, dai::VideoEncoderProperties::Profile::H264_MAIN);
-    ve2->setDefaultProfilePreset(1920, 1080, 30, dai::VideoEncoderProperties::Profile::H265_MAIN);
-    ve3->setDefaultProfilePreset(1280, 720, 30, dai::VideoEncoderProperties::Profile::H264_MAIN);
+    ve1->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H264_MAIN);
+    ve2->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);
+    ve3->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H264_MAIN);
 
     // Linking
     monoLeft->out.link(ve1->input);

--- a/examples/mixed/rgb_encoding_mobilenet.cpp
+++ b/examples/mixed/rgb_encoding_mobilenet.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
     camRgb->setPreviewSize(300, 300);
     camRgb->setInterleaved(false);
 
-    videoEncoder->setDefaultProfilePreset(1920, 1080, 30, dai::VideoEncoderProperties::Profile::H265_MAIN);
+    videoEncoder->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);
 
     nn->setConfidenceThreshold(0.5);
     nn->setBlobPath(nnPath);

--- a/examples/mixed/rgb_encoding_mono_mobilenet.cpp
+++ b/examples/mixed/rgb_encoding_mono_mobilenet.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    videoEncoder->setDefaultProfilePreset(1920, 1080, 30, dai::VideoEncoderProperties::Profile::H265_MAIN);
+    videoEncoder->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);
 
     nn->setConfidenceThreshold(0.5);
     nn->setBlobPath(nnPath);

--- a/examples/mixed/rgb_encoding_mono_mobilenet_depth.cpp
+++ b/examples/mixed/rgb_encoding_mono_mobilenet_depth.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
     monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    videoEncoder->setDefaultProfilePreset(1920, 1080, 30, dai::VideoEncoderProperties::Profile::H265_MAIN);
+    videoEncoder->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);
 
     depth->initialConfig.setConfidenceThreshold(255);
     depth->setRectifyEdgeFillColor(0);  // Black, to better see the cutout

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -403,6 +403,13 @@ class DeviceBase {
     std::vector<CameraBoardSocket> getConnectedCameras();
 
     /**
+     * Get sensor names for cameras that are connected to the device
+     *
+     * @returns Map/dictionary with camera sensor names, indexed by socket
+     */
+    std::unordered_map<CameraBoardSocket, std::string> getCameraSensorNames();
+
+    /**
      * Retrieves current DDR memory information from device
      *
      * @returns Used, remaining and total ddr memory

--- a/include/depthai/pipeline/node/VideoEncoder.hpp
+++ b/include/depthai/pipeline/node/VideoEncoder.hpp
@@ -39,13 +39,23 @@ class VideoEncoder : public Node {
 
     // Sets default options for a specified size and profile
     /**
+     * Sets a default preset based on specified frame rate and profile
+     * @param fps Frame rate in frames per second
+     * @param profile Encoding profile
+     */
+    void setDefaultProfilePreset(float fps, Properties::Profile profile);
+
+    /**
      * Sets a default preset based on specified input size, frame rate and profile
      * @param width Input frame width
      * @param height Input frame height
      * @param fps Frame rate in frames per second
      * @param profile Encoding profile
      */
-    void setDefaultProfilePreset(int width, int height, float fps, Properties::Profile profile);
+    [[deprecated("Input width/height no longer needed, automatically determined from first frame")]] void setDefaultProfilePreset(int width,
+                                                                                                                                  int height,
+                                                                                                                                  float fps,
+                                                                                                                                  Properties::Profile profile);
 
     /**
      * Sets a default preset based on specified input size, frame rate and profile
@@ -53,7 +63,9 @@ class VideoEncoder : public Node {
      * @param fps Frame rate in frames per second
      * @param profile Encoding profile
      */
-    void setDefaultProfilePreset(std::tuple<int, int> size, float fps, Properties::Profile profile);
+    [[deprecated("Input size no longer needed, automatically determined from first frame")]] void setDefaultProfilePreset(std::tuple<int, int> size,
+                                                                                                                          float fps,
+                                                                                                                          Properties::Profile profile);
 
     // node properties
     /**
@@ -72,12 +84,17 @@ class VideoEncoder : public Node {
     /// Set rate control mode
     void setRateControlMode(Properties::RateControlMode mode);
     /// Set encoding profile
-    void setProfile(std::tuple<int, int> size, Properties::Profile profile);
+    void setProfile(Properties::Profile profile);
     /// Set encoding profile
-    void setProfile(int width, int height, Properties::Profile profile);
-    /// Set output bitrate in bps. Final bitrate depends on rate control mode
+    [[deprecated("Input size no longer needed, automatically determined from first frame")]] void setProfile(std::tuple<int, int> size,
+                                                                                                             Properties::Profile profile);
+    /// Set encoding profile
+    [[deprecated("Input width/height no longer needed, automatically determined from first frame")]] void setProfile(int width,
+                                                                                                                     int height,
+                                                                                                                     Properties::Profile profile);
+    /// Set output bitrate in bps, for CBR rate control mode. 0 for auto (based on frame size and FPS)
     void setBitrate(int bitrate);
-    /// Set output bitrate in kbps. Final bitrate depends on rate control mode
+    /// Set output bitrate in kbps, for CBR rate control mode. 0 for auto (based on frame size and FPS)
     void setBitrateKbps(int bitrateKbps);
 
     /**
@@ -131,11 +148,11 @@ class VideoEncoder : public Node {
     /// Get quality
     int getQuality() const;
     /// Get input size
-    std::tuple<int, int> getSize() const;
+    [[deprecated("Input size no longer available, it's determined when first frame arrives")]] std::tuple<int, int> getSize() const;
     /// Get input width
-    int getWidth() const;
+    [[deprecated("Input size no longer available, it's determined when first frame arrives")]] int getWidth() const;
     /// Get input height
-    int getHeight() const;
+    [[deprecated("Input size no longer available, it's determined when first frame arrives")]] int getHeight() const;
     /// Get frame rate
     float getFrameRate() const;
     /// Get lossless mode. Applies only when using [M]JPEG profile.

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -678,6 +678,12 @@ std::vector<CameraBoardSocket> DeviceBase::getConnectedCameras() {
     return pimpl->rpcClient->call("getConnectedCameras").as<std::vector<CameraBoardSocket>>();
 }
 
+std::unordered_map<CameraBoardSocket, std::string> DeviceBase::getCameraSensorNames() {
+    checkClosed();
+
+    return pimpl->rpcClient->call("getCameraSensorNames").as<std::unordered_map<CameraBoardSocket, std::string>>();
+}
+
 // Convinience functions for querying current system information
 MemoryInfo DeviceBase::getDdrMemoryUsage() {
     checkClosed();

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -204,7 +204,8 @@ std::tuple<int, int> ColorCamera::getVideoSize() const {
         int maxVideoHeight = 1080;
 
         if(properties.resolution == ColorCameraProperties::SensorResolution::THE_4_K
-           || properties.resolution == ColorCameraProperties::SensorResolution::THE_12_MP) {
+           || properties.resolution == ColorCameraProperties::SensorResolution::THE_12_MP
+           || properties.resolution == ColorCameraProperties::SensorResolution::THE_13_MP) {
             maxVideoWidth = 3840;
             maxVideoHeight = 2160;
         }
@@ -250,6 +251,10 @@ std::tuple<int, int> ColorCamera::getStillSize() const {
             maxStillWidth = 4032;  // Note not 4056 as full sensor resolution
             maxStillHeight = 3040;
         }
+        if(properties.resolution == dai::ColorCameraProperties::SensorResolution::THE_13_MP) {
+            maxStillWidth = 4192;  // Note not 4208 as full sensor resolution
+            maxStillHeight = 3120;
+        }
 
         // Take into the account the ISP scaling
         int numW = properties.ispScale.horizNumerator;
@@ -292,6 +297,10 @@ std::tuple<int, int> ColorCamera::getResolutionSize() const {
 
         case ColorCameraProperties::SensorResolution::THE_12_MP:
             return {4056, 3040};
+            break;
+
+        case ColorCameraProperties::SensorResolution::THE_13_MP:
+            return {4208, 3120};
             break;
     }
 

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -110,6 +110,10 @@ std::tuple<int, int> MonoCamera::getResolutionSize() const {
         case MonoCameraProperties::SensorResolution::THE_800_P:
             return {1280, 800};
             break;
+
+        case MonoCameraProperties::SensorResolution::THE_480_P:
+            return {640, 480};
+            break;
     }
     return {1280, 720};
 }

--- a/src/pipeline/node/VideoEncoder.cpp
+++ b/src/pipeline/node/VideoEncoder.cpp
@@ -59,12 +59,10 @@ void VideoEncoder::setProfile(int width, int height, VideoEncoderProperties::Pro
 
 void VideoEncoder::setBitrate(int bitrate) {
     properties.bitrate = bitrate;
-    properties.maxBitrate = bitrate;
 }
 
 void VideoEncoder::setBitrateKbps(int bitrateKbps) {
     properties.bitrate = bitrateKbps * 1000;
-    properties.maxBitrate = bitrateKbps * 1000;
 }
 
 void VideoEncoder::setKeyframeFrequency(int freq) {

--- a/src/pipeline/node/VideoEncoder.cpp
+++ b/src/pipeline/node/VideoEncoder.cpp
@@ -1,5 +1,7 @@
 #include "depthai/pipeline/node/VideoEncoder.hpp"
 
+#include "spdlog/spdlog.h"
+
 namespace dai {
 namespace node {
 
@@ -38,32 +40,21 @@ void VideoEncoder::setRateControlMode(VideoEncoderProperties::RateControlMode mo
     properties.rateCtrlMode = mode;
 }
 
+void VideoEncoder::setProfile(VideoEncoderProperties::Profile profile) {
+    properties.profile = profile;
+}
+
 void VideoEncoder::setProfile(std::tuple<int, int> size, VideoEncoderProperties::Profile profile) {
-    setProfile(std::get<0>(size), std::get<1>(size), profile);
+    (void)size;
+    spdlog::warn("VideoEncoder {}: passing 'size' is deprecated. It is auto-determined from first frame", __func__);
+    setProfile(profile);
 }
 
 void VideoEncoder::setProfile(int width, int height, VideoEncoderProperties::Profile profile) {
-    // Width & height H26x limitations
-    if(profile != VideoEncoderProperties::Profile::MJPEG) {
-        if(width % 8 != 0 || height % 8 != 0) {
-            throw std::invalid_argument("VideoEncoder - Width and height must be multiple of 8 for H26x encoder profile");
-        }
-        if(width > 4096 || height > 4096) {
-            throw std::invalid_argument("VideoEncoder - Width and height must be smaller than 4096 for H26x encoder profile");
-        }
-    } else {
-        // width & height MJPEG limitations
-        if(width % 16 != 0 || height % 2 != 0) {
-            throw std::invalid_argument("VideoEncoder - Width must be multiple of 16 and height multiple of 2 for MJPEG encoder profile");
-        }
-        if(width > 16384 || height > 8192) {
-            throw std::invalid_argument("VideoEncoder - Width must be smaller or to 16384 and height to 8192");
-        }
-    }
-
-    properties.width = width;
-    properties.height = height;
-    properties.profile = profile;
+    (void)width;
+    (void)height;
+    spdlog::warn("VideoEncoder {}: passing 'width'/ 'height' is deprecated. The size is auto-determined from first frame", __func__);
+    setProfile(profile);
 }
 
 void VideoEncoder::setBitrate(int bitrate) {
@@ -129,26 +120,29 @@ int VideoEncoder::getQuality() const {
 }
 
 std::tuple<int, int> VideoEncoder::getSize() const {
-    return {properties.width, properties.height};
+    spdlog::warn("VideoEncoder {} is deprecated. The size is auto-determined from first frame and not known upfront", __func__);
+    return {0, 0};
 }
 
 int VideoEncoder::getWidth() const {
-    return std::get<0>(getSize());
+    spdlog::warn("VideoEncoder {} is deprecated. The size is auto-determined from first frame and not known upfront", __func__);
+    return 0;
 }
 
 int VideoEncoder::getHeight() const {
-    return std::get<1>(getSize());
+    spdlog::warn("VideoEncoder {} is deprecated. The size is auto-determined from first frame and not known upfront", __func__);
+    return 0;
 }
 
 float VideoEncoder::getFrameRate() const {
     return properties.frameRate;
 }
 
-void VideoEncoder::setDefaultProfilePreset(int width, int height, float fps, VideoEncoderProperties::Profile profile) {
+void VideoEncoder::setDefaultProfilePreset(float fps, VideoEncoderProperties::Profile profile) {
     // Checks
 
     // Set properties
-    setProfile(width, height, profile);
+    setProfile(profile);
     setFrameRate(fps);
 
     switch(profile) {
@@ -159,38 +153,29 @@ void VideoEncoder::setDefaultProfilePreset(int width, int height, float fps, Vid
         case VideoEncoderProperties::Profile::H264_BASELINE:
         case VideoEncoderProperties::Profile::H264_HIGH:
         case VideoEncoderProperties::Profile::H264_MAIN:
-        case VideoEncoderProperties::Profile::H265_MAIN: {
+        case VideoEncoderProperties::Profile::H265_MAIN:
             // By default set keyframe frequency to equal fps
             properties.keyframeFrequency = static_cast<int32_t>(fps);
-
-            // Approximate bitrate on input w/h and fps
-            constexpr float ESTIMATION_FPS = 30.0f;
-            constexpr float AREA_MUL = 1.1f;
-
-            // calculate pixel area
-            const int pixelArea = width * height;
-            if(pixelArea <= 1280 * 720 * AREA_MUL) {
-                // 720p
-                setBitrateKbps(static_cast<int>((4000 / ESTIMATION_FPS) * fps));
-            } else if(pixelArea <= 1920 * 1080 * AREA_MUL) {
-                // 1080p
-                setBitrateKbps(static_cast<int>((8500 / ESTIMATION_FPS) * fps));
-            } else if(pixelArea <= 2560 * 1440 * AREA_MUL) {
-                // 1440p
-                setBitrateKbps(static_cast<int>((14000 / ESTIMATION_FPS) * fps));
-            } else {
-                // 4K
-                setBitrateKbps(static_cast<int>((20000 / ESTIMATION_FPS) * fps));
-            }
-        } break;
+            // A default bitrate computed by firmware based on size and fps
+            setBitrate(0);
+            break;
 
         default:
             break;
     }
 }
 
+void VideoEncoder::setDefaultProfilePreset(int width, int height, float fps, VideoEncoderProperties::Profile profile) {
+    (void)width;
+    (void)height;
+    spdlog::warn("VideoEncoder {}: passing 'width'/ 'height' is deprecated. The size is auto-determined from first frame", __func__);
+    setDefaultProfilePreset(fps, profile);
+}
+
 void VideoEncoder::setDefaultProfilePreset(std::tuple<int, int> size, float fps, VideoEncoderProperties::Profile profile) {
-    setDefaultProfilePreset(std::get<0>(size), std::get<1>(size), fps, profile);
+    (void)size;
+    spdlog::warn("VideoEncoder {}: passing 'width'/ 'height' is deprecated. The size is auto-determined from first frame", __func__);
+    setDefaultProfilePreset(fps, profile);
 }
 
 bool VideoEncoder::getLossless() const {


### PR DESCRIPTION
- Firmware support and handling for the new resolutions of the cameras:

| Color Resolution | IMX378 (OAK-D) | IMX214 (OAK-D-Lite) |
| --- | ----------- | -- |
| `THE_1080_P` (1920×1080) | ✔️ binning+cropping | ✔️ binning+cropping |
| `THE_4_K` (3840×2160) | ✔️ cropping | ✔️ cropping |
| `THE_12_MP` (4056×3040) | ✔️ full | ✔️ cropping |
| `THE_13_MP` (4208×3120) | ❌ Not supported | ✔️ full |

| Mono Resolution | OV9282 (OAK-D) | OV7251 (OAK-D-Lite) |
| --- | ----------- | -- |
| `THE_400_P` (640×400) | ✔️ binning | ✔️ cropping |
| `THE_480_P` (640×480) | ❌ Not supported | ✔️ full |
| `THE_720_P` (1280×720) | ✔️ cropping | ❌ Not supported |
| `THE_800_P` (1280×800) | ✔️ full | ❌ Not supported |

If an unsupported resolution is configured, the firmware will log an error and default to a working one, but the host might be unaware of this, for example if using API when the pipeline was defined, like `ColorCamera::getResolution()`.
As a solution for that, a new function `device.getCameraSensorNames()` was added, which can be called after the device was created, but before sending down the pipeline. So the pipeline can be customized accordingly. It will usually return:
```
OAK-D:      RGB: "IMX378", LEFT: "OV9282", RIGHT: "OV9282"
OAK-D-Lite: RGB: "IMX214", LEFT: "OV7251", RIGHT: "OV7251"
```
Related PR: https://github.com/luxonis/depthai-shared/pull/63