### PR TITLE
test case for Device constructor not calling tryStartPipeline()

### DIFF
--- a/tests/src/device_usbspeed_test.cpp
+++ b/tests/src/device_usbspeed_test.cpp
@@ -8,22 +8,42 @@
 // Include depthai library
 #include <depthai/depthai.hpp>
 
+void makeInfo(dai::Pipeline& p) {
+    auto info = p.create<dai::node::SystemLogger>();
+    auto xo = p.create<dai::node::XLinkOut>();
+    xo->setStreamName("sysinfo");
+    info->out.link(xo->input);
+}
+
+void verifyInfo(dai::Device& d) {
+    auto infoQ = d.getOutputQueue("sysinfo");
+    if(infoQ->isClosed()) throw std::runtime_error("queue is not open");
+}
+
 TEST_CASE("usb2Mode == true") {
     dai::Pipeline p;
+    makeInfo(p);
     dai::Device d(p, true);
+    verifyInfo(d);
 }
 
 TEST_CASE("UsbSpeed::HIGH") {
     dai::Pipeline p;
+    makeInfo(p);
     dai::Device d(p, dai::UsbSpeed::HIGH);
+    verifyInfo(d);
 }
 
 TEST_CASE("UsbSpeed::SUPER") {
     dai::Pipeline p;
+    makeInfo(p);
     dai::Device d(p, dai::UsbSpeed::SUPER);
+    verifyInfo(d);
 }
 
 TEST_CASE("UsbSpeed::SUPER_PLUS") {
     dai::Pipeline p;
+    makeInfo(p);
     dai::Device d(p, dai::UsbSpeed::SUPER_PLUS);
+    verifyInfo(d);
 }


### PR DESCRIPTION
Catch bug and prevent regression as discussed https://github.com/luxonis/depthai-core/commit/7257b95ecfb8dcb77c075e196ac774cc05cb8bc6#commitcomment-71730879


v2.15.0 with https://github.com/luxonis/depthai-core/pull/384 ...
this PRs test case fails. The fail is desired and good.

`develop` which includes that same PR + fix https://github.com/luxonis/depthai-core/commit/7257b95ecfb8dcb77c075e196ac774cc05cb8bc6 ...
this PRs test case passes. The pass is desired and good.