### PR TITLE
Calib data RGB spec translation fix for some CM3/CM4 boards

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "0db59ca9b81e4901f8bc49023fb8c0121be821a0")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "5813806b6f2de7aaa4c211e5d8aa8e98774da8c8")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "5813806b6f2de7aaa4c211e5d8aa8e98774da8c8")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "2bebad51c15c2e8961899a29b93b93f2409d8464")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Update FW: patch EEPROM data (used for StereoDepth and also sent to host) for incorrectly programmed RGB spec translation (relative to Left camera instead of Right), for some OAK-D-CM3 / OAK-D-CM4 / OAK-D-CM4-PoE boards calibrated with [calibrate.py](https://github.com/luxonis/depthai/blob/main/calibrate.py)

Was mainly leading to wrong RGB-depth alignment.
Related fix for `calibrate.py`: https://github.com/luxonis/depthai/pull/656

___
EDIT: other changes added:
- fix StereoDepth crash with missing EEPROM, report error if missing: `[system] [error] EEPROM chip not detected`
- do not rotate RGB (AUTO orientation) on OAK-D(-Lite) if EEPROM is missing (check based on at least one of L/R cams connected).