### PR TITLE
enable queues of size=0 which only do callbacks

### DIFF
--- a/include/depthai/utility/LockingQueue.hpp
+++ b/include/depthai/utility/LockingQueue.hpp
@@ -19,7 +19,6 @@ class LockingQueue {
 
     void setMaxSize(unsigned sz) {
         // Lock first
-        if(sz == 0) throw std::invalid_argument("Queue size can't be 0!");
         std::unique_lock<std::mutex> lock(guard);
         maxSize = sz;
     }
@@ -57,7 +56,6 @@ class LockingQueue {
 
             // First checks predicate, then waits
             bool pred = signalPush.wait_for(lock, timeout, [this]() { return !queue.empty() || destructed; });
-            if(destructed) return false;
             if(!pred) return false;
 
             // Continue here if and only if queue has any elements
@@ -76,7 +74,6 @@ class LockingQueue {
             std::unique_lock<std::mutex> lock(guard);
 
             signalPush.wait(lock, [this]() { return !queue.empty() || destructed; });
-            if(destructed) return false;
             if(queue.empty()) return false;
 
             while(!queue.empty()) {
@@ -108,6 +105,13 @@ class LockingQueue {
     bool push(T const& data) {
         {
             std::unique_lock<std::mutex> lock(guard);
+            if(maxSize == 0) {
+                // necessary if maxSize was changed
+                while(!queue.empty()) {
+                    queue.pop();
+                }
+                return true;
+            }
             if(!blocking) {
                 // if non blocking, remove as many oldest elements as necessary, so next one will fit
                 // necessary if maxSize was changed
@@ -116,7 +120,6 @@ class LockingQueue {
                 }
             } else {
                 signalPop.wait(lock, [this]() { return queue.size() < maxSize || destructed; });
-                if(destructed) return false;
             }
 
             queue.push(data);
@@ -129,6 +132,13 @@ class LockingQueue {
     bool tryWaitAndPush(T const& data, std::chrono::duration<Rep, Period> timeout) {
         {
             std::unique_lock<std::mutex> lock(guard);
+            if(maxSize == 0) {
+                // necessary if maxSize was changed
+                while(!queue.empty()) {
+                    queue.pop();
+                }
+                return true;
+            }
             if(!blocking) {
                 // if non blocking, remove as many oldest elements as necessary, so next one will fit
                 // necessary if maxSize was changed
@@ -139,7 +149,6 @@ class LockingQueue {
                 // First checks predicate, then waits
                 bool pred = signalPop.wait_for(lock, timeout, [this]() { return queue.size() < maxSize || destructed; });
                 if(!pred) return false;
-                if(destructed) return false;
             }
 
             queue.push(data);
@@ -170,7 +179,7 @@ class LockingQueue {
                 return false;
             }
 
-            value = queue.front();
+            value = std::move(queue.front());
             queue.pop();
         }
         signalPop.notify_all();
@@ -182,10 +191,9 @@ class LockingQueue {
             std::unique_lock<std::mutex> lock(guard);
 
             signalPush.wait(lock, [this]() { return (!queue.empty() || destructed); });
-            if(destructed) return false;
             if(queue.empty()) return false;
 
-            value = queue.front();
+            value = std::move(queue.front());
             queue.pop();
         }
         signalPop.notify_all();
@@ -199,10 +207,9 @@ class LockingQueue {
 
             // First checks predicate, then waits
             bool pred = signalPush.wait_for(lock, timeout, [this]() { return !queue.empty() || destructed; });
-            if(destructed) return false;
             if(!pred) return false;
 
-            value = queue.front();
+            value = std::move(queue.front());
             queue.pop();
         }
         signalPop.notify_all();


### PR DESCRIPTION
Add support for Queues used by depthai-core to have size=0 and therefore only call callbacks.

- minor optimize LockingQueue
- fixes luxonis/depthai-core#366

I've been using this for about a week; size=0 works well in my app.
Passes test+examples, though they don't actively test size=0.