### PR TITLE
Add spatialLocationCalculator output message to spatial detection network

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "2ae062fb9a446d23914256315b718f33a01f3de8")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "e23227b70384c20565c9cc1b32b923f4cfc7eadf")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
@@ -65,6 +65,13 @@ class SpatialDetectionNetwork : public NodeCRTP<DetectionNetwork, SpatialDetecti
     Output passthroughDepth{*this, "passthroughDepth", Output::Type::MSender, {{DatatypeEnum::ImgFrame, false}}};
 
     /**
+     * Output of SpatialLocationCalculator node, which is used internally by SpatialDetectionNetwork.
+     * Suitable when extra information is required from SpatialLocationCalculator node, e.g. minimum, maximum distance.
+     */
+    Output spatialLocationCalculatorOutput{
+        *this, "spatialLocationCalculatorOutput", Output::Type::MSender, {{DatatypeEnum::SpatialLocationCalculatorData, false}}};
+
+    /**
      * Specifies scale factor for detected bounding boxes.
      * @param scaleFactor Scale factor must be in the interval (0,1].
      */


### PR DESCRIPTION
Added `spatialLocationCalculatorOutput` message, which carries the underlying `SpatialLocationCalculator` node output for `SpatialDetectionNetwork`