### PR TITLE
fix Win MSVC cmake INTERPROCEDURAL_OPTIMIZATION

### DIFF
--- a/cmake/Flags.cmake
+++ b/cmake/Flags.cmake
@@ -1,6 +1,8 @@
 ## setup compilation flags
-# conditionally applies flag. If flag is supported by current compiler, it will be added to compile options.
+include(CMakeParseArguments)
 include(CheckCXXCompilerFlag)
+
+# conditionally applies flag. If flag is supported by current compiler, it will be added to compile options.
 function(add_flag target flag)
     check_cxx_compiler_flag(${flag} FLAG_${flag})
     if (FLAG_${flag} EQUAL 1)
@@ -9,38 +11,71 @@ function(add_flag target flag)
 endfunction()
 
 function(add_default_flags target)
+    cmake_parse_arguments(ADF "LEAN" "" "" ${ARGN})
     if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang|GNU)$")
-        # enable those flags
-        add_flag(${target} -Wall)
-        add_flag(${target} -Wextra)
-        add_flag(${target} -Woverloaded-virtual)     # warn if you overload (not override) a virtual function
-        add_flag(${target} -Wformat=2)               # warn on security issues around functions that format output (ie printf)
-        add_flag(${target} -Wmisleading-indentation) # (only in GCC >= 6.0) warn if indentation implies blocks where blocks do not exist
-        add_flag(${target} -Wduplicated-cond)        # (only in GCC >= 6.0) warn if if / else chain has duplicated conditions
-        add_flag(${target} -Wduplicated-branches)    # (only in GCC >= 7.0) warn if if / else branches have duplicated code
-        add_flag(${target} -Wnull-dereference)       # (only in GCC >= 6.0) warn if a null dereference is detected
-        add_flag(${target} -Wdouble-promotion)       # (GCC >= 4.6, Clang >= 3.8) warn if float is implicit promoted to double
-        add_flag(${target} -Wsign-compare)
-        add_flag(${target} -Wtype-limits)            # size_t - size_t >= 0 -> always true
+        if(NOT ADF_LEAN)
+            # enable those flags
+            add_flag(${target} -Wall)
+            add_flag(${target} -Wextra)
+            add_flag(${target} -Woverloaded-virtual)     # warn if you overload (not override) a virtual function
+            add_flag(${target} -Wformat=2)               # warn on security issues around functions that format output (ie printf)
+            add_flag(${target} -Wmisleading-indentation) # (only in GCC >= 6.0) warn if indentation implies blocks where blocks do not exist
+            add_flag(${target} -Wduplicated-cond)        # (only in GCC >= 6.0) warn if if / else chain has duplicated conditions
+            add_flag(${target} -Wduplicated-branches)    # (only in GCC >= 7.0) warn if if / else branches have duplicated code
+            add_flag(${target} -Wnull-dereference)       # (only in GCC >= 6.0) warn if a null dereference is detected
+            add_flag(${target} -Wdouble-promotion)       # (GCC >= 4.6, Clang >= 3.8) warn if float is implicit promoted to double
+            add_flag(${target} -Wsign-compare)
+            add_flag(${target} -Wtype-limits)            # size_t - size_t >= 0 -> always true
 
-        # disable those flags
-        # add_flag(${target} -Wno-unused-command-line-argument)    # clang: warning: argument unused during compilation: '--coverage' [-Wunused-command-line-argument]
-        # add_flag(${target} -Wno-unused-parameter)    # prints too many useless warnings
-        # add_flag(${target} -Wno-format-nonliteral)   # prints way too many warnings from spdlog
-        # add_flag(${target} -Wno-gnu-zero-variadic-macro-arguments)   # https://stackoverflow.com/questions/21266380/is-the-gnu-zero-variadic-macro-arguments-safe-to-ignore
+            # disable those flags
+            # add_flag(${target} -Wno-unused-command-line-argument)    # clang: warning: argument unused during compilation: '--coverage' [-Wunused-command-line-argument]
+            # add_flag(${target} -Wno-unused-parameter)    # prints too many useless warnings
+            # add_flag(${target} -Wno-format-nonliteral)   # prints way too many warnings from spdlog
+            # add_flag(${target} -Wno-gnu-zero-variadic-macro-arguments)   # https://stackoverflow.com/questions/21266380/is-the-gnu-zero-variadic-macro-arguments-safe-to-ignore
 
