### PR TITLE
skip devices named "<error>" in device search

### DIFF
--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -108,6 +108,10 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
 
         for(unsigned i = 0; i < numdev; i++) {
             DeviceInfo info = {};
+            if(std::strcmp("<error>", deviceDescAll.at(i).name) == 0) {
+                spdlog::error("skipping {} device having name \"{}\"", XLinkDeviceStateToStr(state), deviceDescAll.at(i).name);
+                continue;
+            }
             info.desc = deviceDescAll.at(i);
             info.state = state;
             bool allowedId = allowedDeviceIds.find(info.getMxId()) != std::string::npos || allowedDeviceIds.empty();


### PR DESCRIPTION
partial fix luxonis/depthai-core#300

This is needed even after the watchdog work on host and device merged in Jan/Feb.
When device is in the error state and host is search for it, the name returned is `<error>` as in #300 and adds this unusable/corrupt device to the collection returned from the API.

With this PR, it will log an error, skip to the next possible device, and not include this errant device in the returned collection of devices. Without it, all callers in all apps have to write the same loop that does the same string compare to `<error>`.

Calling code now gets a correct collection of found devices. So if there was only one OAK hardware attached and it was this errant devices, the collection returned will be empty. A good thing.

Here is the log appearance. You can reproduce the error state and such logging using the steps in #300
```
[2022-02-15 22:13:44.117] [error] skipping X_LINK_UNBOOTED device having name "<error>"
```

Passes the full test+examples suite
```
[ctest] 100% tests passed, 0 tests failed out of 79
[ctest] 
[ctest] Total Test time (real) = 997.82 sec
[ctest] CTest finished with return code 0 
```
