### PR TITLE
XLink regression fix

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,8 +8,8 @@ hunter_config(
 hunter_config(
     XLink
     VERSION "luxonis-2021.4-master"
-    URL "https://github.com/luxonis/XLink/archive/9e2c90d0f68f2c32434b4f5d450d837b884cef1d.tar.gz"
-    SHA1 "eb18f8a5726d205e7b6e7972155e43c1fd173712"
+    URL "https://github.com/luxonis/XLink/archive/18a192fcf620163c9281ed55f28092d95b98ba72.tar.gz"
+    SHA1 "3d66ddf7b1913fd2fddbeda708396c3c43f95460"
 )
 
 hunter_config(


### PR DESCRIPTION
Fixes regression of XLink signaling a `SIGPIPE` (XLink PR: https://github.com/luxonis/XLink/pull/23)
Closes: #275 