-        # promote to errors
-        add_flag(${target} -Werror=self-assign-field)  # error if self assign - bugprone
-        add_flag(${target} -Werror=unused-lambda-capture)  # error if lambda capture is unused
-        add_flag(${target} -Werror=return-type)      # warning: control reaches end of non-void function [-Wreturn-type]
-        add_flag(${target} -Werror=non-virtual-dtor) # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
-        add_flag(${target} -Werror=sign-compare)     # warn the user if they compare a signed and unsigned numbers
-        add_flag(${target} -Werror=reorder)          # field '$1' will be initialized after field '$2'
-        add_flag(${target} -Werror=switch-enum)      # if switch case is missing - error
+            # promote to errors
+            add_flag(${target} -Werror=self-assign-field)  # error if self assign - bugprone
+            add_flag(${target} -Werror=unused-lambda-capture)  # error if lambda capture is unused
+            add_flag(${target} -Werror=return-type)      # warning: control reaches end of non-void function [-Wreturn-type]
+            add_flag(${target} -Werror=non-virtual-dtor) # warn the user if a class with virtual functions has a non-virtual destructor. This helps catch hard to track down memory errors
+            add_flag(${target} -Werror=sign-compare)     # warn the user if they compare a signed and unsigned numbers
+            add_flag(${target} -Werror=reorder)          # field '$1' will be initialized after field '$2'
+            add_flag(${target} -Werror=switch-enum)      # if switch case is missing - error
+        endif()
 
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         # using Visual Studio C++
-        # TODO(warchant): add flags https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#msvc
+        if(NOT ADF_LEAN)
+            # TODO(warchant): add flags https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#msvc
+        endif()
+
+        # disable INTERPROCEDURAL_OPTIMIZATION and enable /LTCG for issue https://github.com/luxonis/depthai-core/issues/334
+        if(WIN32)
+            get_target_property(_EXPORT ${target} WINDOWS_EXPORT_ALL_SYMBOLS)
+            if(_EXPORT)
+                if(CMAKE_BUILD_TYPE)
+                    string(TOUPPER "_${CMAKE_BUILD_TYPE}" _BUILD_TYPE)
+                else()
+                    set(_BUILD_TYPE "")
+                endif()
+                set(_PROP_NAME INTERPROCEDURAL_OPTIMIZATION${_BUILD_TYPE})
+                get_property(_PROP_SET TARGET ${target} PROPERTY ${_PROP_NAME} SET)
+                if(NOT _PROP_SET)
+                    set(_PROP_NAME INTERPROCEDURAL_OPTIMIZATION)
+                endif()
+                get_target_property(_INTER_OPT ${target} ${_PROP_NAME})
+                if(_INTER_OPT)
+                    set_target_properties(${target} PROPERTIES ${_PROP_NAME} OFF)
+                    # check_linker_flag() only available in cmake 3.18+
+                    target_link_options(${target} PRIVATE /LTCG)
+                endif()
+                unset(_BUILD_TYPE)
+                unset(_INTER_OPT)
+                unset(_PROP_NAME)
+                unset(_PROP_SET)
+            endif()
+            unset(_EXPORT)
+        endif()
     endif()
 
 endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(Sanitizers)
 # Create utility library
 add_library(utility utility/utility.cpp)
 target_include_directories(utility PUBLIC "utility")
-
+add_default_flags(utility LEAN)
 target_link_libraries(utility FP16::fp16 ${OpenCV_LIBS})
 
 # Helper for adding new examples
@@ -16,6 +16,7 @@ function(dai_add_example example_name example_src enable_test)
 
     # Add example
     add_executable(${example_name} ${example_src})
+    add_default_flags(${example_name} LEAN)
     target_link_libraries(${example_name} PRIVATE utility depthai::opencv ${OpenCV_LIBS})
 
     # Add sanitizers for example

