### PR TITLE
Adds a timeout for closing an XLink connection

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,8 +8,8 @@ hunter_config(
 hunter_config(
     XLink
     VERSION "luxonis-2021.3-develop"
-    URL "https://github.com/luxonis/XLink/archive/4c149080d22c35a17ce285f5bca99f2b2fe05e46.tar.gz"
-    SHA1 "64b0a8bfeb1a91f909df88ea8b1d0b17885b92ff"
+    URL "https://github.com/luxonis/XLink/archive/0d08d99dad1fd1117d703a6fa73e8759c8843470.tar.gz"
+    SHA1 "f1371942fe39d9040ae7f2b0f0f4a4818bf15aac"
 )
 
 hunter_config(

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -184,7 +184,7 @@ void XLinkConnection::close() {
         auto tmp = deviceLinkId;
 
         auto ret = XLinkResetRemoteTimeout(deviceLinkId, duration_cast<milliseconds>(RESET_TIMEOUT).count());
-        if(ret != X_LINK_SUCCESS){
+        if(ret != X_LINK_SUCCESS) {
             spdlog::debug("XLinkResetRemoteTimeout returned: {}", XLinkErrorToStr(ret));
         }
 

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -176,14 +176,21 @@ void XLinkConnection::checkClosed() const {
 void XLinkConnection::close() {
     if(closed.exchange(true)) return;
 
+    using namespace std::chrono;
+    constexpr auto RESET_TIMEOUT = seconds(2);
+    constexpr auto BOOTUP_SEARCH = seconds(5);
+
     if(deviceLinkId != -1 && rebootOnDestruction) {
         auto tmp = deviceLinkId;
-        XLinkResetRemote(deviceLinkId);
+
+        auto ret = XLinkResetRemoteTimeout(deviceLinkId, duration_cast<milliseconds>(RESET_TIMEOUT).count());
+        if(ret != X_LINK_SUCCESS){
+            spdlog::debug("XLinkResetRemoteTimeout returned: {}", XLinkErrorToStr(ret));
+        }
+
         deviceLinkId = -1;
 
         // TODO(themarpe) - revisit for TCPIP protocol
-        using namespace std::chrono;
-        const auto BOOTUP_SEARCH = std::chrono::seconds(5);
 
         // Wait till same device reappears (is rebooted).
         // Only in case if device was booted to begin with


### PR DESCRIPTION
Adds a timeout to XLinkConnection `close` as this can block main thread of execution if a device doesn't properly let host know that the link has fallen down (PoE devices specific)