### PR TITLE
Customizable depth unit

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "b3bbd4d5a9a8108b654e6e63e0beb21520c2beca")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "309cba28a6d73b83a0ac9365d41bd02a65e03090")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "309cba28a6d73b83a0ac9365d41bd02a65e03090")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "86b4e1837b2ba14cd73dcc0968fcd25f02a62a71")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "86b4e1837b2ba14cd73dcc0968fcd25f02a62a71")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "df5e50e79532ddaa879a6ccf2928fbbe27adeef7")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -98,7 +98,7 @@ class StereoDepthConfig : public Buffer {
     /**
      * Set depth unit of depth map.
      *
-     * Metre, centimetre, millimetre, inch, foot or custom unit is available.
+     * Meter, centimeter, millimeter, inch, foot or custom unit is available.
      */
     StereoDepthConfig& setDepthUnit(AlgorithmControl::DepthUnit depthUnit);
 

--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -96,6 +96,18 @@ class StereoDepthConfig : public Buffer {
     StereoDepthConfig& setSubpixel(bool enable);
 
     /**
+     * Set depth unit of depth map.
+     *
+     * Metre, centimetre, millimetre, inch, foot or custom unit is available.
+     */
+    StereoDepthConfig& setDepthUnit(AlgorithmControl::DepthUnit depthUnit);
+
+    /**
+     * Get depth unit of depth map.
+     */
+    AlgorithmControl::DepthUnit getDepthUnit();
+
+    /**
      * Useful for normalization of the disparity map.
      * @returns Maximum disparity value that the node can return
      */

--- a/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
@@ -78,13 +78,13 @@ class SpatialDetectionNetwork : public NodeCRTP<DetectionNetwork, SpatialDetecti
     void setBoundingBoxScaleFactor(float scaleFactor);
 
     /**
-     * Specifies lower threshold in depth units (millimetre by default) for depth values which will used to calculate spatial data
+     * Specifies lower threshold in depth units (millimeter by default) for depth values which will used to calculate spatial data
      * @param lowerThreshold LowerThreshold must be in the interval [0,upperThreshold] and less than upperThreshold.
      */
     void setDepthLowerThreshold(uint32_t lowerThreshold);
 
     /**
-     * Specifies upper threshold in depth units (millimetre by default) for depth values which will used to calculate spatial data
+     * Specifies upper threshold in depth units (millimeter by default) for depth values which will used to calculate spatial data
      * @param upperThreshold UpperThreshold must be in the interval (lowerThreshold,65535].
      */
     void setDepthUpperThreshold(uint32_t upperThreshold);

--- a/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
@@ -78,13 +78,13 @@ class SpatialDetectionNetwork : public NodeCRTP<DetectionNetwork, SpatialDetecti
     void setBoundingBoxScaleFactor(float scaleFactor);
 
     /**
-     * Specifies lower threshold in millimeters for depth values which will used to calculate spatial data
+     * Specifies lower threshold in depth units (millimetre by default) for depth values which will used to calculate spatial data
      * @param lowerThreshold LowerThreshold must be in the interval [0,upperThreshold] and less than upperThreshold.
      */
     void setDepthLowerThreshold(uint32_t lowerThreshold);
 
     /**
-     * Specifies upper threshold in millimeters for depth values which will used to calculate spatial data
+     * Specifies upper threshold in depth units (millimetre by default) for depth values which will used to calculate spatial data
      * @param upperThreshold UpperThreshold must be in the interval (lowerThreshold,65535].
      */
     void setDepthUpperThreshold(uint32_t upperThreshold);

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -58,7 +58,7 @@ class StereoDepth : public NodeCRTP<Node, StereoDepth, StereoDepthProperties> {
     Input right{*this, "right", Input::Type::SReceiver, false, 8, true, {{DatatypeEnum::ImgFrame, true}}};
 
     /**
-     * Outputs ImgFrame message that carries RAW16 encoded (0..65535) depth data in depth units (millimetre by default).
+     * Outputs ImgFrame message that carries RAW16 encoded (0..65535) depth data in depth units (millimeter by default).
      *
      * Non-determined / invalid depth values are set to 0
      */

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -58,7 +58,7 @@ class StereoDepth : public NodeCRTP<Node, StereoDepth, StereoDepthProperties> {
     Input right{*this, "right", Input::Type::SReceiver, false, 8, true, {{DatatypeEnum::ImgFrame, true}}};
 
     /**
-     * Outputs ImgFrame message that carries RAW16 encoded (0..65535) depth data in millimeters.
+     * Outputs ImgFrame message that carries RAW16 encoded (0..65535) depth data in depth units (millimetre by default).
      *
      * Non-determined / invalid depth values are set to 0
      */

--- a/src/pipeline/datatype/StereoDepthConfig.cpp
+++ b/src/pipeline/datatype/StereoDepthConfig.cpp
@@ -66,6 +66,15 @@ StereoDepthConfig& StereoDepthConfig::setSubpixel(bool enable) {
     return *this;
 }
 
+StereoDepthConfig& StereoDepthConfig::setDepthUnit(AlgorithmControl::DepthUnit depthUnit) {
+    cfg.algorithmControl.depthUnit = depthUnit;
+    return *this;
+}
+
+dai::StereoDepthConfig::AlgorithmControl::DepthUnit StereoDepthConfig::getDepthUnit() {
+    return cfg.algorithmControl.depthUnit;
+}
+
 float StereoDepthConfig::getMaxDisparity() const {
     float maxDisp = 95.0;
     if(cfg.costMatching.disparityWidth == RawStereoDepthConfig::CostMatching::DisparityWidth::DISPARITY_64) {


### PR DESCRIPTION
Example of usage:

```
stereo->initialConfig.setDepthUnit(dai::StereoDepthConfig::AlgorithmControl::DepthUnit::CENTIMETRE);
```
Available units:
`METER, CENTIMETER, MILLIMETER, INCH, FOOT, CUSTOM`

Related: https://github.com/luxonis/depthai-shared/pull/89