### PR TITLE
Add DEPTHAI_DEVICE_MXIDS env variable support

### DIFF
--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -91,7 +91,7 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
         states = {state};
     }
 
-    auto allowedDeviceIDs = spdlog::details::os::getenv("DEPTHAI_DEVICE_MXIDS");
+    auto allowedDeviceIDs = utility::getEnv("DEPTHAI_DEVICE_MXID_LIST");
 
     // Get all available devices (unbooted & booted)
     for(const auto& state : states) {
@@ -112,8 +112,8 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
             info.state = state;
             bool allowedID = allowedDeviceIDs.find(info.getMxId()) != std::string::npos || allowedDeviceIDs.empty();
             if(allowedID) {
-	      devices.push_back(info);
-	    }
+                devices.push_back(info);
+            }
         }
     }
 

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -91,6 +91,8 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
         states = {state};
     }
 
+    auto allowedDeviceIDs = spdlog::details::os::getenv("DEPTHAI_DEVICE_MXIDS");
+
     // Get all available devices (unbooted & booted)
     for(const auto& state : states) {
         unsigned int numdev = 0;
@@ -108,7 +110,10 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
             DeviceInfo info = {};
             info.desc = deviceDescAll.at(i);
             info.state = state;
-            devices.push_back(info);
+            bool allowedID = allowedDeviceIDs.find(info.getMxId()) != std::string::npos || allowedDeviceIDs.empty();
+            if(allowedID) {
+	      devices.push_back(info);
+	    }
         }
     }
 


### PR DESCRIPTION
This commit adds support for a 'DEPTHAI_DEVICE_MXIDS' environment variable which limits the visibility of devices enumerated. The use case is that when dealing with multiple cameras attached to the same computer, it can be useful to have fine control over which one(s) are invokable in existing scripts and applications which weren't necessarily written with multiple camera support in mind. 