### PR TITLE
Use focal length from calibration intrinsics for fisheye cameras 

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a367a99082def6e82292ea1b18c3c5e7f730d302")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "20b10069ee4ab7d93ca2a6ed129696092e4c7e0e")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "9349b07517306b353cfbfeeb1be2c9746f9eda8e")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a367a99082def6e82292ea1b18c3c5e7f730d302")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -317,6 +317,12 @@ class StereoDepth : public NodeCRTP<Node, StereoDepth, StereoDepthProperties> {
      * @param mode Stereo depth preset mode
      */
     void setDefaultProfilePreset(PresetMode mode);
+
+    /**
+     * Sets a default preset based on specified option.
+     * @param mode Stereo depth preset mode
+     */
+    void setFocalLengthFromCalibration(bool focalLengthFromCalibration);
 };
 
 }  // namespace node

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -171,6 +171,10 @@ void StereoDepth::setPostProcessingHardwareResources(int numShaves, int numMemor
     properties.numPostProcessingMemorySlices = numMemorySlices;
 }
 
+void StereoDepth::setFocalLengthFromCalibration(bool focalLengthFromCalibration) {
+    properties.focalLengthFromCalibration = focalLengthFromCalibration;
+}
+
 void StereoDepth::setDefaultProfilePreset(PresetMode mode) {
     presetMode = mode;
     switch(presetMode) {

--- a/tests/src/multiple_devices_test.cpp
+++ b/tests/src/multiple_devices_test.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include <atomic>
+#include <iostream>
 #include <vector>
 
 // Inludes common necessary includes for development using depthai library
@@ -46,9 +46,8 @@ int main() {
         this_thread::sleep_for(500ms);
     } while(availableDevices.size() <= 1 && steady_clock::now() - t1 <= 3s);
 
-    for(const auto& dev : availableDevices){
-        threads.push_back(thread([dev, pipeline, deviceCounter](){
-
+    for(const auto& dev : availableDevices) {
+        threads.push_back(thread([dev, pipeline, deviceCounter]() {
             // Optional delay between device connection
             // if(deviceCounter) this_thread::sleep_for(1s);
 
@@ -83,18 +82,17 @@ int main() {
                     counter++;
                 }
 
-                if(counter < NUM_MESSAGES){
+                if(counter < NUM_MESSAGES) {
                     finished = false;
                 }
             }
-
         }
 
         std::this_thread::sleep_for(1ms);
     }
 
     // Join device threads
-    for(auto& thread : threads){
+    for(auto& thread : threads) {
         thread.join();
     }
 


### PR DESCRIPTION
Use focal length from intrinsics for fisheye lenses.
Can be explicitly overridden: `setFocalLengthFromCalibration(bool)`
Shared: https://github.com/luxonis/depthai-shared/pull/79