### PR TITLE
PipelineImpl::create() use make_shared, not raw new()

### DIFF
--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -80,7 +80,7 @@ class PipelineImpl {
         // Get unique id for this new node
         auto id = getNextUniqueId();
         // Create and store the node in the map
-        auto node = std::shared_ptr<N>(new N(itself, id));
+        auto node = std::make_shared<N>(itself, id);
         nodeMap[id] = node;
         // Return shared pointer to this node
         return node;


### PR DESCRIPTION
Fixes luxonis/depthai-core#340

all test+examples pass on my local Windows MSVC x64 shared_lib builds.
Interested to see the results of the CI matrix. 😊