### PR TITLE
fix stream+packet ownership/move; fix thread crashes

### DIFF
--- a/examples/cmake/ExecuteTestTimeout.cmake
+++ b/examples/cmake/ExecuteTestTimeout.cmake
@@ -8,7 +8,7 @@ foreach(_arg RANGE ${CMAKE_ARGC})
 
     if("${CMAKE_ARGV${_arg}}" STREQUAL "-P")
         set(append true)
-        message(status "found -P")
+        message(STATUS "found -P")
     endif()
 endforeach()
 list(REMOVE_AT arguments 0)
@@ -40,5 +40,5 @@ elseif(error_variable EQUAL 133 OR error_variable MATCHES "Child killed")
 else()
     # not timeout and error code != 0, not okay
     message(FATAL_ERROR "${PATH_TO_TEST_EXECUTABLE} produced an error (${error_variable}) while running")
-endif() 
+endif()
 

--- a/include/depthai/device/DataQueue.hpp
+++ b/include/depthai/device/DataQueue.hpp
@@ -37,7 +37,7 @@ class DataOutputQueue {
 
    public:
     // DataOutputQueue constructor
-    DataOutputQueue(const std::shared_ptr<XLinkConnection>& conn, const std::string& streamName, unsigned int maxSize = 16, bool blocking = true);
+    DataOutputQueue(const std::shared_ptr<XLinkConnection> conn, const std::string& streamName, unsigned int maxSize = 16, bool blocking = true);
     ~DataOutputQueue();
 
     /**
@@ -346,7 +346,7 @@ class DataInputQueue {
     std::size_t maxDataSize;
 
    public:
-    DataInputQueue(const std::shared_ptr<XLinkConnection>& conn, const std::string& streamName, unsigned int maxSize = 16, bool blocking = true);
+    DataInputQueue(const std::shared_ptr<XLinkConnection> conn, const std::string& streamName, unsigned int maxSize = 16, bool blocking = true);
     ~DataInputQueue();
 
     /**

--- a/include/depthai/pipeline/datatype/StreamMessageParser.hpp
+++ b/include/depthai/pipeline/datatype/StreamMessageParser.hpp
@@ -18,8 +18,8 @@
 namespace dai {
 class StreamMessageParser {
    public:
-    static std::shared_ptr<RawBuffer> parseMessage(streamPacketDesc_t* packet);
-    static std::shared_ptr<ADatatype> parseMessageToADatatype(streamPacketDesc_t* packet);
+    static std::shared_ptr<RawBuffer> parseMessage(streamPacketDesc_t* const packet);
+    static std::shared_ptr<ADatatype> parseMessageToADatatype(streamPacketDesc_t* const packet);
     static std::vector<std::uint8_t> serializeMessage(const std::shared_ptr<const RawBuffer>& data);
     static std::vector<std::uint8_t> serializeMessage(const RawBuffer& data);
     static std::vector<std::uint8_t> serializeMessage(const std::shared_ptr<const ADatatype>& data);

--- a/include/depthai/utility/LockingQueue.hpp
+++ b/include/depthai/utility/LockingQueue.hpp
@@ -43,9 +43,10 @@ class LockingQueue {
     }
 
     void destruct() {
-        destructed = true;
-        signalPop.notify_all();
-        signalPush.notify_all();
+        if(!destructed.exchange(true)) {
+            signalPop.notify_all();
+            signalPush.notify_all();
+        }
     }
     ~LockingQueue() = default;
 

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -20,18 +20,31 @@
 
 namespace dai {
 
+class StreamPacketDesc : public streamPacketDesc_t {
+   public:
+    StreamPacketDesc() noexcept : streamPacketDesc_t{nullptr, 0} {};
+    StreamPacketDesc(const StreamPacketDesc&) = delete;
+    StreamPacketDesc(StreamPacketDesc&& other) noexcept;
+    StreamPacketDesc& operator=(const StreamPacketDesc&) = delete;
+    StreamPacketDesc& operator=(StreamPacketDesc&& other) noexcept;
+    ~StreamPacketDesc() noexcept;
+};
+
 class XLinkStream {
     // static
     constexpr static int STREAM_OPEN_RETRIES = 5;
     constexpr static std::chrono::milliseconds WAIT_FOR_STREAM_RETRY{50};
 
+    std::shared_ptr<XLinkConnection> connection;
     std::string streamName;
     streamId_t streamId{INVALID_STREAM_ID};
 
    public:
-    XLinkStream(const XLinkConnection& conn, const std::string& name, std::size_t maxWriteSize);
+    XLinkStream(const std::shared_ptr<XLinkConnection> conn, const std::string& name, std::size_t maxWriteSize);
     XLinkStream(const XLinkStream&) = delete;
     XLinkStream(XLinkStream&& stream);
+    XLinkStream& operator=(const XLinkStream&) = delete;
+    XLinkStream& operator=(XLinkStream&& stream);
     ~XLinkStream();
 
     // Blocking
@@ -43,18 +56,22 @@ class XLinkStream {
     // split write helper
     void writeSplit(const void* data, std::size_t size, std::size_t split);
     void writeSplit(const std::vector<uint8_t>& data, std::size_t split);
-    // USE ONLY WHEN COPYING DATA AT LATER STAGES
-    streamPacketDesc_t* readRaw();
+    StreamPacketDesc readMove();
 
     // Timeout
     bool write(const void* data, std::size_t size, std::chrono::milliseconds timeout);
     bool write(const std::uint8_t* data, std::size_t size, std::chrono::milliseconds timeout);
     bool write(const std::vector<std::uint8_t>& data, std::chrono::milliseconds timeout);
     bool read(std::vector<std::uint8_t>& data, std::chrono::milliseconds timeout);
-    bool readRaw(streamPacketDesc_t*& pPacket, std::chrono::milliseconds timeout);
+    bool readMove(StreamPacketDesc& packet, const std::chrono::milliseconds timeout);
+    // TODO optional<StreamPacketDesc> readMove(timeout) -or- tuple<bool, StreamPacketDesc> readMove(timeout)
 
-    // USE ONLY WHEN COPYING DATA AT LATER STAGES
-    void readRawRelease();
+    // deprecated use readMove() instead; readRaw leads to memory violations and/or memory leaks
+    [[deprecated("use readMove()")]] streamPacketDesc_t* readRaw();
+    // deprecated use readMove(packet, timeout) instead; readRaw leads to memory violations and/or memory leaks
+    [[deprecated("use readMove(packet, timeout)")]] bool readRaw(streamPacketDesc_t*& pPacket, std::chrono::milliseconds timeout);
+    // deprecated; unsafe leads to memory violations and/or memory leaks
+    [[deprecated]] void readRawRelease();
 
     streamId_t getStreamId() const;
 };

--- a/src/device/CallbackHandler.cpp
+++ b/src/device/CallbackHandler.cpp
@@ -18,15 +18,12 @@ CallbackHandler::CallbackHandler(std::shared_ptr<XLinkConnection> conn,
     t = std::thread([this, streamName]() {
         try {
             // open stream with 1B write size (no writing will happen here)
-            XLinkStream stream(*connection, streamName, device::XLINK_USB_BUFFER_MAX_SIZE);
+            XLinkStream stream(connection, streamName, device::XLINK_USB_BUFFER_MAX_SIZE);
 
             while(running) {
-                // read packet
-                auto* packet = stream.readRaw();
-                // parse packet
-                auto data = StreamMessageParser::parseMessage(packet);
-                // release packet
-                stream.readRawRelease();
+                // Blocking -- parse packet
+                auto packet = stream.readMove();
+                const auto data = StreamMessageParser::parseMessage(&packet);
 
                 // CALLBACK
                 auto toSend = callback(data);

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -85,6 +85,9 @@ std::vector<uint8_t> DeviceBootloader::createDepthaiApplicationPackage(const Pip
         // TODO(themarpe) - specify OpenVINO version
         deviceFirmware = Resources::getInstance().getDeviceFirmware(false, version);
     }
+    if(deviceFirmware.empty()) {
+        throw std::runtime_error("Error getting device firmware");
+    }
 
     // Serialize data
     std::vector<uint8_t> pipelineBinary, assetsBinary;
@@ -236,7 +239,7 @@ void DeviceBootloader::init(bool embeddedMvcmd, const std::string& pathToMvcmd, 
         }
 
         // prepare bootloader stream
-        stream = std::make_unique<XLinkStream>(*connection, bootloader::XLINK_CHANNEL_BOOTLOADER, bootloader::XLINK_STREAM_MAX_SIZE);
+        stream = std::make_unique<XLinkStream>(connection, bootloader::XLINK_CHANNEL_BOOTLOADER, bootloader::XLINK_STREAM_MAX_SIZE);
 
         // Retrieve bootloader version
         version = requestVersion();
@@ -258,7 +261,7 @@ void DeviceBootloader::init(bool embeddedMvcmd, const std::string& pathToMvcmd, 
         connection = std::make_shared<XLinkConnection>(deviceInfo, X_LINK_BOOTLOADER);
 
         // If type is specified, try to boot into that BL type
-        stream = std::make_unique<XLinkStream>(*connection, bootloader::XLINK_CHANNEL_BOOTLOADER, bootloader::XLINK_STREAM_MAX_SIZE);
+        stream = std::make_unique<XLinkStream>(connection, bootloader::XLINK_CHANNEL_BOOTLOADER, bootloader::XLINK_STREAM_MAX_SIZE);
 
         // Retrieve bootloader version
         version = requestVersion();
@@ -284,16 +287,22 @@ void DeviceBootloader::init(bool embeddedMvcmd, const std::string& pathToMvcmd, 
                 std::atomic<bool> wdRunning{true};
                 std::thread wd = std::thread([&]() {
                     // prepare watchdog thread
-                    XLinkStream stream(*connection, bootloader::XLINK_CHANNEL_WATCHDOG, 64);
-                    std::vector<uint8_t> watchdogKeepalive = {0, 0, 0, 0};
-                    while(wdRunning) {
-                        try {
-                            stream.write(watchdogKeepalive);
-                        } catch(const std::exception&) {
-                            break;
+                    try {
+                        // constructor can throw in rare+quick start/stop scenarios because
+                        // the connection is close() eg. by DeviceBootloader::close()
+                        XLinkStream stream(connection, bootloader::XLINK_CHANNEL_WATCHDOG, 64);
+                        std::vector<uint8_t> watchdogKeepalive = {0, 0, 0, 0};
+                        while(wdRunning) {
+                            try {
+                                stream.write(watchdogKeepalive);
+                            } catch(const std::exception&) {
+                                break;
+                            }
+                            // Ping with a period half of that of the watchdog timeout
+                            std::this_thread::sleep_for(bootloader::XLINK_WATCHDOG_TIMEOUT / 2);
                         }
-                        // Ping with a period half of that of the watchdog timeout
-                        std::this_thread::sleep_for(bootloader::XLINK_WATCHDOG_TIMEOUT / 2);
+                    } catch(const std::exception&) {
+                        // ignore, probably invalid connection or stream
                     }
                 });
 
@@ -318,8 +327,9 @@ void DeviceBootloader::init(bool embeddedMvcmd, const std::string& pathToMvcmd, 
 
                 // Now reconnect
                 connection = std::make_shared<XLinkConnection>(deviceInfo, X_LINK_BOOTLOADER);
+
                 // prepare new bootloader stream
-                stream = std::make_unique<XLinkStream>(*connection, bootloader::XLINK_CHANNEL_BOOTLOADER, bootloader::XLINK_STREAM_MAX_SIZE);
+                stream = std::make_unique<XLinkStream>(connection, bootloader::XLINK_CHANNEL_BOOTLOADER, bootloader::XLINK_STREAM_MAX_SIZE);
 
                 // Retrieve bootloader version
                 version = requestVersion();
@@ -359,7 +369,7 @@ void DeviceBootloader::init(bool embeddedMvcmd, const std::string& pathToMvcmd, 
                 }
 
                 // prepare bootloader stream
-                stream = std::make_unique<XLinkStream>(*connection, bootloader::XLINK_CHANNEL_BOOTLOADER, bootloader::XLINK_STREAM_MAX_SIZE);
+                stream = std::make_unique<XLinkStream>(connection, bootloader::XLINK_CHANNEL_BOOTLOADER, bootloader::XLINK_STREAM_MAX_SIZE);
 
                 // Retrieve bootloader version
                 version = requestVersion();
@@ -386,29 +396,33 @@ void DeviceBootloader::init(bool embeddedMvcmd, const std::string& pathToMvcmd, 
 
     // prepare watchdog thread, which will keep device alive
     watchdogThread = std::thread([this]() {
-        // prepare watchdog thread
-        XLinkStream stream(*connection, bootloader::XLINK_CHANNEL_WATCHDOG, 64);
-
-        std::shared_ptr<XLinkConnection> conn = this->connection;
-        std::vector<uint8_t> watchdogKeepalive = {0, 0, 0, 0};
-        std::vector<uint8_t> reset = {1, 0, 0, 0};
-        while(watchdogRunning) {
-            try {
-                stream.write(watchdogKeepalive);
-            } catch(const std::exception&) {
-                break;
-            }
-            // Ping with a period half of that of the watchdog timeout
-            std::this_thread::sleep_for(bootloader::XLINK_WATCHDOG_TIMEOUT / 2);
-        }
-
         try {
-            // Send reset request
-            stream.write(reset);
-            // Dummy read (wait till link falls down)
-            stream.readRaw();
+            // constructor often throws in quick start/stop scenarios because
+            // the connection is close()...usually by DeviceBootloader::close()
+            XLinkStream stream(connection, bootloader::XLINK_CHANNEL_WATCHDOG, 64);
+            std::vector<uint8_t> watchdogKeepalive = {0, 0, 0, 0};
+            std::vector<uint8_t> reset = {1, 0, 0, 0};
+            while(watchdogRunning) {
+                try {
+                    stream.write(watchdogKeepalive);
+                } catch(const std::exception&) {
+                    break;
+                }
+                // Ping with a period half of that of the watchdog timeout
+                std::this_thread::sleep_for(bootloader::XLINK_WATCHDOG_TIMEOUT / 2);
+            }
+
+            try {
+                // Send reset request
+                stream.write(reset);
+                // Dummy read (wait till link falls down)
+                const auto dummy = stream.readMove();
+            } catch(const std::exception&) {
+                // ignore
+            }
         } catch(const std::exception&) {
-        }  // ignore
+            // ignore
+        }
 
         // Sleep a bit, so device isn't available anymore
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -423,9 +437,12 @@ void DeviceBootloader::close() {
     auto t1 = steady_clock::now();
     spdlog::debug("DeviceBootloader about to be closed...");
 
-    // Close connection first (so queues unblock)
+    // Close connection first; causes Xlink internal calls to unblock semaphore waits and
+    // return error codes, which then allows queues to unblock
+    // always manage ownership because other threads (e.g. watchdog) are running and need to
+    // keep the shared_ptr valid (even if closed). Otherwise leads to using null pointers,
+    // invalid memory, etc. which hard crashes main app
     connection->close();
-    connection = nullptr;
 
     // Stop watchdog
     watchdogRunning = false;
@@ -434,6 +451,7 @@ void DeviceBootloader::close() {
     if(watchdogThread.joinable()) watchdogThread.join();
 
     // Close stream
+    // BUGBUG investigate ownership; can another thread accessing this at the same time?
     stream = nullptr;
 
     spdlog::debug("DeviceBootloader closed, {}", duration_cast<milliseconds>(steady_clock::now() - t1).count());

--- a/src/pipeline/datatype/StreamMessageParser.cpp
+++ b/src/pipeline/datatype/StreamMessageParser.cpp
@@ -68,15 +68,15 @@ inline std::shared_ptr<T> parseDatatype(std::uint8_t* metadata, size_t size, std
     return tmp;
 }
 
-std::shared_ptr<RawBuffer> StreamMessageParser::parseMessage(streamPacketDesc_t* packet) {
-    int serializedObjectSize = readIntLE(packet->data + packet->length - 4);
-    auto objectType = static_cast<DatatypeEnum>(readIntLE(packet->data + packet->length - 8));
+std::shared_ptr<RawBuffer> StreamMessageParser::parseMessage(streamPacketDesc_t* const packet) {
+    const int serializedObjectSize = readIntLE(packet->data + packet->length - 4);
+    const auto objectType = static_cast<DatatypeEnum>(readIntLE(packet->data + packet->length - 8));
 
     if(serializedObjectSize < 0) {
         throw std::runtime_error("Bad packet, couldn't parse");
     }
-    std::uint32_t bufferLength = packet->length - 8 - serializedObjectSize;
-    auto* metadataStart = packet->data + bufferLength;
+    const std::uint32_t bufferLength = packet->length - 8 - serializedObjectSize;
+    auto* const metadataStart = packet->data + bufferLength;
 
     // copy data part
     std::vector<uint8_t> data(packet->data, packet->data + bufferLength);
@@ -155,15 +155,15 @@ std::shared_ptr<RawBuffer> StreamMessageParser::parseMessage(streamPacketDesc_t*
     throw std::runtime_error("Bad packet, couldn't parse");
 }
 
-std::shared_ptr<ADatatype> StreamMessageParser::parseMessageToADatatype(streamPacketDesc_t* packet) {
-    int serializedObjectSize = readIntLE(packet->data + packet->length - 4);
-    auto objectType = static_cast<DatatypeEnum>(readIntLE(packet->data + packet->length - 8));
+std::shared_ptr<ADatatype> StreamMessageParser::parseMessageToADatatype(streamPacketDesc_t* const packet) {
+    const int serializedObjectSize = readIntLE(packet->data + packet->length - 4);
+    const auto objectType = static_cast<DatatypeEnum>(readIntLE(packet->data + packet->length - 8));
 
     if(serializedObjectSize < 0) {
         throw std::runtime_error("Bad packet, couldn't parse");
     }
-    std::uint32_t bufferLength = packet->length - 8 - serializedObjectSize;
-    auto* metadataStart = packet->data + bufferLength;
+    const std::uint32_t bufferLength = packet->length - 8 - serializedObjectSize;
+    auto* const metadataStart = packet->data + bufferLength;
 
     // copy data part
     std::vector<uint8_t> data(packet->data, packet->data + bufferLength);

--- a/src/utility/Resources.cpp
+++ b/src/utility/Resources.cpp
@@ -245,6 +245,9 @@ std::function<void()> getLazyTarXzFunction(MTX& lazyMtx, CV& cv, BOOL& mutexAcqu
         {
             std::unique_lock<std::mutex> cvLock(mtxCv);
             mutexAcquired = true;
+            // manual unlock since notified thread would immediately block again, waiting
+            // for the notifying thread to release the lock https://en.cppreference.com/w/cpp/thread/condition_variable/notify_all
+            cvLock.unlock();
             cv.notify_all();
         }
 

--- a/src/xlink/XLinkStream.cpp
+++ b/src/xlink/XLinkStream.cpp
@@ -13,15 +13,14 @@ namespace dai {
 constexpr std::chrono::milliseconds XLinkStream::WAIT_FOR_STREAM_RETRY;
 constexpr int XLinkStream::STREAM_OPEN_RETRIES;
 
-XLinkStream::XLinkStream(const XLinkConnection& conn, const std::string& name, std::size_t maxWriteSize) : streamName(name) {
+XLinkStream::XLinkStream(const std::shared_ptr<XLinkConnection> conn, const std::string& name, std::size_t maxWriteSize) : connection(conn), streamName(name) {
     if(name.empty()) throw std::invalid_argument("Cannot create XLinkStream using empty stream name");
-    if(conn.getLinkId() == -1) throw std::invalid_argument("Cannot create XLinkStream using unconnected XLinkConnection");
+    if(!connection || connection->getLinkId() == -1) throw std::invalid_argument("Cannot create XLinkStream using unconnected XLinkConnection");
 
     streamId = INVALID_STREAM_ID;
 
     for(int retryCount = 0; retryCount < STREAM_OPEN_RETRIES; retryCount++) {
-        streamId = XLinkOpenStream(conn.getLinkId(), streamName.c_str(), static_cast<int>(maxWriteSize));
-
+        streamId = XLinkOpenStream(connection->getLinkId(), streamName.c_str(), static_cast<int>(maxWriteSize));
         if(streamId == INVALID_STREAM_ID) {
             // Give some time before continuing
             std::this_thread::sleep_for(WAIT_FOR_STREAM_RETRY);
@@ -34,13 +33,18 @@ XLinkStream::XLinkStream(const XLinkConnection& conn, const std::string& name, s
 }
 
 // Move constructor
-XLinkStream::XLinkStream(XLinkStream&& stream) : streamName(std::move(stream.streamName)) {
-    // Construct from 'stream' into current
-    // Just copy its streamId
-    streamId = stream.streamId;
+XLinkStream::XLinkStream(XLinkStream&& other)
+    : connection(std::move(other.connection)), streamName(std::exchange(other.streamName, {})), streamId(std::exchange(other.streamId, INVALID_STREAM_ID)) {
+    // Set other's streamId to INVALID_STREAM_ID to prevent closing
+}
 
-    // Set 'stream's streamId to INVALID_STREAM_ID to prevent closing
-    stream.streamId = INVALID_STREAM_ID;
+XLinkStream& XLinkStream::operator=(XLinkStream&& other) {
+    if(this != &other) {
+        connection = std::move(other.connection);
+        streamId = std::exchange(other.streamId, INVALID_STREAM_ID);
+        streamName = std::exchange(other.streamName, {});
+    }
+    return *this;
 }
 
 XLinkStream::~XLinkStream() {
@@ -48,6 +52,23 @@ XLinkStream::~XLinkStream() {
     if(streamId != INVALID_STREAM_ID) {
         XLinkCloseStream(streamId);
     }
+}
+
+StreamPacketDesc::StreamPacketDesc(StreamPacketDesc&& other) noexcept : streamPacketDesc_t{other.data, other.length} {
+    other.data = nullptr;
+    other.length = 0;
+}
+
+StreamPacketDesc& StreamPacketDesc::operator=(StreamPacketDesc&& other) noexcept {
+    if(this != &other) {
+        data = std::exchange(other.data, nullptr);
+        length = std::exchange(other.length, 0);
+    }
+    return *this;
+}
+
+StreamPacketDesc::~StreamPacketDesc() noexcept {
+    XLinkDeallocateMoveData(data, length);
 }
 
 ////////////////////
@@ -69,19 +90,27 @@ void XLinkStream::write(const std::vector<std::uint8_t>& data) {
 }
 
 void XLinkStream::read(std::vector<std::uint8_t>& data) {
-    streamPacketDesc_t* pPacket = nullptr;
-    auto status = XLinkReadData(streamId, &pPacket);
+    StreamPacketDesc packet;
+    const auto status = XLinkReadMoveData(streamId, &packet);
     if(status != X_LINK_SUCCESS) {
         throw XLinkReadError(status, streamName);
     }
-    data = std::vector<std::uint8_t>(pPacket->data, pPacket->data + pPacket->length);
-    XLinkReleaseData(streamId);
+    data = std::vector<std::uint8_t>(packet.data, packet.data + packet.length);
 }
 
 std::vector<std::uint8_t> XLinkStream::read() {
     std::vector<std::uint8_t> data;
     read(data);
     return data;
+}
+
+StreamPacketDesc XLinkStream::readMove() {
+    StreamPacketDesc packet;
+    const auto status = XLinkReadMoveData(streamId, &packet);
+    if(status != X_LINK_SUCCESS) {
+        throw XLinkReadError(status, streamName);
+    }
+    return packet;
 }
 
 // USE ONLY WHEN COPYING DATA AT LATER STAGES
@@ -145,18 +174,27 @@ bool XLinkStream::write(const std::vector<std::uint8_t>& data, std::chrono::mill
 }
 
 bool XLinkStream::read(std::vector<std::uint8_t>& data, std::chrono::milliseconds timeout) {
-    streamPacketDesc_t* pPacket = nullptr;
-    auto status = XLinkReadDataWithTimeout(streamId, &pPacket, static_cast<unsigned int>(timeout.count()));
+    StreamPacketDesc packet;
+    const auto status = XLinkReadMoveDataWithTimeout(streamId, &packet, static_cast<unsigned int>(timeout.count()));
     if(status == X_LINK_SUCCESS) {
-        data = std::vector<std::uint8_t>(pPacket->data, pPacket->data + pPacket->length);
-        XLinkReleaseData(streamId);
+        data = std::vector<std::uint8_t>(packet.data, packet.data + packet.length);
         return true;
     } else if(status == X_LINK_TIMEOUT) {
         return false;
     } else {
         throw XLinkReadError(status, streamName);
     }
-    return false;
+}
+
+bool XLinkStream::readMove(StreamPacketDesc& packet, const std::chrono::milliseconds timeout) {
+    const auto status = XLinkReadMoveDataWithTimeout(streamId, &packet, static_cast<unsigned int>(timeout.count()));
+    if(status == X_LINK_SUCCESS) {
+        return true;
+    } else if(status == X_LINK_TIMEOUT) {
+        return false;
+    } else {
+        throw XLinkReadError(status, streamName);
+    }
 }
 
 bool XLinkStream::readRaw(streamPacketDesc_t*& pPacket, std::chrono::milliseconds timeout) {


### PR DESCRIPTION
This PR is a limited set of changes needed to fix luxonis/depthai-core#257
It requires XLink move semantics https://github.com/luxonis/XLink/pull/29

- fix many thread/ownership issues for start/stop scenarios
- XLinkStream::readMove() for moving packet ownership
- fix XLinkStream move semantics
- removed all use of XLinkStream::readRaw as often leads to
  memory violations and/or memory leaks
- deprecate all XLinkStream::readRaw...() APIs

This PR is NOT a rearchitect of the classes/ownership of depthai-core. There are many opportunities for additional move-semantics, const correctness, RAII, etc. This PR does not address those.

This PR does NOT include an agnostic `RawBuffer` container (e.g. aligned vector)