--- a/examples/FeatureTracker/feature_tracker.cpp
+++ b/examples/FeatureTracker/feature_tracker.cpp
@@ -37,7 +37,7 @@ class FeatureTrackerDrawer {
             std::deque<dai::Point2f>& path = trackedFeaturesPath.at(currentID);
 
             path.push_back(currentFeature.position);
-            while(path.size() > std::max(1, trackedFeaturesPathLength)) {
+            while(path.size() > std::max<unsigned int>(1, trackedFeaturesPathLength)) {
                 path.pop_front();
             }
         }
@@ -61,7 +61,7 @@ class FeatureTrackerDrawer {
 
         for(auto& featurePath : trackedFeaturesPath) {
             std::deque<dai::Point2f>& path = featurePath.second;
-            int j = 0;
+            unsigned int j = 0;
             for(j = 0; j < path.size() - 1; j++) {
                 auto src = cv::Point(path[j].x, path[j].y);
                 auto dst = cv::Point(path[j + 1].x, path[j + 1].y);

--- a/examples/MobileNet/mono_mobilenet.cpp
+++ b/examples/MobileNet/mono_mobilenet.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/MobileNet/rgb_mobilenet.cpp
+++ b/examples/MobileNet/rgb_mobilenet.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/MobileNet/rgb_mobilenet_4k.cpp
+++ b/examples/MobileNet/rgb_mobilenet_4k.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/MobileNet/video_mobilenet.cpp
+++ b/examples/MobileNet/video_mobilenet.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/ObjectTracker/object_tracker.cpp
+++ b/examples/ObjectTracker/object_tracker.cpp
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
             int x2 = roi.bottomRight().x;
             int y2 = roi.bottomRight().y;
 
-            int labelIndex = t.label;
+            uint32_t labelIndex = t.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/ObjectTracker/object_tracker_video.cpp
+++ b/examples/ObjectTracker/object_tracker_video.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];
@@ -173,7 +173,7 @@ int main(int argc, char** argv) {
             int x2 = roi.bottomRight().x;
             int y2 = roi.bottomRight().y;
 
-            int labelIndex = t.label;
+            uint32_t labelIndex = t.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/ObjectTracker/spatial_object_tracker.cpp
+++ b/examples/ObjectTracker/spatial_object_tracker.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
             int x2 = roi.bottomRight().x;
             int y2 = roi.bottomRight().y;
 
-            int labelIndex = t.label;
+            uint32_t labelIndex = t.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/SpatialDetection/spatial_mobilenet.cpp
+++ b/examples/SpatialDetection/spatial_mobilenet.cpp
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/SpatialDetection/spatial_mobilenet_mono.cpp
+++ b/examples/SpatialDetection/spatial_mobilenet_mono.cpp
@@ -142,7 +142,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * rectifiedRight.cols;
             int y2 = detection.ymax * rectifiedRight.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/SpatialDetection/spatial_tiny_yolo.cpp
+++ b/examples/SpatialDetection/spatial_tiny_yolo.cpp
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/Yolo/tiny_yolo.cpp
+++ b/examples/Yolo/tiny_yolo.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/mixed/mono_depth_mobilenetssd.cpp
+++ b/examples/mixed/mono_depth_mobilenetssd.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/mixed/rgb_encoding_mobilenet.cpp
+++ b/examples/mixed/rgb_encoding_mobilenet.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
             int x2 = detection.xmax * frame.cols;
             int y2 = detection.ymax * frame.rows;
 
-            int labelIndex = detection.label;
+            uint32_t labelIndex = detection.label;
             std::string labelStr = to_string(labelIndex);
             if(labelIndex < labelMap.size()) {
                 labelStr = labelMap[labelIndex];

--- a/examples/mixed/rgb_encoding_mono_mobilenet.cpp
+++ b/examples/mixed/rgb_encoding_mono_mobilenet.cpp
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
                 int x2 = detection.xmax * monoRight->getResolutionHeight() + offsetX;
                 int y2 = detection.ymax * monoRight->getResolutionHeight();
 
-                int labelIndex = detection.label;
+                uint32_t labelIndex = detection.label;
                 std::string labelStr = to_string(labelIndex);
                 if(labelIndex < labelMap.size()) {
                     labelStr = labelMap[labelIndex];
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
                 int x2 = detection.xmax * frameManip.cols;
                 int y2 = detection.ymax * frameManip.rows;
 
-                int labelIndex = detection.label;
+                uint32_t labelIndex = detection.label;
                 std::string labelStr = to_string(labelIndex);
                 if(labelIndex < labelMap.size()) {
                     labelStr = labelMap[labelIndex];

--- a/examples/mixed/rgb_encoding_mono_mobilenet_depth.cpp
+++ b/examples/mixed/rgb_encoding_mono_mobilenet_depth.cpp
@@ -139,7 +139,7 @@ int main(int argc, char** argv) {
                 int x2 = detection.xmax * monoRight->getResolutionHeight() + offsetX;
                 int y2 = detection.ymax * monoRight->getResolutionHeight();
 
-                int labelIndex = detection.label;
+                uint32_t labelIndex = detection.label;
                 std::string labelStr = to_string(labelIndex);
                 if(labelIndex < labelMap.size()) {
                     labelStr = labelMap[labelIndex];
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
                 int x2 = detection.xmax * monoRight->getResolutionHeight() + offsetX;
                 int y2 = detection.ymax * monoRight->getResolutionHeight();
 
-                int labelIndex = detection.label;
+                uint32_t labelIndex = detection.label;
                 std::string labelStr = to_string(labelIndex);
                 if(labelIndex < labelMap.size()) {
                     labelStr = labelMap[labelIndex];
@@ -183,7 +183,7 @@ int main(int argc, char** argv) {
                 int x2 = detection.xmax * frameManip.cols;
                 int y2 = detection.ymax * frameManip.rows;
 
-                int labelIndex = detection.label;
+                uint32_t labelIndex = detection.label;
                 std::string labelStr = to_string(labelIndex);
                 if(labelIndex < labelMap.size()) {
                     labelStr = labelMap[labelIndex];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ function(dai_add_test test_name test_src)
 
     # Create test executable
     add_executable(${test_name} ${test_src})
+    add_default_flags(${test_name} LEAN)
 
     # Add to clangformat target
     if(COMMAND target_clangformat_setup)

--- a/tests/src/bootloader_config_test.cpp
+++ b/tests/src/bootloader_config_test.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Bootloader Config") {
     config.setStaticIPv4(ipv4, ipv4Mask, ipv4Gateway);
 
     std::array<uint8_t, 4> ipv4InMemory = {192, 168, 1, 150};
-    for(int i = 0; i < ipv4InMemory.size(); i++) {
+    for(size_t i = 0; i < ipv4InMemory.size(); i++) {
         REQUIRE(ipv4InMemory[i] == reinterpret_cast<uint8_t*>(&config.network.ipv4)[i]);
     }
 

--- a/tests/src/multiple_devices_test.cpp
+++ b/tests/src/multiple_devices_test.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <tuple>
 
 // Inludes common necessary includes for development using depthai library
 #include "depthai/depthai.hpp"
@@ -51,6 +52,7 @@ int main() {
 
             // Optional delay between device connection
             // if(deviceCounter) this_thread::sleep_for(1s);
+            std::ignore = deviceCounter;
 
             auto device = make_shared<dai::Device>(pipeline, dev, dai::UsbSpeed::SUPER);
             device->getOutputQueue("rgb", 4, false);

--- a/tests/src/serialization_test.cpp
+++ b/tests/src/serialization_test.cpp
@@ -24,10 +24,10 @@ TEST_CASE("Roundtrip") {
         }
         printf("\n");
 
-        REQUIRE(des.width.value() == 0xa0a0a0a0);
-        REQUIRE(des.height.value() == 0xa0a0a0a0);
-        REQUIRE(des.outWidth.value() == 0x55555555);
-        REQUIRE(des.outHeight.value() == 0x55555555);
+        REQUIRE(des.width.value() == (int)0xa0a0a0a0);
+        REQUIRE(des.height.value() == (int)0xa0a0a0a0);
+        REQUIRE(des.outWidth.value() == (int)0x55555555);
+        REQUIRE(des.outHeight.value() == (int)0x55555555);
         REQUIRE(des.numFramesPool == 42);
     }
 
@@ -41,10 +41,10 @@ TEST_CASE("Roundtrip") {
         }
         printf("\n");
 
-        REQUIRE(des.width.value() == 0xa0a0a0a0);
-        REQUIRE(des.height.value() == 0xa0a0a0a0);
-        REQUIRE(des.outWidth.value() == 0x55555555);
-        REQUIRE(des.outHeight.value() == 0x55555555);
+        REQUIRE(des.width.value() == (int)0xa0a0a0a0);
+        REQUIRE(des.height.value() == (int)0xa0a0a0a0);
+        REQUIRE(des.outWidth.value() == (int)0x55555555);
+        REQUIRE(des.outHeight.value() == (int)0x55555555);
         REQUIRE(des.numFramesPool == 42);
     }
 }


### PR DESCRIPTION
Workaround for Windows MSVC incompatibility with BUILD_SHARED_LIBS + WINDOWS_EXPORT_ALL_SYMBOLS + INTERPROCEDURAL_OPTIMIZATION
Fixes luxonis/depthai-core#334

Approach:  used the existing `add_default_flags()` function as the issue is about flags and that function was used in all the needed places.

I'm interested to see the CI test it across the matrix. 🤔
Passes all tests and examples on my Windows MSVC x64 build, debug+release, with settings...
```cmake
set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON CACHE BOOL "")
set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF CACHE BOOL "")
```