### PR TITLE
Regression fixes for 2.14.0

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "2ae062fb9a446d23914256315b718f33a01f3de8")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "f503b7adfd44b696187b7825a12a134ded0ca3f3")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -17,6 +17,9 @@ class ColorCamera : public NodeCRTP<Node, ColorCamera, ColorCameraProperties> {
    public:
     constexpr static const char* NAME = "ColorCamera";
 
+   protected:
+    Properties& getProperties();
+
    private:
     std::shared_ptr<RawCameraControl> rawControl;
 

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -21,6 +21,9 @@ class StereoDepth : public NodeCRTP<Node, StereoDepth, StereoDepthProperties> {
      */
     enum class PresetMode : std::uint32_t { HIGH_ACCURACY, HIGH_DENSITY };
 
+   protected:
+    Properties& getProperties();
+
    private:
     PresetMode presetMode = PresetMode::HIGH_DENSITY;
     std::shared_ptr<RawStereoDepthConfig> rawConfig;

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstdint>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -26,6 +26,11 @@ ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeI
     setOutputRefs({&video, &preview, &still, &isp, &raw});
 }
 
+ColorCamera::Properties& ColorCamera::getProperties() {
+    properties.initialControl = *rawControl;
+    return properties;
+}
+
 // Set board socket to use
 void ColorCamera::setBoardSocket(dai::CameraBoardSocket boardSocket) {
     properties.boardSocket = boardSocket;

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -32,6 +32,11 @@ StereoDepth::StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeI
     setDefaultProfilePreset(presetMode);
 }
 
+StereoDepth::Properties& StereoDepth::getProperties() {
+    properties.initialConfig = *rawConfig;
+    return properties;
+}
+
 void StereoDepth::loadCalibrationData(const std::vector<std::uint8_t>& data) {
     (void)data;
     spdlog::warn("{} is deprecated. This function call is replaced by Pipeline::setCalibrationData under pipeline. ", __func__);


### PR DESCRIPTION
- Due to recent refactoring of properties `ColorCamera` and `StereoDepth` initial configs didn't work. (E.g. setting default confidence threshold etc.).
- Latest develop didn't compile with clang 13, `#include <memory>` was missing from `XLinkConnection`
- Added checks if input/output of StereoDepth node are connected. (A host side bug: https://github.com/luxonis/depthai-experiments/commit/4ce0a670526ef7c28e3b98a6c1eded5f923c4c14
exposed a crash when no output of Stereo was used/connected )
