### PR TITLE
Added watchdog protection

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,8 +8,8 @@ hunter_config(
 hunter_config(
     XLink
     VERSION "luxonis-2021.4-master"
-    URL "https://github.com/luxonis/XLink/archive/8a2ea2741b70dc5179952ad52aa80e126240e852.tar.gz"
-    SHA1 "86c683f72092e4830b960cf5d7d3de079b1549e4"
+    URL "https://github.com/luxonis/XLink/archive/7bad147f6d45960d79b545d5575cc1a72fc85c5e.tar.gz"
+    SHA1 "76dc0b131cdb821fedc8fa94400ba49a41d8e8d3"
 )
 
 hunter_config(

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,8 +8,8 @@ hunter_config(
 hunter_config(
     XLink
     VERSION "luxonis-2021.4-master"
-    URL "https://github.com/luxonis/XLink/archive/7bad147f6d45960d79b545d5575cc1a72fc85c5e.tar.gz"
-    SHA1 "76dc0b131cdb821fedc8fa94400ba49a41d8e8d3"
+    URL "https://github.com/luxonis/XLink/archive/38393eaa77c84bbb2d124a9b2bcb26ea3b106ba7.tar.gz"
+    SHA1 "1b6902a099947ff7c32a5519f7e8deec071fe83f"
 )
 
 hunter_config(

--- a/src/utility/Resources.cpp
+++ b/src/utility/Resources.cpp
@@ -368,15 +368,20 @@ std::vector<std::uint8_t> Resources::getDeviceFirmware(bool usb2Mode, OpenVINO::
 }
 
 std::vector<std::uint8_t> createPrebootHeader(const std::vector<uint8_t>& payload, uint32_t magic1, uint32_t magic2) {
-    const std::uint8_t HEADER[] = {77,
-                                   65,
-                                   50,
-                                   120,
+    // clang-format off
+    const std::uint8_t HEADER[] = {77, 65, 50, 120,
+                                   // WD Protection
+                                   // TODO(themarpe) - expose timings                             
+                                   0x9A, 0xA8, 0x00, 0x32, 0x20, 0xAD, 0xDE, 0xD0, 0xF1,
+                                   0x9A, 0x9C, 0x00, 0x32, 0x20, 0xFF, 0xFF, 0xFF, 0xFF,
+                                   0x9A, 0xA8, 0x00, 0x32, 0x20, 0xAD, 0xDE, 0xD0, 0xF1,
+                                   0x9A, 0xA4, 0x00, 0x32, 0x20, 0x01, 0x00, 0x00, 0x00,
                                    0x8A,
                                    static_cast<uint8_t>((magic1 >> 0) & 0xFF),
                                    static_cast<uint8_t>((magic1 >> 8) & 0xFF),
                                    static_cast<uint8_t>((magic1 >> 16) & 0xFF),
                                    static_cast<uint8_t>((magic1 >> 24) & 0xFF)};
+    // clang-format on
 
     // Store the constructed preboot information
     std::vector<std::uint8_t> prebootHeader;


### PR DESCRIPTION
Increases robustness when interfacing with USB devices. Protects against processes that exit before whole FW is sent to device at boot stage and removes the need to power cycle the device in that case.

Includes https://github.com/luxonis/XLink/pull/39 changes which address similar case but at MXID retrieval step.

Fixes: #291

CC: @diablodale for giving it a try on how it pairs with #291
EDIT: And on #300 