### PR TITLE
fix errant printf params in examples

### DIFF
--- a/examples/IMU/imu_gyroscope_accelerometer.cpp
+++ b/examples/IMU/imu_gyroscope_accelerometer.cpp
@@ -58,9 +58,9 @@ int main() {
             auto acceleroTs = acceleroTs1 - baseTs;
             auto gyroTs = gyroTs1 - baseTs;
 
-            printf("Accelerometer timestamp: %ld ms\n", duration_cast<milliseconds>(acceleroTs).count());
+            printf("Accelerometer timestamp: %ld ms\n", static_cast<long>(duration_cast<milliseconds>(acceleroTs).count()));
             printf("Accelerometer [m/s^2]: x: %.3f y: %.3f z: %.3f \n", acceleroValues.x, acceleroValues.y, acceleroValues.z);
-            printf("Gyroscope timestamp: %ld ms\n", duration_cast<milliseconds>(gyroTs).count());
+            printf("Gyroscope timestamp: %ld ms\n", static_cast<long>(duration_cast<milliseconds>(gyroTs).count()));
             printf("Gyroscope [rad/s]: x: %.3f y: %.3f z: %.3f \n", gyroValues.x, gyroValues.y, gyroValues.z);
         }
 

--- a/examples/IMU/imu_rotation_vector.cpp
+++ b/examples/IMU/imu_rotation_vector.cpp
@@ -45,7 +45,7 @@ int main() {
             auto& rVvalues = imuPacket.rotationVector;
 
             auto rvTs = rVvalues.timestamp.get() - baseTs;
-            printf("Rotation vector timestamp: %ld ms\n", duration_cast<milliseconds>(rvTs).count());
+            printf("Rotation vector timestamp: %ld ms\n", static_cast<long>(duration_cast<milliseconds>(rvTs).count()));
 
             printf(
                 "Quaternion: i: %.3f j: %.3f k: %.3f real: %.3f\n"

--- a/examples/MobileNet/webcam_mobilenet_example.cpp
+++ b/examples/MobileNet/webcam_mobilenet_example.cpp
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
             cv::rectangle(frame, cv::Rect(cv::Point(x1, y1), cv::Point(x2, y2)), cv::Scalar(255, 255, 255));
         }
 
-        printf("===================== %lu detection(s) =======================\n", dets.size());
+        printf("===================== %lu detection(s) =======================\n", static_cast<unsigned long>(dets.size()));
         for(unsigned det = 0; det < dets.size(); ++det) {
             printf("%5d | %6.4f | %7.4f | %7.4f | %7.4f | %7.4f\n",
                    dets[det].label,


### PR DESCRIPTION
Pass correctly sized integers to printf -- continuing to silence noise

Fixes luxonis/depthai-core#259