### PR TITLE
OV7251 (OAK-D Lite mono camera) configurable FPS

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "921b8a6a29fa445ea1c250d76dbe8694b5768584")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "af9024d1b2f023f80171f7a36fbeca4718a7b808")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Maximum possible now, per configured resolution:
- `THE_480_P` - 99 FPS
- `THE_400_P` - 117 FPS

However, with multiple cameras running in parallel, ISP 3A computations are limited to about 200 .. 210 FPS total. We'll follow up with a configuration for lowering the 3A rate, so to not run on every frame, but reuse the same ISP configuration for N frames in a row. This will allow also running stereo depth at 200 FPS, with new camera configs for higher FPS.