### PR TITLE
Add manual white balance / color temperature camera control

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "4f7c0c94b0d70b502c20e55c14eadff875485a06")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "efb86d01cfead07c7978bde3d8f82bc059f4ac51")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "29036665ba3c8416048f602f0bfc82c17d26fc2e")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "4f7c0c94b0d70b502c20e55c14eadff875485a06")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/ColorCamera/rgb_camera_control.cpp
+++ b/examples/ColorCamera/rgb_camera_control.cpp
@@ -1,14 +1,16 @@
 /**
  * This example shows usage of Camera Control message as well as ColorCamera configInput to change crop x and y
- * Uses 'WASD' controls to move the crop window, 'C' to capture a still image, 'T' to trigger autofocus, 'IOKL,.'
- * for manual exposure/focus:
+ * Uses 'WASD' controls to move the crop window, 'C' to capture a still image, 'T' to trigger autofocus, 'IOKL,.[]'
+ * for manual exposure/focus/white-balance:
  *   Control:      key[dec/inc]  min..max
  *   exposure time:     I   O      1..33000 [us]
  *   sensitivity iso:   K   L    100..1600
  *   focus:             ,   .      0..255 [far..near]
+ *   white balance:     [   ]   1000..12000 (light color temperature K)
  * To go back to auto controls:
  *   'E' - autoexposure
  *   'F' - autofocus (continuous)
+ *   'B' - auto white-balance
  */
 #include <iostream>
 
@@ -24,6 +26,7 @@ static constexpr int STEP_SIZE = 8;
 static constexpr int EXP_STEP = 500;  // us
 static constexpr int ISO_STEP = 50;
 static constexpr int LENS_STEP = 3;
+static constexpr int WB_STEP = 200;
 
 static int clamp(int num, int v0, int v1) {
     return std::max(v0, std::min(num, v1));
@@ -97,6 +100,10 @@ int main() {
     int sensMin = 100;
     int sensMax = 1600;
 
+    int wbManual = 4000;
+    int wbMin = 1000;
+    int wbMax = 12000;
+
     while(true) {
         auto previewFrames = previewQueue->tryGetAll<dai::ImgFrame>();
         for(const auto& previewFrame : previewFrames) {
@@ -153,6 +160,11 @@ int main() {
             dai::CameraControl ctrl;
             ctrl.setAutoExposureEnable();
             controlQueue->send(ctrl);
+        } else if(key == 'b') {
+            printf("Auto white-balance enable\n");
+            dai::CameraControl ctrl;
+            ctrl.setAutoWhiteBalanceMode(dai::CameraControl::AutoWhiteBalanceMode::AUTO);
+            controlQueue->send(ctrl);
         } else if(key == ',' || key == '.') {
             if(key == ',') lensPos -= LENS_STEP;
             if(key == '.') lensPos += LENS_STEP;
@@ -171,6 +183,14 @@ int main() {
             printf("Setting manual exposure, time: %d, iso: %d\n", expTime, sensIso);
             dai::CameraControl ctrl;
             ctrl.setManualExposure(expTime, sensIso);
+            controlQueue->send(ctrl);
+        } else if(key == '[' || key == ']') {
+            if(key == '[') wbManual -= WB_STEP;
+            if(key == ']') wbManual += WB_STEP;
+            wbManual = clamp(wbManual, wbMin, wbMax);
+            printf("Setting manual white balance, temperature: %d K\n", wbManual);
+            dai::CameraControl ctrl;
+            ctrl.setManualWhiteBalance(wbManual);
             controlQueue->send(ctrl);
         } else if(key == 'w' || key == 'a' || key == 's' || key == 'd') {
             if(key == 'a') {

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -136,6 +136,12 @@ class CameraControl : public Buffer {
      */
     void setAutoWhiteBalanceLock(bool lock);
 
+    /**
+     * Set a command to manually specify white-balance color correction
+     * @param colorTemperatureK Light source color temperature in kelvins, range 1000..12000
+     */
+    void setManualWhiteBalance(int colorTemperatureK);
+
     // Other image controls
     /**
      * Set a command to adjust image brightness

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -85,6 +85,10 @@ void CameraControl::setAutoWhiteBalanceLock(bool lock) {
     cfg.setCommand(RawCameraControl::Command::AWB_LOCK);
     cfg.awbLockMode = lock;
 }
+void CameraControl::setManualWhiteBalance(int colorTemperatureK) {
+    cfg.setCommand(RawCameraControl::Command::WB_COLOR_TEMP);
+    cfg.wbColorTemp = colorTemperatureK;
+}
 
 // Other image controls
 void CameraControl::setBrightness(int value) {

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -42,7 +42,6 @@ void CameraControl::setAutoFocusRegion(uint16_t startX, uint16_t startY, uint16_
 void CameraControl::setManualFocus(uint8_t lensPosition) {
     cfg.setCommand(RawCameraControl::Command::MOVE_LENS);
     cfg.lensPosition = lensPosition;
-    setAutoFocusMode(AutoFocusMode::OFF);  // TODO added for initialConfig case
 }
 
 // Exposure


### PR DESCRIPTION
New `CameraControl` function:
```
    /**
     * Set a command to manually specify white-balance color correction
     * @param colorTemperatureK Light source color temperature in kelvins, range 1000..12000
     */
    void setManualWhiteBalance(int colorTemperatureK);
```

Updated `ColorCamera/rgb_camera_control` example with new key controls:
```
*   Control:      key[dec/inc]  min..max
*   white balance:     [   ]   1000..12000 (light color temperature K)

* 'B' - auto white-balance
```
Also fixes a FW issue: manual exposure set through initial control with other controls didn't work properly.

Related PR: https://github.com/luxonis/depthai-shared/pull/67