### PR TITLE
add const ADatatype::getRaw(), Buffer::getData(); add copy+move Buffer::setData()

### DIFF
--- a/include/depthai/pipeline/datatype/ADatatype.hpp
+++ b/include/depthai/pipeline/datatype/ADatatype.hpp
@@ -18,7 +18,7 @@ class ADatatype {
     explicit ADatatype(std::shared_ptr<RawBuffer> r) : raw(std::move(r)) {}
     virtual ~ADatatype() = default;
     virtual std::shared_ptr<dai::RawBuffer> serialize() const = 0;
-    std::shared_ptr<RawBuffer> getRaw() {
+    std::shared_ptr<RawBuffer> getRaw() const {
         return raw;
     }
 };

--- a/include/depthai/pipeline/datatype/Buffer.hpp
+++ b/include/depthai/pipeline/datatype/Buffer.hpp
@@ -20,14 +20,20 @@ class Buffer : public ADatatype {
 
     // helpers
     /**
+     * @brief Get non-owning reference to internal buffer
      * @returns Reference to internal buffer
      */
-    std::vector<std::uint8_t>& getData();
+    std::vector<std::uint8_t>& getData() const;
 
     /**
      * @param data Copies data to internal buffer
      */
-    void setData(std::vector<std::uint8_t> data);
+    void setData(const std::vector<std::uint8_t>& data);
+
+    /**
+     * @param data Moves data to internal buffer
+     */
+    void setData(std::vector<std::uint8_t>&& data);
 };
 
 }  // namespace dai

--- a/src/pipeline/datatype/Buffer.cpp
+++ b/src/pipeline/datatype/Buffer.cpp
@@ -10,11 +10,15 @@ Buffer::Buffer() : ADatatype(std::make_shared<dai::RawBuffer>()) {}
 Buffer::Buffer(std::shared_ptr<dai::RawBuffer> ptr) : ADatatype(std::move(ptr)) {}
 
 // helpers
-std::vector<std::uint8_t>& Buffer::getData() {
+std::vector<std::uint8_t>& Buffer::getData() const {
     return raw->data;
 }
 
-void Buffer::setData(std::vector<std::uint8_t> data) {
+void Buffer::setData(const std::vector<std::uint8_t>& data) {
+    raw->data = data;
+}
+
+void Buffer::setData(std::vector<std::uint8_t>&& data) {
     raw->data = std::move(data);
 }
 


### PR DESCRIPTION
Adds `const` to two member methods, enables operation on const and constref objects
Also add/clarify the copy and move Buffer::setData() functions to ensure there is no fallback to internal copy+move when a single move should be used instead.

All 65 tests + examples pass. And I have been using these changes since ~7 December which had considerable testing over the last month.

Fixes luxonis/depthai-core#330