### PR TITLE
Set lens position from calibration data

### DIFF
--- a/examples/Script/script_forward_frames.cpp
+++ b/examples/Script/script_forward_frames.cpp
@@ -11,7 +11,6 @@ int main() {
 
     // Define a source - color camera
     auto cam = pipeline.create<dai::node::ColorCamera>();
-    cam->initialControl.setManualFocus(130);
     // Not needed, you can display 1080P frames as well
     cam->setIspScale(1, 2);
 

--- a/examples/StereoDepth/rgb_depth_aligned.cpp
+++ b/examples/StereoDepth/rgb_depth_aligned.cpp
@@ -26,6 +26,7 @@ int main() {
 
     // Create pipeline
     dai::Pipeline pipeline;
+    dai::Device device;
     std::vector<std::string> queueNames;
 
     // Define sources and outputs
@@ -49,7 +50,16 @@ int main() {
     if(downscaleColor) camRgb->setIspScale(2, 3);
     // For now, RGB needs fixed focus to properly align with depth.
     // This value was used during calibration
-    camRgb->initialControl.setManualFocus(135);
+    try {
+        auto calibData = device.readCalibration();
+        auto lensPosition = calibData.getLensPosition(dai::CameraBoardSocket::RGB);
+        if(lensPosition) {
+            camRgb->initialControl.setManualFocus(lensPosition);
+        }
+    } catch(const std::exception& ex) {
+        std::cout << ex.what() << std::endl;
+        return 1;
+    }
 
     left->setResolution(monoRes);
     left->setBoardSocket(dai::CameraBoardSocket::LEFT);
@@ -70,7 +80,7 @@ int main() {
     stereo->disparity.link(depthOut->input);
 
     // Connect to device and start pipeline
-    dai::Device device(pipeline);
+    device.startPipeline(pipeline);
 
     // Sets queues size and behavior
     for(const auto& name : queueNames) {

--- a/examples/StereoDepth/rgb_depth_confidence_aligned.cpp
+++ b/examples/StereoDepth/rgb_depth_confidence_aligned.cpp
@@ -30,6 +30,7 @@ int main() {
 
     // Create pipeline
     dai::Pipeline pipeline;
+    dai::Device device;
     std::vector<std::string> queueNames;
 
     // Define sources and outputs
@@ -56,7 +57,16 @@ int main() {
     if(downscaleColor) camRgb->setIspScale(2, 3);
     // For now, RGB needs fixed focus to properly align with depth.
     // This value was used during calibration
-    camRgb->initialControl.setManualFocus(135);
+    try {
+        auto calibData = device.readCalibration();
+        auto lensPosition = calibData.getLensPosition(dai::CameraBoardSocket::RGB);
+        if(lensPosition) {
+            camRgb->initialControl.setManualFocus(lensPosition);
+        }
+    } catch(const std::exception& ex) {
+        std::cout << ex.what() << std::endl;
+        return 1;
+    }
 
     left->setResolution(monoRes);
     left->setBoardSocket(dai::CameraBoardSocket::LEFT);
@@ -78,7 +88,7 @@ int main() {
     stereo->confidenceMap.link(confOut->input);
 
     // Connect to device and start pipeline
-    dai::Device device(pipeline);
+    device.startPipeline(pipeline);
 
     // Sets queues size and behavior
     for(const auto& name : queueNames) {


### PR DESCRIPTION
Initally we used value `130` for lens position during calibration, which got hard-coded in examples. but that is now changed, camera dependent.

Reading the value from calibration data prior to setting lens position ensures correct RGB alignment for all boards.