### PR TITLE
Openvino: Fix error reporting when blob is not set

### DIFF
--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -21,7 +21,7 @@ class NeuralNetwork : public NodeCRTP<Node, NeuralNetwork, NeuralNetworkProperti
 
    protected:
     tl::optional<OpenVINO::Version> getRequiredOpenVINOVersion() override;
-    OpenVINO::Version networkOpenvinoVersion;
+    tl::optional<OpenVINO::Version> networkOpenvinoVersion;
 
    public:
     NeuralNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -28,7 +28,7 @@ void NeuralNetwork::setBlobPath(const std::string& path) {
 }
 
 void NeuralNetwork::setBlob(OpenVINO::Blob blob) {
-    networkOpenvinoVersion = blob.version;
+    *networkOpenvinoVersion = blob.version;
     auto asset = assetManager.set("__blob", std::move(blob.data));
     properties.blobUri = asset->getRelativeUri();
     properties.blobSize = static_cast<uint32_t>(asset->data.size());

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -28,7 +28,7 @@ void NeuralNetwork::setBlobPath(const std::string& path) {
 }
 
 void NeuralNetwork::setBlob(OpenVINO::Blob blob) {
-    *networkOpenvinoVersion = blob.version;
+    this->networkOpenvinoVersion = blob.version;
     auto asset = assetManager.set("__blob", std::move(blob.data));
     properties.blobUri = asset->getRelativeUri();
     properties.blobSize = static_cast<uint32_t>(asset->data.size());


### PR DESCRIPTION
Reports: `RuntimeError: DetectionNetwork(1) - No blob is loaded`
instead: `RuntimeError: Pipeline - 'DetectionNetwork' node with id: 1, isn't compatible with forced OpenVINO version`
when openvino version is set explicitly and blob is not set (`setBlobPath`)