### PR TITLE
Swap ACCELEROMETER_RAW x and y axis to match ACCELEROMETER

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "c429e4118c1b806c00440398cea96ae27603abc4")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "1d6fe578d91ff098c30f35a2f6663b55b9b845db")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Addresses issue #319 where ACCELEROMETER_RAW and ACCELEROMETER outputs are inconsistent. 