### PR TITLE
Fix failing CI for MacOS

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -97,7 +97,6 @@ jobs:
     - name: Install dependencies
       if: matrix.os == 'macos-latest'
       run: |
-        brew update
         brew install libusb opencv
 
     - name: Install dependencies
@@ -171,7 +170,6 @@ jobs:
     - name: Install dependencies
       if: matrix.os == 'macos-latest'
       run: |
-        brew update
         brew install libusb opencv
 
     - name: Install dependencies


### PR DESCRIPTION
Remove brew update, before running CI. It was introduced in https://github.com/luxonis/depthai-core/commit/5992cf1d40e511b1fd568af8bab0561dd9a20ae9 due to: https://github.com/actions/virtual-environments/issues/3165 but no longer needed.