### PR TITLE
add cmake vars for local depthai-bootloader/shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ option(DEPTHAI_INSTALL   "Enable install target for depthai-core targets" ON)
 
 # Debug option
 set(DEPTHAI_XLINK_LOCAL "" CACHE STRING "Path to local XLink source to use instead of Hunter")
+set(DEPTHAI_SHARED_LOCAL "" CACHE STRING "Path to local depthai-shared source to use instead of submodule")
+set(DEPTHAI_BOOTLOADER_SHARED_LOCAL "" CACHE STRING "Path to local depthai-bootloader-shared source to use instead of submodule")
 
 # Enable backward stack printing on crash
 option(DEPTHAI_ENABLE_BACKWARD "Enable stacktrace printing on crash using Backward" ON)

--- a/shared/depthai-bootloader-shared.cmake
+++ b/shared/depthai-bootloader-shared.cmake
@@ -1,4 +1,8 @@
-set(DEPTHAI_BOOTLOADER_SHARED_FOLDER ${CMAKE_CURRENT_LIST_DIR}/depthai-bootloader-shared)
+if(DEPTHAI_BOOTLOADER_SHARED_LOCAL)
+    set(DEPTHAI_BOOTLOADER_SHARED_FOLDER ${DEPTHAI_BOOTLOADER_SHARED_LOCAL})
+else()
+    set(DEPTHAI_BOOTLOADER_SHARED_FOLDER ${CMAKE_CURRENT_LIST_DIR}/depthai-bootloader-shared)
+endif()
 
 set(DEPTHAI_BOOTLOADER_SHARED_SOURCES
     ${DEPTHAI_BOOTLOADER_SHARED_FOLDER}/src/SBR.c
@@ -17,16 +21,18 @@ set(DEPTHAI_BOOTLOADER_SHARED_INCLUDE
 find_package(Git)
 if(GIT_FOUND AND NOT DEPTHAI_DOWNLOADED_SOURCES)
 
-    # Check that submodule is initialized and updated
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} submodule status ${DEPTHAI_BOOTLOADER_SHARED_FOLDER}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-        OUTPUT_VARIABLE statusCommit
-        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    string(SUBSTRING ${statusCommit} 0 1 status)
-    if(${status} STREQUAL "-")
-        message(FATAL_ERROR "Submodule 'depthai-bootloader-shared' not initialized/updated. Run 'git submodule update --init --recursive' first")
+    if(NOT DEPTHAI_BOOTLOADER_SHARED_LOCAL)
+        # Check that submodule is initialized and updated
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} submodule status ${DEPTHAI_BOOTLOADER_SHARED_FOLDER}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE statusCommit
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        string(SUBSTRING ${statusCommit} 0 1 status)
+        if(${status} STREQUAL "-")
+            message(FATAL_ERROR "Submodule 'depthai-bootloader-shared' not initialized/updated. Run 'git submodule update --init --recursive' first")
+        endif()
     endif()
 
     # Get depthai-bootloader-shared current commit

--- a/shared/depthai-shared.cmake
+++ b/shared/depthai-shared.cmake
@@ -1,4 +1,8 @@
-set(DEPTHAI_SHARED_FOLDER ${CMAKE_CURRENT_LIST_DIR}/depthai-shared)
+if(DEPTHAI_SHARED_LOCAL)
+    set(DEPTHAI_SHARED_FOLDER ${DEPTHAI_SHARED_LOCAL})
+else()
+    set(DEPTHAI_SHARED_FOLDER ${CMAKE_CURRENT_LIST_DIR}/depthai-shared)
+endif()
 
 set(DEPTHAI_SHARED_3RDPARTY_HEADERS_PATH "depthai-shared/3rdparty")
 
@@ -23,16 +27,18 @@ set(DEPTHAI_SHARED_INCLUDE
 find_package(Git)
 if(GIT_FOUND AND NOT DEPTHAI_DOWNLOADED_SOURCES)
 
-    # Check that submodule is initialized and updated
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} submodule status ${DEPTHAI_SHARED_FOLDER}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-        OUTPUT_VARIABLE statusCommit
-        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    string(SUBSTRING ${statusCommit} 0 1 status)
-    if(${status} STREQUAL "-")
-        message(FATAL_ERROR "Submodule 'depthai-shared' not initialized/updated. Run 'git submodule update --init --recursive' first")
+    if(NOT DEPTHAI_SHARED_LOCAL)
+        # Check that submodule is initialized and updated
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} submodule status ${DEPTHAI_SHARED_FOLDER}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE statusCommit
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        string(SUBSTRING ${statusCommit} 0 1 status)
+        if(${status} STREQUAL "-")
+            message(FATAL_ERROR "Submodule 'depthai-shared' not initialized/updated. Run 'git submodule update --init --recursive' first")
+        endif()
     endif()
 
     # Get depthai-shared current commit


### PR DESCRIPTION
Fixes luxonis/depthai-core#264 by adding two optional cmake vars `DEPTHAI_SHARED_LOCAL` and `DEPTHAI_BOOTLOADER_SHARED_LOCAL`
When either or both are set, they will cause cmake to use the given directories instead of the submodules

Allows for easy coding/debugging of those two components/repos by optional separation 