### PR TITLE
Stereo: Auto enable distortion correction for fisheye lenses

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "b9914d084f5fa91233d53352f7f5abc56ef8412c")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "dcf4526f11cf88c88a0d3a3fbaba9152e96bf2c9")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "dcf4526f11cf88c88a0d3a3fbaba9152e96bf2c9")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "613d3600d858acd8b742e15293079d880a2d3789")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -312,14 +312,14 @@ class StereoDepth : public NodeCRTP<Node, StereoDepth, StereoDepthProperties> {
     void setDefaultProfilePreset(PresetMode mode);
 
     /**
-     * Sets a default preset based on specified option.
-     * @param mode Stereo depth preset mode
+     * Whether to use focal length from calibration intrinsics or calculate based on calibration FOV.
+     * Default value is true.
      */
-    void setFocalLengthFromCalibration(bool focalLengthFromCalibration);
+    [[deprecated("setFocalLengthFromCalibration is deprecated. Default value is true.")]] void setFocalLengthFromCalibration(bool focalLengthFromCalibration);
 
     /**
      * Use 3x3 homography matrix for stereo rectification instead of sparse mesh generated on device.
-     * Default value: true.
+     * Default behaviour is AUTO, for lenses with FOV over 90 degrees sparse mesh is used, otherwise 3x3 homography.
      * If custom mesh data is provided through loadMeshData or loadMeshFiles this option is ignored.
      * @param useHomographyRectification true: 3x3 homography matrix generated from calibration data is used for stereo rectification, can't correct lens
      * distortion.

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -31,7 +31,6 @@ StereoDepth::StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeI
                    &confidenceMap});
 
     setDefaultProfilePreset(presetMode);
-    setFocalLengthFromCalibration(true);
 }
 
 StereoDepth::Properties& StereoDepth::getProperties() {


### PR DESCRIPTION
Deprecated `setFocalLengthFromCalibration`.
API for `useHomographyRectification` didn't change.