### PR TITLE
Warp engine improvements for RGB alignment/stereo rectification

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "2bebad51c15c2e8961899a29b93b93f2409d8464")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "9215cfc78468345cf226e92984ff3ed7ad3cfe2b")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "9215cfc78468345cf226e92984ff3ed7ad3cfe2b")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "b3bbd4d5a9a8108b654e6e63e0beb21520c2beca")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
- Mitigates RGB alignment crash: `Fatal error. Please report to developers. Log: 'PlgWarpHW' '741'`
- Better error handling/recovery in case of SIPP framework error.
- Reduces memory usage of CMX by 256 kB when RGB alignment is enabled.
- Reduces memory usage of CMX by 64 kB when stereo rectification/dewarp is enabled.
