### PR TITLE
Add SD card support

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "48fca4a443d841221c94c70d5c05e7e946168636")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "8811678636629201aeca81fee8eaf0d9255fa03e")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Accessible from Script nodes usually at:
`/media/mmcsd-0-0`    - first partition
`/media/mmcsd-0-1`    - second partition
...
The partition(s) should be pre-formatted as FAT32.
Note the Script node must set: `.setProcessor(dai::ProcessorType::LEON_CSS)`

TODO:
- add C++ example (available only in python for now)
- auto-unmount when the app is closed, to flush any cached data and prevent filesystem corruption