### PR TITLE
Specify minimum nlohmann version

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "9349b07517306b353cfbfeeb1be2c9746f9eda8e")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "3d9de41af6dc3ea065110836fe05fe2d895795b9")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/depthaiDependencies.cmake
+++ b/cmake/depthaiDependencies.cmake
@@ -52,7 +52,7 @@ endif()
 find_package(Threads ${_QUIET} REQUIRED)
 
 # Nlohmann JSON
-find_package(nlohmann_json ${_QUIET} CONFIG REQUIRED)
+find_package(nlohmann_json 3.9.0 ${_QUIET} CONFIG REQUIRED)
 
 # libnop for serialization
 find_package(libnop ${_QUIET} CONFIG REQUIRED)


### PR DESCRIPTION
Shared PR: https://github.com/luxonis/depthai-shared/pull/80

Specifies minimum supported nlohmann json version for both CMake and non-CMake usage (in shared PR)

Fixes: #349 #265 