### PR TITLE
Release v2.13.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(WIN32)
 endif()
 
 # Create depthai project
-project(depthai VERSION "2.13.2" LANGUAGES CXX C)
+project(depthai VERSION "2.13.3" LANGUAGES CXX C)
 get_directory_property(has_parent PARENT_DIRECTORY)
 if(has_parent)
     set(DEPTHAI_VERSION ${PROJECT_VERSION} PARENT_SCOPE)

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a6ed5f116c68dfd4514533867411b479a2fdfea1")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "48fca4a443d841221c94c70d5c05e7e946168636")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "29036665ba3c8416048f602f0bfc82c17d26fc2e")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a6ed5f116c68dfd4514533867411b479a2fdfea1")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,8 +8,8 @@ hunter_config(
 hunter_config(
     XLink
     VERSION "luxonis-2021.4-master"
-    URL "https://github.com/luxonis/XLink/archive/d2de4895b8f956b3f3afea220a95a30dd4a3ae79.tar.gz"
-    SHA1 "2f58b22a9c2441f9adf8ebd871f2d08162ec552b"
+    URL "https://github.com/luxonis/XLink/archive/09fcfc93ca7060b07fe21db7371fc83e04a257f3.tar.gz"
+    SHA1 "7c8a947e80aaab7ceeb615001349f44e4162af4a"
 )
 
 hunter_config(

--- a/examples/ColorCamera/rgb_camera_control.cpp
+++ b/examples/ColorCamera/rgb_camera_control.cpp
@@ -1,14 +1,16 @@
 /**
  * This example shows usage of Camera Control message as well as ColorCamera configInput to change crop x and y
- * Uses 'WASD' controls to move the crop window, 'C' to capture a still image, 'T' to trigger autofocus, 'IOKL,.'
- * for manual exposure/focus:
+ * Uses 'WASD' controls to move the crop window, 'C' to capture a still image, 'T' to trigger autofocus, 'IOKL,.[]'
+ * for manual exposure/focus/white-balance:
  *   Control:      key[dec/inc]  min..max
  *   exposure time:     I   O      1..33000 [us]
  *   sensitivity iso:   K   L    100..1600
  *   focus:             ,   .      0..255 [far..near]
+ *   white balance:     [   ]   1000..12000 (light color temperature K)
  * To go back to auto controls:
  *   'E' - autoexposure
  *   'F' - autofocus (continuous)
+ *   'B' - auto white-balance
  */
 #include <iostream>
 
@@ -24,6 +26,7 @@ static constexpr int STEP_SIZE = 8;
 static constexpr int EXP_STEP = 500;  // us
 static constexpr int ISO_STEP = 50;
 static constexpr int LENS_STEP = 3;
+static constexpr int WB_STEP = 200;
 
 static int clamp(int num, int v0, int v1) {
     return std::max(v0, std::min(num, v1));
@@ -97,6 +100,10 @@ int main() {
     int sensMin = 100;
     int sensMax = 1600;
 
+    int wbManual = 4000;
+    int wbMin = 1000;
+    int wbMax = 12000;
+
     while(true) {
         auto previewFrames = previewQueue->tryGetAll<dai::ImgFrame>();
         for(const auto& previewFrame : previewFrames) {
@@ -153,6 +160,11 @@ int main() {
             dai::CameraControl ctrl;
             ctrl.setAutoExposureEnable();
             controlQueue->send(ctrl);
+        } else if(key == 'b') {
+            printf("Auto white-balance enable\n");
+            dai::CameraControl ctrl;
+            ctrl.setAutoWhiteBalanceMode(dai::CameraControl::AutoWhiteBalanceMode::AUTO);
+            controlQueue->send(ctrl);
         } else if(key == ',' || key == '.') {
             if(key == ',') lensPos -= LENS_STEP;
             if(key == '.') lensPos += LENS_STEP;
@@ -171,6 +183,14 @@ int main() {
             printf("Setting manual exposure, time: %d, iso: %d\n", expTime, sensIso);
             dai::CameraControl ctrl;
             ctrl.setManualExposure(expTime, sensIso);
+            controlQueue->send(ctrl);
+        } else if(key == '[' || key == ']') {
+            if(key == '[') wbManual -= WB_STEP;
+            if(key == ']') wbManual += WB_STEP;
+            wbManual = clamp(wbManual, wbMin, wbMax);
+            printf("Setting manual white balance, temperature: %d K\n", wbManual);
+            dai::CameraControl ctrl;
+            ctrl.setManualWhiteBalance(wbManual);
             controlQueue->send(ctrl);
         } else if(key == 'w' || key == 'a' || key == 's' || key == 'd') {
             if(key == 'a') {

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -136,6 +136,12 @@ class CameraControl : public Buffer {
      */
     void setAutoWhiteBalanceLock(bool lock);
 
+    /**
+     * Set a command to manually specify white-balance color correction
+     * @param colorTemperatureK Light source color temperature in kelvins, range 1000..12000
+     */
+    void setManualWhiteBalance(int colorTemperatureK);
+
     // Other image controls
     /**
      * Set a command to adjust image brightness

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -42,7 +42,6 @@ void CameraControl::setAutoFocusRegion(uint16_t startX, uint16_t startY, uint16_
 void CameraControl::setManualFocus(uint8_t lensPosition) {
     cfg.setCommand(RawCameraControl::Command::MOVE_LENS);
     cfg.lensPosition = lensPosition;
-    setAutoFocusMode(AutoFocusMode::OFF);  // TODO added for initialConfig case
 }
 
 // Exposure
@@ -84,6 +83,10 @@ void CameraControl::setAutoWhiteBalanceMode(AutoWhiteBalanceMode mode) {
 void CameraControl::setAutoWhiteBalanceLock(bool lock) {
     cfg.setCommand(RawCameraControl::Command::AWB_LOCK);
     cfg.awbLockMode = lock;
+}
+void CameraControl::setManualWhiteBalance(int colorTemperatureK) {
+    cfg.setCommand(RawCameraControl::Command::WB_COLOR_TEMP);
+    cfg.wbColorTemp = colorTemperatureK;
 }
 
 // Other image controls


### PR DESCRIPTION
## Features
- Added manual white balance (color temperature) camera control

## Bug fixes
- Firmware:
  - Fix a potential crash when VideoEncoder is used (regression from v2.13.0)
  - Fix a crash when more than 4x VideoEncoder instances are created
  - Fix a StereoDepth crash with RGB-depth alignment and missing RGB calibration (having the latest calib v6)
  - Fix RGB-depth alignment when running at full mono camera resolution
- XLink:
  - Fix a potential segmentation fault on device close
  - Fix some incorrectly calculated timeouts (on wait for reset)

## Misc
- Code changes: https://github.com/luxonis/depthai-core/pull/288; https://github.com/luxonis/depthai-shared/pull/69

## Known issues
- OAK-D Lite
  - FPS currently fixed to 30
  - Auto-exposure flicker may be seen on Mono cameras