### PR TITLE
Invalid device warnings suppression

### DIFF
--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -88,7 +88,7 @@ class DeviceBase {
      * Gets first available device. Device can be either in XLINK_UNBOOTED or XLINK_BOOTLOADER state
      * @returns Tuple of bool and DeviceInfo. Bool specifies if device was found. DeviceInfo specifies the found device
      */
-    static std::tuple<bool, DeviceInfo> getFirstAvailableDevice();
+    static std::tuple<bool, DeviceInfo> getFirstAvailableDevice(bool skipInvalidDevice = true);
 
     /**
      * Finds a device by MX ID. Example: 14442C10D13EABCE00

--- a/include/depthai/xlink/XLinkConnection.hpp
+++ b/include/depthai/xlink/XLinkConnection.hpp
@@ -35,9 +35,9 @@ struct DeviceInfo {
 class XLinkConnection {
    public:
     // static API
-    static std::vector<DeviceInfo> getAllConnectedDevices(XLinkDeviceState_t state = X_LINK_ANY_STATE);
-    static std::tuple<bool, DeviceInfo> getFirstDevice(XLinkDeviceState_t state = X_LINK_ANY_STATE);
-    static std::tuple<bool, DeviceInfo> getDeviceByMxId(std::string, XLinkDeviceState_t state = X_LINK_ANY_STATE);
+    static std::vector<DeviceInfo> getAllConnectedDevices(XLinkDeviceState_t state = X_LINK_ANY_STATE, bool skipInvalidDevices = true);
+    static std::tuple<bool, DeviceInfo> getFirstDevice(XLinkDeviceState_t state = X_LINK_ANY_STATE, bool skipInvalidDevices = true);
+    static std::tuple<bool, DeviceInfo> getDeviceByMxId(std::string, XLinkDeviceState_t state = X_LINK_ANY_STATE, bool skipInvalidDevice = true);
     static DeviceInfo bootBootloader(const DeviceInfo& devInfo);
 
     XLinkConnection(const DeviceInfo& deviceDesc, std::vector<std::uint8_t> mvcmdBinary, XLinkDeviceState_t expectedState = X_LINK_BOOTED);

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -79,7 +79,7 @@ constexpr std::chrono::milliseconds XLinkConnection::WAIT_FOR_BOOTUP_TIMEOUT_TCP
 constexpr std::chrono::milliseconds XLinkConnection::WAIT_FOR_BOOTUP_TIMEOUT_USB;
 constexpr std::chrono::milliseconds XLinkConnection::WAIT_FOR_CONNECT_TIMEOUT;
 
-std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState_t state) {
+std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState_t state, bool skipInvalidDevices) {
     initialize();
 
     std::vector<DeviceInfo> devices;
@@ -108,8 +108,8 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
 
         for(unsigned i = 0; i < numdev; i++) {
             DeviceInfo info = {};
-            if(std::strcmp("<error>", deviceDescAll.at(i).name) == 0) {
-                spdlog::error("skipping {} device having name \"{}\"", XLinkDeviceStateToStr(state), deviceDescAll.at(i).name);
+            if(skipInvalidDevices && std::strcmp("<error>", deviceDescAll.at(i).name) == 0) {
+                spdlog::warn("skipping {} device having name \"{}\"", XLinkDeviceStateToStr(state), deviceDescAll.at(i).name);
                 continue;
             }
             info.desc = deviceDescAll.at(i);
@@ -124,16 +124,16 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
     return devices;
 }
 
-std::tuple<bool, DeviceInfo> XLinkConnection::getFirstDevice(XLinkDeviceState_t state) {
-    auto devices = getAllConnectedDevices();
+std::tuple<bool, DeviceInfo> XLinkConnection::getFirstDevice(XLinkDeviceState_t state, bool skipInvalidDevice) {
+    auto devices = getAllConnectedDevices(state, skipInvalidDevice);
     for(const auto& d : devices) {
         if(d.state == state || state == X_LINK_ANY_STATE) return {true, d};
     }
     return {false, DeviceInfo()};
 }
 
-std::tuple<bool, DeviceInfo> XLinkConnection::getDeviceByMxId(std::string mxId, XLinkDeviceState_t state) {
-    auto devices = getAllConnectedDevices();
+std::tuple<bool, DeviceInfo> XLinkConnection::getDeviceByMxId(std::string mxId, XLinkDeviceState_t state, bool skipInvalidDevice) {
+    auto devices = getAllConnectedDevices(state, skipInvalidDevice);
     for(const auto& d : devices) {
         if(d.state == state || state == X_LINK_ANY_STATE) {
             if(d.getMxId() == mxId) {
@@ -259,7 +259,7 @@ void XLinkConnection::close() {
             do {
                 DeviceInfo tmp;
                 for(const auto& state : {X_LINK_UNBOOTED, X_LINK_BOOTLOADER}) {
-                    std::tie(found, tmp) = XLinkConnection::getDeviceByMxId(deviceInfo.getMxId(), state);
+                    std::tie(found, tmp) = XLinkConnection::getDeviceByMxId(deviceInfo.getMxId(), state, false);
                     if(found) break;
                 }
             } while(!found && steady_clock::now() - t1 < BOOTUP_SEARCH);


### PR DESCRIPTION
Suppressed redundant warnings for invalid devices, by only checking for them once on search calls with timeout.