### PR TITLE
OpenVINO Blob structure

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "da3d84edfae44b9057e6c8b1aa0afcbb28e04092")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "e26f3cb5f99331a020212a1780373e212c1350fb")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/openvino/OpenVINO.hpp
+++ b/include/depthai/openvino/OpenVINO.hpp
@@ -4,8 +4,11 @@
 #include <exception>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include "depthai-shared/common/TensorInfo.hpp"
 
 namespace dai {
 
@@ -14,6 +17,29 @@ class OpenVINO {
    public:
     /// OpenVINO Version supported version information
     enum Version { VERSION_2020_3, VERSION_2020_4, VERSION_2021_1, VERSION_2021_2, VERSION_2021_3, VERSION_2021_4 };
+
+    /// OpenVINO Blob
+    struct Blob {
+        /**
+         * @brief Construct a new Blob from data in memory
+         *
+         * @param data In memory blob
+         */
+        Blob(std::vector<uint8_t> data);
+        /**
+         * @brief Construct a new Blob by loading from a filesystem path
+         *
+         * @param path Filesystem path to the blob
+         */
+        Blob(const std::string& path);
+        Version version;
+        std::unordered_map<std::string, TensorInfo> networkInputs;
+        std::unordered_map<std::string, TensorInfo> networkOutputs;
+        uint32_t stageCount = 0;
+        uint32_t numShaves = 0;
+        uint32_t numSlices = 0;
+        std::vector<uint8_t> data;
+    };
 
     /// Main OpenVINO version
     constexpr static const Version DEFAULT_VERSION = VERSION_2021_4;

--- a/include/depthai/openvino/OpenVINO.hpp
+++ b/include/depthai/openvino/OpenVINO.hpp
@@ -32,12 +32,20 @@ class OpenVINO {
          * @param path Filesystem path to the blob
          */
         Blob(const std::string& path);
+
+        /// OpenVINO version
         Version version;
+        /// Map of input names to additional information
         std::unordered_map<std::string, TensorInfo> networkInputs;
+        /// Map of output names to additional information
         std::unordered_map<std::string, TensorInfo> networkOutputs;
+        /// Number of network stages
         uint32_t stageCount = 0;
+        /// Number of shaves the blob was compiled for
         uint32_t numShaves = 0;
+        /// Number of CMX slices the blob was compiled for
         uint32_t numSlices = 0;
+        /// Blob data
         std::vector<uint8_t> data;
     };
 

--- a/include/depthai/pipeline/AssetManager.hpp
+++ b/include/depthai/pipeline/AssetManager.hpp
@@ -74,6 +74,7 @@ class AssetManager /*: public Assets*/ {
      * @returns Shared pointer to asset
      */
     std::shared_ptr<dai::Asset> set(const std::string& key, const std::vector<std::uint8_t>& data, int alignment = 64);
+    std::shared_ptr<dai::Asset> set(const std::string& key, std::vector<std::uint8_t>&& data, int alignment = 64);
 
     /**
      * @returns Asset assigned to the specified key or a nullptr otherwise

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -66,6 +66,14 @@ class NeuralNetwork : public NodeCRTP<Node, NeuralNetwork, NeuralNetworkProperti
     void setBlobPath(const std::string& path);
 
     /**
+     * Load network blob into assets and use once pipeline is started.
+     *
+     * Throws if blob isn't valid
+     * @param blob Network blob
+     */
+    void setBlob(OpenVINO::Blob blob);
+
+    /**
      * Specifies how many frames will be available in the pool
      * @param numFrames How many frames will pool have
      */

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -60,7 +60,7 @@ class NeuralNetwork : public NodeCRTP<Node, NeuralNetwork, NeuralNetworkProperti
     /**
      * Load network blob into assets and use once pipeline is started.
      *
-     * Throws if file doesn't exist or isn't a valid network blob.
+     * @throws Error if file doesn't exist or isn't a valid network blob.
      * @param path Path to network blob
      */
     void setBlobPath(const std::string& path);
@@ -68,7 +68,6 @@ class NeuralNetwork : public NodeCRTP<Node, NeuralNetwork, NeuralNetworkProperti
     /**
      * Load network blob into assets and use once pipeline is started.
      *
-     * Throws if blob isn't valid
      * @param blob Network blob
      */
     void setBlob(OpenVINO::Blob blob);

--- a/src/openvino/BlobReader.cpp
+++ b/src/openvino/BlobReader.cpp
@@ -26,7 +26,9 @@ namespace {
 
 template <typename T>
 T readFromBlob(const std::vector<std::uint8_t>& blob, uint32_t& offset) {
-    assert(offset + sizeof(T) <= blob.size());
+    if(offset + sizeof(T) > blob.size()){
+        throw std::logic_error("BlobReader error: Filesize is less than blob specifies. Likely corrupted");
+    }
 
     auto srcPtr = blob.data() + offset;
     offset += sizeof(T);
@@ -51,6 +53,10 @@ void BlobReader::parse(const std::vector<std::uint8_t>& blob) {
 
     if(blobHeader.magic_number != BLOB_MAGIC_NUMBER) {
         throw std::logic_error("BlobReader error: File does not seem to be a supported neural network blob");
+    }
+
+    if(blob.size() < blobHeader.file_size) {
+        throw std::logic_error("BlobReader error: Filesize is less than blob specifies. Likely corrupted");
     }
 
     const auto readIO = [this, &blob](uint32_t& ioSectionOffset, uint32_t idx) {

--- a/src/openvino/BlobReader.cpp
+++ b/src/openvino/BlobReader.cpp
@@ -7,6 +7,8 @@
 
 #include "BlobReader.hpp"
 
+#include <spdlog/fmt/fmt.h>
+
 #include <cassert>
 #include <memory>
 #include <sstream>
@@ -32,6 +34,10 @@ T readFromBlob(const std::vector<std::uint8_t>& blob, uint32_t& offset) {
     return *reinterpret_cast<const T*>(srcPtr);
 }
 
+bool isIOShapeName(std::string name) {
+    return name.find("@shape") != std::string::npos;
+}
+
 }  // namespace
 
 void BlobReader::parse(const std::vector<std::uint8_t>& blob) {
@@ -47,108 +53,73 @@ void BlobReader::parse(const std::vector<std::uint8_t>& blob) {
         throw std::logic_error("BlobReader error: File does not seem to be a supported neural network blob");
     }
 
-    //// TODO(themarpe) - add support for getting back some basic network information
+    const auto readIO = [this, &blob](uint32_t& ioSectionOffset, uint32_t idx) {
+        auto ioIdx = readFromBlob<uint32_t>(blob, ioSectionOffset);
+        if(ioIdx != idx) {
+            throw std::runtime_error(
+                fmt::format("BlobReader failed on I/O processing, its' ioIdx parameter (which is {}) is "
+                            "different from its' processing order (which is {})",
+                            ioIdx,
+                            idx));
+        }
 
-    // _inputInfo.totalSize = _blobHeader.inputs_size;
-    // _outputInfo.totalSize = _blobHeader.outputs_size;
-    //
-    // auto inputInfoSecOffset = _blobHeader.input_info_section_offset;
-    // for (uint32_t i = 0; i < _blobHeader.inputs_count; i++) {
-    //     auto ioIdx = readFromBlob<uint32_t>(blob, inputInfoSecOffset);
-    //     assert(ioIdx == i);
-    //
-    //     auto ioBufferOffset = readFromBlob<int32_t>(blob, inputInfoSecOffset);
-    //
-    //     auto nameLength = readFromBlob<uint32_t>(blob, inputInfoSecOffset);
-    //     std::string inputName(nameLength, 0);
-    //     for (auto& c : inputName) {
-    //         c = readFromBlob<char>(blob, inputInfoSecOffset);
-    //     }
-    //
-    //     // Truncate zeros
-    //     inputName = inputName.c_str();
-    //
-    //     auto dataType = readFromBlob<DataType>(blob, inputInfoSecOffset);
-    //     auto orderCode = readFromBlob<uint32_t>(blob, inputInfoSecOffset);
-    //
-    //     auto numDims = readFromBlob<uint32_t>(blob, inputInfoSecOffset);
-    //
-    //     auto dimsOrder = DimsOrder::fromCode(orderCode);
-    //     auto perm = dimsOrder.toPermutation();
-    //     assert(perm.size() == numDims);
-    //
-    //     auto dimsLocation = readFromBlob<Location>(blob, inputInfoSecOffset);
-    //     VPU_THROW_UNLESS(dimsLocation == Location::Blob,
-    //         "BlobReader error while parsing {} input data: only Blob location for input shape is supported, but {} was given",
-    //         inputName, dimsLocation);
-    //     auto dimsOffset = _blobHeader.const_data_section_offset + readFromBlob<uint32_t>(blob, inputInfoSecOffset);
-    //
-    //     // Skip strides' location and offset
-    //     inputInfoSecOffset += 2 * sizeof(uint32_t);
-    //
-    //     DimValues vpuDims;
-    //
-    //     for (int i = 0; i < perm.size(); ++i) {
-    //         vpuDims.set(perm[i], readFromBlob<uint32_t>(blob, dimsOffset));
-    //     }
-    //
-    //     ie::TensorDesc ieDesc = DataDesc(dataType, dimsOrder, vpuDims).toTensorDesc();
-    //     ie::Data inputData(inputName, ieDesc);
-    //
-    //     ie::InputInfo input;
-    //     input.setInputData(std::make_shared<ie::Data>(inputData));
-    //
-    //     _networkInputs[input.name()]    = std::make_shared<ie::InputInfo>(input);
-    //     _inputInfo.offset[input.name()] = ioBufferOffset;
-    // }
-    //
-    // auto outputInfoSecOffset = _blobHeader.output_info_section_offset;
-    // for (size_t i = 0; i < _blobHeader.outputs_count; i++) {
-    //     auto ioIdx = readFromBlob<uint32_t>(blob, outputInfoSecOffset);
-    //     IE_ASSERT(ioIdx == i);
-    //
-    //     auto ioBufferOffset = readFromBlob<int32_t>(blob, outputInfoSecOffset);
-    //
-    //     auto nameLength = readFromBlob<uint32_t>(blob, outputInfoSecOffset);
-    //     std::string outputName(nameLength, 0);
-    //     for (auto& c : outputName) {
-    //         c = readFromBlob<char>(blob, outputInfoSecOffset);
-    //     }
-    //
-    //     // Truncate zeros
-    //     outputName = outputName.c_str();
-    //
-    //     auto dataType = readFromBlob<DataType>(blob, outputInfoSecOffset);
-    //     auto orderCode = readFromBlob<uint32_t>(blob, outputInfoSecOffset);
-    //
-    //     auto numDims = readFromBlob<uint32_t>(blob, outputInfoSecOffset);
-    //
-    //
-    //     auto dimsOrder = DimsOrder::fromCode(orderCode);
-    //     auto perm = dimsOrder.toPermutation();
-    //     IE_ASSERT(perm.size() == numDims);
-    //
-    //     auto dimsLocation = readFromBlob<Location>(blob, outputInfoSecOffset);
-    //     VPU_THROW_UNLESS(dimsLocation == Location::Blob,
-    //         "BlobReader error while parsing {} output data: only Blob location for output shape is supported, but {} was given",
-    //         outputName, dimsLocation);
-    //     auto dimsOffset = _blobHeader.const_data_section_offset + readFromBlob<uint32_t>(blob, outputInfoSecOffset);
-    //
-    //     // Skip strides' location and offset
-    //     outputInfoSecOffset += 2 * sizeof(uint32_t);
-    //
-    //     DimValues vpuDims;
-    //
-    //     for (int i = 0; i < perm.size(); ++i) {
-    //         vpuDims.set(perm[i], readFromBlob<uint32_t>(blob, dimsOffset));
-    //     }
-    //
-    //     ie::TensorDesc ieDesc = DataDesc(dataType, dimsOrder, vpuDims).toTensorDesc();
-    //     ie::Data outputData(outputName, ieDesc);
-    //
-    //     _networkOutputs[outputData.getName()]    = std::make_shared<ie::Data>(outputData);
-    //     _outputInfo.offset[outputData.getName()] = ioBufferOffset;
-    // }
+        auto ioBufferOffset = readFromBlob<int32_t>(blob, ioSectionOffset);
+
+        auto nameLength = readFromBlob<uint32_t>(blob, ioSectionOffset);
+        std::string ioName(nameLength, 0);
+        for(auto& c : ioName) {
+            c = readFromBlob<char>(blob, ioSectionOffset);
+        }
+
+        // Truncate zeros
+        ioName = ioName.c_str();
+
+        auto dataType = static_cast<TensorInfo::DataType>(readFromBlob<int32_t>(blob, ioSectionOffset));
+        auto orderCode = static_cast<TensorInfo::StorageOrder>(readFromBlob<uint32_t>(blob, ioSectionOffset));
+
+        auto numDims = readFromBlob<uint32_t>(blob, ioSectionOffset);
+
+        // ignore
+        readFromBlob<int32_t>(blob, ioSectionOffset);
+
+        auto dimsOffset = blobHeader.const_data_section_offset + readFromBlob<uint32_t>(blob, ioSectionOffset);
+
+        // Skip strides' location and offset
+        ioSectionOffset += 2 * sizeof(uint32_t);
+
+        std::vector<unsigned> dims;
+        for(unsigned i = 0; i < numDims; ++i) {
+            dims.push_back(readFromBlob<uint32_t>(blob, dimsOffset));
+        }
+
+        TensorInfo io;
+        io.numDimensions = numDims;
+        io.dims = dims;
+        io.name = ioName;
+        io.offset = ioBufferOffset;
+        io.order = orderCode;
+        io.dataType = dataType;
+
+        return io;
+    };
+
+    auto inputInfoSecOffset = blobHeader.input_info_section_offset;
+    for(uint32_t i = 0; i < blobHeader.inputs_count; i++) {
+        const auto processedInput = readIO(inputInfoSecOffset, i);
+        if(!isIOShapeName(processedInput.name)) {
+            // Add to inputs
+            networkInputs[processedInput.name] = processedInput;
+        }
+    }
+
+    auto outputInfoSecOffset = blobHeader.output_info_section_offset;
+    for(uint32_t i = 0; i < blobHeader.outputs_count; i++) {
+        const auto processedOutput = readIO(outputInfoSecOffset, i);
+        if(!isIOShapeName(processedOutput.name)) {
+            // Add to inputs
+            networkOutputs[processedOutput.name] = processedOutput;
+        }
+    }
 }
 
 }  // namespace dai

--- a/src/openvino/BlobReader.cpp
+++ b/src/openvino/BlobReader.cpp
@@ -27,7 +27,7 @@ namespace {
 template <typename T>
 T readFromBlob(const std::vector<std::uint8_t>& blob, uint32_t& offset) {
     if(offset + sizeof(T) > blob.size()){
-        throw std::logic_error("BlobReader error: Filesize is less than blob specifies. Likely corrupted");
+        throw std::length_error("BlobReader error: Filesize is less than blob specifies. Likely corrupted");
     }
 
     auto srcPtr = blob.data() + offset;
@@ -56,7 +56,7 @@ void BlobReader::parse(const std::vector<std::uint8_t>& blob) {
     }
 
     if(blob.size() < blobHeader.file_size) {
-        throw std::logic_error("BlobReader error: Filesize is less than blob specifies. Likely corrupted");
+        throw std::length_error("BlobReader error: Filesize is less than blob specifies. Likely corrupted");
     }
 
     const auto readIO = [this, &blob](uint32_t& ioSectionOffset, uint32_t idx) {

--- a/src/openvino/BlobReader.hpp
+++ b/src/openvino/BlobReader.hpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "BlobFormat.hpp"
+#include "depthai-shared/common/TensorInfo.hpp"
 
 namespace dai {
 
@@ -20,10 +21,10 @@ public:
 
     void parse(const std::vector<std::uint8_t>& blob);
 
-    //const ie::InputsDataMap& getNetworkInputs() const { return _networkInputs; }
-    //const ie::OutputsDataMap& getNetworkOutputs() const { return _networkOutputs; }
+    const std::unordered_map<std::string, TensorInfo>& getNetworkInputs() const { return networkInputs; }
+    const std::unordered_map<std::string, TensorInfo>& getNetworkOutputs() const { return networkOutputs; }
 
-    //uint32_t getStageCount() const { return blobHeader.stages_count; }
+    uint32_t getStageCount() const { return blobHeader.stages_count; }
 
     uint32_t getMagicNumber() const { return blobHeader.magic_number; }
 
@@ -32,9 +33,6 @@ public:
 
     uint32_t getNumberOfShaves() const { return blobHeader.number_of_shaves; }
     uint32_t getNumberOfSlices() const { return blobHeader.number_of_cmx_slices; }
-
-    //const DataInfo& getInputInfo()  const { return _inputInfo; }
-    //const DataInfo& getOutputInfo() const { return _outputInfo; }
 
     std::pair<const std::uint8_t*, size_t> getHeader() const { return {pBlob, sizeof(ElfN_Ehdr) + sizeof(mv_blob_header)};}
 
@@ -45,12 +43,9 @@ private:
 
     constexpr static std::uint32_t BLOB_MAGIC_NUMBER = 9709;
 
-    // TODO(themarpe) - add additional network information
-    //ie::InputsDataMap  _networkInputs;
-    //ie::OutputsDataMap _networkOutputs;
+    std::unordered_map<std::string, TensorInfo> networkInputs;
+    std::unordered_map<std::string, TensorInfo> networkOutputs;
 
-    //DataInfo _inputInfo;
-    //DataInfo _outputInfo;
 };
 
 }  // namespace dai

--- a/src/pipeline/AssetManager.cpp
+++ b/src/pipeline/AssetManager.cpp
@@ -53,6 +53,15 @@ std::shared_ptr<dai::Asset> AssetManager::set(const std::string& key, const std:
     return set(std::move(binaryAsset));
 }
 
+std::shared_ptr<dai::Asset> AssetManager::set(const std::string& key, std::vector<std::uint8_t>&& data, int alignment) {
+    // Create an asset
+    Asset binaryAsset(key);
+    binaryAsset.alignment = alignment;
+    binaryAsset.data = std::move(data);
+    // Store asset
+    return set(std::move(binaryAsset));
+}
+
 std::shared_ptr<const Asset> AssetManager::get(const std::string& key) const {
     if(assetMap.count(key) == 0) {
         return nullptr;

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -24,13 +24,12 @@ tl::optional<OpenVINO::Version> NeuralNetwork::getRequiredOpenVINOVersion() {
 
 // Specify local filesystem path to load the blob (which gets loaded at loadAssets)
 void NeuralNetwork::setBlobPath(const std::string& path) {
-    auto asset = assetManager.set("__blob", path);
+    setBlob(OpenVINO::Blob(path));
+}
 
-    // Read blobs header to determine openvino version
-    BlobReader reader;
-    reader.parse(asset->data);
-    networkOpenvinoVersion = OpenVINO::getBlobLatestSupportedVersion(reader.getVersionMajor(), reader.getVersionMinor());
-
+void NeuralNetwork::setBlob(OpenVINO::Blob blob) {
+    networkOpenvinoVersion = blob.version;
+    auto asset = assetManager.set("__blob", std::move(blob.data));
     properties.blobUri = asset->getRelativeUri();
     properties.blobSize = static_cast<uint32_t>(asset->data.size());
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,8 +93,8 @@ dai_add_test(pipeline_test src/pipeline_test.cpp)
 dai_add_test(neural_network_test src/neural_network_test.cpp)
 target_compile_definitions(neural_network_test PRIVATE BLOB_PATH="${mobilenet_blob}")
 
-dai_add_test(openvino_blob src/openvino_blob_test.cpp)
-target_compile_definitions(openvino_blob PRIVATE
+dai_add_test(openvino_blob_test src/openvino_blob_test.cpp)
+target_compile_definitions(openvino_blob_test PRIVATE
     OPENVINO_2020_3_BLOB_PATH="${openvino_2020_3_blob}"
     OPENVINO_2020_4_BLOB_PATH="${openvino_2020_4_blob}"
     OPENVINO_2021_1_BLOB_PATH="${openvino_2021_1_blob}"

--- a/tests/src/neural_network_test.cpp
+++ b/tests/src/neural_network_test.cpp
@@ -16,14 +16,19 @@ const size_t MOBILENET_DATA_SIZE = MOBILENET_WIDTH * MOBILENET_HEIGHT * MOBILENE
 const auto MOBILENET_INPUT_TENSOR = "data";
 const auto MOBILENET_OUTPUT_TENSOR = "detection_out";
 
-dai::Pipeline createNeuralNetworkPipeline() {
+dai::Pipeline createNeuralNetworkPipeline(bool manualBlob) {
     dai::Pipeline p;
     auto x_in = p.create<dai::node::XLinkIn>();
     auto x_out = p.create<dai::node::XLinkOut>();
     auto nn = p.create<dai::node::NeuralNetwork>();
 
     // Load blob
-    nn->setBlobPath(BLOB_PATH);
+    if(manualBlob) {
+        dai::OpenVINO::Blob blob(BLOB_PATH);
+        nn->setBlob(std::move(blob));
+    } else {
+        nn->setBlobPath(BLOB_PATH);
+    }
     // Set input stream
     x_in->setStreamName("input");
     // Set output stream
@@ -36,11 +41,11 @@ dai::Pipeline createNeuralNetworkPipeline() {
     return p;
 }
 
-TEST_CASE("Neural network node data checks") {
+void test(bool manualBlob) {
     using namespace std::chrono;
     using namespace std::chrono_literals;
 
-    auto pipeline = createNeuralNetworkPipeline();
+    auto pipeline = createNeuralNetworkPipeline(manualBlob);
 
     dai::Device device(pipeline.getOpenVINOVersion());
 
@@ -90,4 +95,11 @@ TEST_CASE("Neural network node data checks") {
 
     // At the end test if any error messages appeared
     REQUIRE(receivedLogMessage == false);
+}
+
+TEST_CASE("Neural network node data checks - setBlobPath") {
+    test(false);
+}
+TEST_CASE("Neural network node data checks - setBlob") {
+    test(true);
 }

--- a/tests/src/openvino_blob_test.cpp
+++ b/tests/src/openvino_blob_test.cpp
@@ -4,6 +4,7 @@
 // std
 #include <atomic>
 #include <iostream>
+#include <fstream>
 
 // Include depthai library
 #include <depthai/depthai.hpp>
@@ -173,4 +174,15 @@ TEST_CASE("OpenVINO 2021.4 blob") {
     auto networkOpenvinoVersion = p.getOpenVINOVersion();
     REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2021_4);
     dai::Device d(p);
+}
+
+// Check if an exception is thrown if blob is corrupted
+TEST_CASE("OpenVINO corrupted blob") {
+    std::ifstream stream(OPENVINO_2021_4_BLOB_PATH, std::ios::in | std::ios::binary);
+    std::vector<std::uint8_t> blobData(std::istreambuf_iterator<char>(stream), {});
+
+    // Corrupt blob by removing half the file size
+    blobData.resize(blobData.size()/2);
+
+    REQUIRE_THROWS(dai::OpenVINO::Blob(blobData));
 }

--- a/tests/src/openvino_blob_test.cpp
+++ b/tests/src/openvino_blob_test.cpp
@@ -8,6 +8,119 @@
 // Include depthai library
 #include <depthai/depthai.hpp>
 
+// setBlob
+
+void checkBlob(dai::OpenVINO::Blob& blob) {
+    printf("Blob: ");
+    for(const auto& in : blob.networkInputs) {
+        std::string name = in.first;
+        auto tensor = in.second;
+        printf("'%s - dims: %d - order: %04x - type: %d' ", name.c_str(), tensor.numDimensions, tensor.order, tensor.dataType);
+    }
+    for(const auto& out : blob.networkOutputs) {
+        std::string name = out.first;
+        auto tensor = out.second;
+        printf("'%s - dims: %d - order: %04x - type: %d' ", name.c_str(), tensor.numDimensions, tensor.order, tensor.dataType);
+    }
+    printf("(%u %u %u %u)\n", blob.stageCount, blob.numShaves, blob.numSlices, blob.version);
+
+    REQUIRE(blob.networkInputs.size() == 1);
+    REQUIRE(blob.networkInputs.at("0").numDimensions == 4);
+    REQUIRE(blob.networkInputs.at("0").order == dai::TensorInfo::StorageOrder::NCHW);
+    // REQUIRE(blob.networkInputs.at("0").dataType == dai::TensorInfo::DataType::U8F);
+
+    REQUIRE(blob.networkOutputs.size() == 1);
+    REQUIRE(blob.networkOutputs.at("14").numDimensions == 4);
+    REQUIRE(blob.networkOutputs.at("14").order == dai::TensorInfo::StorageOrder::NCHW);
+    REQUIRE(blob.networkOutputs.at("14").dataType == dai::TensorInfo::DataType::FP16);
+}
+
+TEST_CASE("OpenVINO 2020.3 setBlob") {
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::NeuralNetwork>();
+
+    dai::OpenVINO::Blob blob(OPENVINO_2020_3_BLOB_PATH);
+    REQUIRE(blob.version == dai::OpenVINO::VERSION_2020_3);
+    checkBlob(blob);
+    nn->setBlob(std::move(blob));
+
+    auto networkOpenvinoVersion = p.getOpenVINOVersion();
+    REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2020_3);
+    dai::Device d(p);
+}
+
+TEST_CASE("OpenVINO 2020.4 setBlob") {
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::NeuralNetwork>();
+
+    dai::OpenVINO::Blob blob(OPENVINO_2020_4_BLOB_PATH);
+    REQUIRE(blob.version == dai::OpenVINO::VERSION_2020_4);
+    checkBlob(blob);
+    nn->setBlob(std::move(blob));
+
+    auto networkOpenvinoVersion = p.getOpenVINOVersion();
+    REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2020_4);
+    dai::Device d(p);
+}
+
+TEST_CASE("OpenVINO 2021.1 setBlob") {
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::NeuralNetwork>();
+
+    dai::OpenVINO::Blob blob(OPENVINO_2021_1_BLOB_PATH);
+    REQUIRE(blob.version == dai::OpenVINO::VERSION_2021_1);
+    checkBlob(blob);
+    nn->setBlob(std::move(blob));
+
+    auto networkOpenvinoVersion = p.getOpenVINOVersion();
+    REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2021_1);
+    dai::Device d(p);
+}
+
+TEST_CASE("OpenVINO 2021.2 setBlob") {
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::NeuralNetwork>();
+
+    dai::OpenVINO::Blob blob(OPENVINO_2021_2_BLOB_PATH);
+    REQUIRE(blob.version == dai::OpenVINO::VERSION_2021_2);
+    checkBlob(blob);
+    nn->setBlob(std::move(blob));
+
+    auto networkOpenvinoVersion = p.getOpenVINOVersion();
+    REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2021_2);
+    dai::Device d(p);
+}
+
+TEST_CASE("OpenVINO 2021.3 setBlob") {
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::NeuralNetwork>();
+
+    dai::OpenVINO::Blob blob(OPENVINO_2021_3_BLOB_PATH);
+    REQUIRE(blob.version == dai::OpenVINO::VERSION_2021_3);
+    checkBlob(blob);
+    nn->setBlob(std::move(blob));
+
+    auto networkOpenvinoVersion = p.getOpenVINOVersion();
+    REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2021_3);
+    dai::Device d(p);
+}
+
+TEST_CASE("OpenVINO 2021.4 setBlob") {
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::NeuralNetwork>();
+
+    dai::OpenVINO::Blob blob(OPENVINO_2021_4_BLOB_PATH);
+    REQUIRE(blob.version == dai::OpenVINO::VERSION_2021_4);
+    checkBlob(blob);
+    nn->setBlob(std::move(blob));
+
+    auto networkOpenvinoVersion = p.getOpenVINOVersion();
+    REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2021_4);
+    dai::Device d(p);
+}
+
+// setBlobPath
+
 TEST_CASE("OpenVINO 2020.3 blob") {
     dai::Pipeline p;
     auto nn = p.create<dai::node::NeuralNetwork>();


### PR DESCRIPTION
Added reader and Blob structure to be able to query network details before using it in a pipeline.
Information include:
 - map of IO /w names, dimensions, datatype, order, ...
 - num shaves
 - num slices
 - stage count
 
Added some light tests for this functionality.

Also added `NeuralNetwork::setBlob` which takes a blob instead of a path

Note: moved `TensorInfo` to `common/` under `depthai-shared`, as its now used in more places

