### PR TITLE
Add OpenVINO 2022.1 support

### DIFF
--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Configure, Build and Test
       if: matrix.os != 'linux'
       run: |
-        cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D HUNTER_ROOT=$HOME/.hun_${{ matrix.flavor }} -D DEPTHAI_BUILD_EXAMPLES=ON -D DEPTHAI_BUILD_TESTS=ON -D DEPTHAI_TEST_EXAMPLES=ON
+        cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D HUNTER_ROOT=$HOME/.hun2_${{ matrix.flavor }} -D DEPTHAI_BUILD_EXAMPLES=ON -D DEPTHAI_BUILD_TESTS=ON -D DEPTHAI_TEST_EXAMPLES=ON
         cmake --build build --parallel 8 --config Release
         cd build
         ctest -C Release --output-on-failure -L usb
@@ -64,7 +64,7 @@ jobs:
       run: |
         export DISPLAY=:99
         xdpyinfo -display $DISPLAY >/dev/null 2>&1 || (Xvfb $DISPLAY &)
-        cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D HUNTER_ROOT=$HOME/.hun_${{ matrix.flavor }} -D DEPTHAI_BUILD_EXAMPLES=ON -D DEPTHAI_BUILD_TESTS=ON -D DEPTHAI_TEST_EXAMPLES=ON
+        cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -D HUNTER_ROOT=$HOME/.hun2_${{ matrix.flavor }} -D DEPTHAI_BUILD_EXAMPLES=ON -D DEPTHAI_BUILD_TESTS=ON -D DEPTHAI_TEST_EXAMPLES=ON
         cmake --build build --parallel 8 --config Release
         cd build
         ctest -C Release --output-on-failure -L usb

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "2872593946d8096f7085a7fc07b2bce419659f67")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "077fa75ba35a83d8c42156c40718d412a5825b77")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "e3df316f89fed6ba7e0fa33564699f055ce15891")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "2872593946d8096f7085a7fc07b2bce419659f67")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "166f9a5f96742f03e53ce186b5f07b91b0a4df98")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "e3df316f89fed6ba7e0fa33564699f055ce15891")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "7e4ab98f6d7ee21586e69839dca5a993c40fb87a")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "f7763c62bcc77f0d7bb259a5684d076e8e74b4a9")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "1023338b5a0bee222d45c024cdaeb05fa08248d6")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "7e4ab98f6d7ee21586e69839dca5a993c40fb87a")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/openvino/OpenVINO.hpp
+++ b/include/depthai/openvino/OpenVINO.hpp
@@ -17,7 +17,7 @@ namespace dai {
 class OpenVINO {
    public:
     /// OpenVINO Version supported version information
-    enum Version { VERSION_2020_3, VERSION_2020_4, VERSION_2021_1, VERSION_2021_2, VERSION_2021_3, VERSION_2021_4 };
+    enum Version { VERSION_2020_3, VERSION_2020_4, VERSION_2021_1, VERSION_2021_2, VERSION_2021_3, VERSION_2021_4, VERSION_2022_1 };
 
     /// OpenVINO Blob
     struct Blob {
@@ -51,7 +51,7 @@ class OpenVINO {
     };
 
     /// Main OpenVINO version
-    constexpr static const Version DEFAULT_VERSION = VERSION_2021_4;
+    constexpr static const Version DEFAULT_VERSION = VERSION_2022_1;
 
     /**
      * @returns Supported versions

--- a/src/openvino/OpenVINO.cpp
+++ b/src/openvino/OpenVINO.cpp
@@ -22,25 +22,34 @@ constexpr OpenVINO::Version OpenVINO::DEFAULT_VERSION;
 // major and minor represent openvino NN blob version information
 const std::map<std::pair<std::uint32_t, std::uint32_t>, OpenVINO::Version> OpenVINO::blobVersionToLatestOpenvinoMapping = {
     {{5, 0}, OpenVINO::VERSION_2020_3},
-    {{6, 0}, OpenVINO::VERSION_2021_4},
+    {{6, 0}, OpenVINO::VERSION_2022_1},
     {{2020, 3}, OpenVINO::VERSION_2020_3},
     {{2020, 4}, OpenVINO::VERSION_2020_4},
     {{2021, 1}, OpenVINO::VERSION_2021_1},
     {{2021, 2}, OpenVINO::VERSION_2021_2},
     {{2021, 3}, OpenVINO::VERSION_2021_3},
     {{2021, 4}, OpenVINO::VERSION_2021_4},
+    {{2022, 1}, OpenVINO::VERSION_2022_1},
 
 };
 
 const std::map<std::pair<std::uint32_t, std::uint32_t>, std::vector<OpenVINO::Version>> OpenVINO::blobVersionToOpenvinoMapping = {
     {{5, 0}, {OpenVINO::VERSION_2020_3}},
-    {{6, 0}, {OpenVINO::VERSION_2020_4, OpenVINO::VERSION_2021_1, OpenVINO::VERSION_2021_2, OpenVINO::VERSION_2021_3, OpenVINO::VERSION_2021_4}},
+    {{6, 0},
+     {OpenVINO::VERSION_2020_4,
+      OpenVINO::VERSION_2021_1,
+      OpenVINO::VERSION_2021_2,
+      OpenVINO::VERSION_2021_3,
+      OpenVINO::VERSION_2021_4,
+      OpenVINO::VERSION_2022_1}},
     {{2020, 3}, {OpenVINO::VERSION_2020_3}},
     {{2020, 4}, {OpenVINO::VERSION_2020_4}},
     {{2021, 1}, {OpenVINO::VERSION_2021_1}},
     {{2021, 2}, {OpenVINO::VERSION_2021_2}},
     {{2021, 3}, {OpenVINO::VERSION_2021_3}},
     {{2021, 4}, {OpenVINO::VERSION_2021_4}},
+    {{2022, 1}, {OpenVINO::VERSION_2022_1}},
+
 };
 
 std::vector<OpenVINO::Version> OpenVINO::getVersions() {
@@ -49,7 +58,8 @@ std::vector<OpenVINO::Version> OpenVINO::getVersions() {
             OpenVINO::VERSION_2021_1,
             OpenVINO::VERSION_2021_2,
             OpenVINO::VERSION_2021_3,
-            OpenVINO::VERSION_2021_4};
+            OpenVINO::VERSION_2021_4,
+            OpenVINO::VERSION_2022_1};
 }
 
 std::string OpenVINO::getVersionName(OpenVINO::Version version) {
@@ -66,6 +76,8 @@ std::string OpenVINO::getVersionName(OpenVINO::Version version) {
             return "2021.3";
         case OpenVINO::VERSION_2021_4:
             return "2021.4";
+        case OpenVINO::VERSION_2022_1:
+            return "2022.1";
     }
     throw std::logic_error("OpenVINO - Unknown version enum specified");
 }

--- a/src/utility/Resources.cpp
+++ b/src/utility/Resources.cpp
@@ -42,8 +42,8 @@ static std::vector<std::uint8_t> createPrebootHeader(const std::vector<uint8_t>&
 constexpr static auto CMRC_DEPTHAI_DEVICE_TAR_XZ = "depthai-device-fwp-" DEPTHAI_DEVICE_VERSION ".tar.xz";
 
 // Main FW
-constexpr static auto DEPTHAI_CMD_OPENVINO_2021_4_PATH = "depthai-device-openvino-2021.4-" DEPTHAI_DEVICE_VERSION ".cmd";
-constexpr static auto MAIN_FW_PATH = DEPTHAI_CMD_OPENVINO_2021_4_PATH;
+constexpr static auto DEPTHAI_CMD_OPENVINO_2022_1_PATH = "depthai-device-openvino-2022.1-" DEPTHAI_DEVICE_VERSION ".cmd";
+constexpr static auto MAIN_FW_PATH = DEPTHAI_CMD_OPENVINO_2022_1_PATH;
 constexpr static auto& MAIN_FW_VERSION = OpenVINO::DEFAULT_VERSION;
 
 // Patches from Main FW
@@ -59,7 +59,7 @@ static constexpr auto array_of(T&&... t) -> std::array<V, sizeof...(T)> {
     return {{std::forward<T>(t)...}};
 }
 
-constexpr static auto RESOURCE_LIST_DEVICE = array_of<const char*>(DEPTHAI_CMD_OPENVINO_2021_4_PATH,
+constexpr static auto RESOURCE_LIST_DEVICE = array_of<const char*>(DEPTHAI_CMD_OPENVINO_2022_1_PATH,
                                                                    DEPTHAI_CMD_OPENVINO_2020_3_PATCH_PATH,
                                                                    DEPTHAI_CMD_OPENVINO_2020_4_PATCH_PATH,
                                                                    DEPTHAI_CMD_OPENVINO_2021_1_PATCH_PATH,
@@ -138,6 +138,7 @@ std::vector<std::uint8_t> Resources::getDeviceFirmware(Device::Config config, da
                 depthaiPatch = resourceMapDevice.at(DEPTHAI_CMD_OPENVINO_2021_3_PATCH_PATH);
                 break;
 
+            case OpenVINO::VERSION_2021_4:
             case MAIN_FW_VERSION:
                 depthaiBinary = resourceMapDevice.at(MAIN_FW_PATH);
                 break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,6 +173,13 @@ hunter_private_data(
     FILE "text-image-super-resolution-0001_2021.4.2_4shave.blob"
     LOCATION openvino_2021_4_blob
 )
+# OpenVINO 2022.1.0 blob
+hunter_private_data(
+    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2022.1.0_4shave.blob"
+    SHA1 "98e94b865b9c48a92eaebd1ddc883712dfe7cfcb"
+    FILE "text-image-super-resolution-0001_2022.1.0_4shave.blob"
+    LOCATION openvino_2022_1_blob
+)
 
 
 # Add tests
@@ -191,6 +198,7 @@ dai_test_compile_definitions(openvino_blob_test PRIVATE
     OPENVINO_2021_2_BLOB_PATH="${openvino_2021_2_blob}"
     OPENVINO_2021_3_BLOB_PATH="${openvino_2021_3_blob}"
     OPENVINO_2021_4_BLOB_PATH="${openvino_2021_4_blob}"
+    OPENVINO_2022_1_BLOB_PATH="${openvino_2022_1_blob}"
 )
 
 # Bootloader configuration tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -171,7 +171,7 @@ hunter_private_data(
     URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2021.4.2_4shave.blob"
     SHA1 "164b6b2ae48d38bc4f07cc8296b8bcb7644a1578"
     FILE "text-image-super-resolution-0001_2021.4.2_4shave.blob"
-    LOCATION openvino_2021_4_blob
+    LOCATION openvino_2021_4_2_blob
 )
 # OpenVINO 2022.1.0 blob
 hunter_private_data(
@@ -197,7 +197,7 @@ dai_test_compile_definitions(openvino_blob_test PRIVATE
     OPENVINO_2021_1_BLOB_PATH="${openvino_2021_1_blob}"
     OPENVINO_2021_2_BLOB_PATH="${openvino_2021_2_blob}"
     OPENVINO_2021_3_BLOB_PATH="${openvino_2021_3_blob}"
-    OPENVINO_2021_4_BLOB_PATH="${openvino_2021_4_blob}"
+    OPENVINO_2021_4_BLOB_PATH="${openvino_2021_4_2_blob}"
     OPENVINO_2022_1_BLOB_PATH="${openvino_2022_1_blob}"
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,13 +173,13 @@ hunter_private_data(
     FILE "text-image-super-resolution-0001_2021.4.2_4shave.blob"
     LOCATION openvino_2021_4_2_blob
 )
-# OpenVINO 2022.1.0 blob
-hunter_private_data(
-    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2022.1.0_4shave.blob"
-    SHA1 "98e94b865b9c48a92eaebd1ddc883712dfe7cfcb"
-    FILE "text-image-super-resolution-0001_2022.1.0_4shave.blob"
-    LOCATION openvino_2022_1_blob
-)
+# # OpenVINO 2022.1.0 blob
+# hunter_private_data(
+#     URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2022.1.0_4shave.blob"
+#     SHA1 "98e94b865b9c48a92eaebd1ddc883712dfe7cfcb"
+#     FILE "text-image-super-resolution-0001_2022.1.0_4shave.blob"
+#     LOCATION openvino_2022_1_blob
+# )
 
 
 # Add tests
@@ -198,7 +198,7 @@ dai_test_compile_definitions(openvino_blob_test PRIVATE
     OPENVINO_2021_2_BLOB_PATH="${openvino_2021_2_blob}"
     OPENVINO_2021_3_BLOB_PATH="${openvino_2021_3_blob}"
     OPENVINO_2021_4_BLOB_PATH="${openvino_2021_4_2_blob}"
-    OPENVINO_2022_1_BLOB_PATH="${openvino_2022_1_blob}"
+    # OPENVINO_2022_1_BLOB_PATH="${openvino_2022_1_blob}"
 )
 
 # Bootloader configuration tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,13 +173,13 @@ hunter_private_data(
     FILE "text-image-super-resolution-0001_2021.4.2_4shave.blob"
     LOCATION openvino_2021_4_2_blob
 )
-# # OpenVINO 2022.1.0 blob
-# hunter_private_data(
-#     URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2022.1.0_4shave.blob"
-#     SHA1 "98e94b865b9c48a92eaebd1ddc883712dfe7cfcb"
-#     FILE "text-image-super-resolution-0001_2022.1.0_4shave.blob"
-#     LOCATION openvino_2022_1_blob
-# )
+# OpenVINO 2022.1.0 blob
+hunter_private_data(
+    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2022.1.0_4shave.blob"
+    SHA1 "98e94b865b9c48a92eaebd1ddc883712dfe7cfcb"
+    FILE "text-image-super-resolution-0001_2022.1.0_4shave.blob"
+    LOCATION openvino_2022_1_blob
+)
 
 
 # Add tests
@@ -198,7 +198,7 @@ dai_test_compile_definitions(openvino_blob_test PRIVATE
     OPENVINO_2021_2_BLOB_PATH="${openvino_2021_2_blob}"
     OPENVINO_2021_3_BLOB_PATH="${openvino_2021_3_blob}"
     OPENVINO_2021_4_BLOB_PATH="${openvino_2021_4_2_blob}"
-    # OPENVINO_2022_1_BLOB_PATH="${openvino_2022_1_blob}"
+    OPENVINO_2022_1_BLOB_PATH="${openvino_2022_1_blob}"
 )
 
 # Bootloader configuration tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,11 +166,11 @@ hunter_private_data(
     FILE "text-image-super-resolution-0001_2021.3_4shave.blob"
     LOCATION openvino_2021_3_blob
 )
-# OpenVINO 2021.4 blob
+# OpenVINO 2021.4.2 blob
 hunter_private_data(
     URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2021.4.2_4shave.blob"
     SHA1 "164b6b2ae48d38bc4f07cc8296b8bcb7644a1578"
-    FILE "text-image-super-resolution-0001_2021.4_4shave.blob"
+    FILE "text-image-super-resolution-0001_2021.4.2_4shave.blob"
     LOCATION openvino_2021_4_blob
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -168,8 +168,8 @@ hunter_private_data(
 )
 # OpenVINO 2021.4 blob
 hunter_private_data(
-    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2021.4_4shave.blob"
-    SHA1 "fd11bb63781fc3315cdf4bb74247a8b98817f6fd"
+    URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/network/text-image-super-resolution-0001_2021.4.2_4shave.blob"
+    SHA1 "164b6b2ae48d38bc4f07cc8296b8bcb7644a1578"
     FILE "text-image-super-resolution-0001_2021.4_4shave.blob"
     LOCATION openvino_2021_4_blob
 )

--- a/tests/src/openvino_blob_test.cpp
+++ b/tests/src/openvino_blob_test.cpp
@@ -120,6 +120,20 @@ TEST_CASE("OpenVINO 2021.4 setBlob") {
     dai::Device d(p);
 }
 
+TEST_CASE("OpenVINO 2022.1 setBlob") {
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::NeuralNetwork>();
+
+    dai::OpenVINO::Blob blob(OPENVINO_2022_1_BLOB_PATH);
+    REQUIRE(blob.version == dai::OpenVINO::VERSION_2022_1);
+    checkBlob(blob);
+    nn->setBlob(std::move(blob));
+
+    auto networkOpenvinoVersion = p.getOpenVINOVersion();
+    REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2022_1);
+    dai::Device d(p);
+}
+
 // setBlobPath
 
 TEST_CASE("OpenVINO 2020.3 blob") {
@@ -173,6 +187,15 @@ TEST_CASE("OpenVINO 2021.4 blob") {
     nn->setBlobPath(OPENVINO_2021_4_BLOB_PATH);
     auto networkOpenvinoVersion = p.getOpenVINOVersion();
     REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2021_4);
+    dai::Device d(p);
+}
+
+TEST_CASE("OpenVINO 2022.1 blob") {
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::NeuralNetwork>();
+    nn->setBlobPath(OPENVINO_2022_1_BLOB_PATH);
+    auto networkOpenvinoVersion = p.getOpenVINOVersion();
+    REQUIRE(networkOpenvinoVersion == dai::OpenVINO::VERSION_2022_1);
     dai::Device d(p);
 }
 


### PR DESCRIPTION
Todo:
-add 2022.1 support for blobconverter
-add tests
-change all blobs to 2022.1

Note that 2021.4 and 2022.1 are intercompatible.