### PR TITLE
move semantics with DataOutputQueue::addCallback()

### DIFF
--- a/src/device/CallbackHandler.cpp
+++ b/src/device/CallbackHandler.cpp
@@ -26,7 +26,7 @@ CallbackHandler::CallbackHandler(std::shared_ptr<XLinkConnection> conn,
                 const auto data = StreamMessageParser::parseMessage(&packet);
 
                 // CALLBACK
-                auto toSend = callback(data);
+                auto toSend = callback(std::move(data));
 
                 auto serialized = StreamMessageParser::serializeMessage(toSend);
 

--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -138,8 +138,8 @@ int DataOutputQueue::addCallback(std::function<void(std::string, std::shared_ptr
     // Get unique id
     int id = uniqueCallbackId++;
 
-    // assign callback
-    callbacks[id] = callback;
+    // move assign callback
+    callbacks[id] = std::move(callback);
 
     // return id assigned to the callback
     return id;
@@ -147,12 +147,12 @@ int DataOutputQueue::addCallback(std::function<void(std::string, std::shared_ptr
 
 int DataOutputQueue::addCallback(std::function<void(std::shared_ptr<ADatatype>)> callback) {
     // Create a wrapper
-    return addCallback([callback](std::string, std::shared_ptr<ADatatype> message) { callback(message); });
+    return addCallback([callback = std::move(callback)](std::string, std::shared_ptr<ADatatype> message) { callback(std::move(message)); });
 }
 
 int DataOutputQueue::addCallback(std::function<void()> callback) {
     // Create a wrapper
-    return addCallback([callback](std::string, std::shared_ptr<ADatatype>) { callback(); });
+    return addCallback([callback = std::move(callback)](std::string, std::shared_ptr<ADatatype>) { callback(); });
 }
 
 bool DataOutputQueue::removeCallback(int callbackId) {

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -311,7 +311,7 @@ bool Device::startPipelineImpl(const Pipeline& pipeline) {
                 }
 
                 // Add to the end of event queue
-                eventQueue.push_back(queueName);
+                eventQueue.push_back(std::move(queueName));
             }
 
             // notify the rest


### PR DESCRIPTION
- fixes luxonis/depthai-core#390
- minor move tweaks using callbacks

Passes full test+example suite on Windows.
Compiles with gcc10 on U20.04.