### PR TITLE
Support for new S2/Pro devices

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "adc0375d7ec059f253627e076edc4aab7f7a1a6b")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "87b278f6d491234baae352f7cdf3dd0dc7791bba")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -295,6 +295,14 @@ std::tuple<int, int> ColorCamera::getResolutionSize() const {
         case ColorCameraProperties::SensorResolution::THE_13_MP:
             return {4208, 3120};
             break;
+
+        case ColorCameraProperties::SensorResolution::THE_720_P:
+            return {1280, 720};
+            break;
+
+        case ColorCameraProperties::SensorResolution::THE_800_P:
+            return {1280, 800};
+            break;
     }
 
     return {1920, 1080};


### PR DESCRIPTION
- FW: support for OAK-D-S2 / OAK-D-Pro using the latest board DM9098 R6M2E6
- Handle new resolutions `THE_720_P` and `THE_800_P` for ColorCamera, applicable to OV9782 on RGB/center socket

Related PR: https://github.com/luxonis/depthai-shared/pull/100