### PR TITLE
FW YoloV5 support and stability updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,17 @@ if(DEPTHAI_ENABLE_BACKWARD)
     set(CMAKE_ENABLE_EXPORTS ON)
 endif()
 
+# Force Colored output when using Ninja
+# Global option - affects all targets
+option(FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)" OFF)
+if(FORCE_COLORED_OUTPUT)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+       add_compile_options(-fdiagnostics-color=always)
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       add_compile_options(-fcolor-diagnostics)
+    endif()
+endif()
+
 ### Constants
 set(PROJECT_EXPORT_GROUP "${PROJECT_NAME}Targets")
 

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "48fca4a443d841221c94c70d5c05e7e946168636")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "7cff595514999a71475eee47141532c193a476f9")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Added YoloV5 support in FW and some stability improvements.
Also added a CMake option to force colored output for use Ninja