### PR TITLE
Resolve compilation issues with spdlog and newer fmtlib (external)

### DIFF
--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -48,7 +48,7 @@ DataOutputQueue::DataOutputQueue(const std::shared_ptr<XLinkConnection> conn, co
                                   name,
                                   std::chrono::duration_cast<std::chrono::microseconds>(t2Parse - t1Parse),
                                   data->getRaw()->data.size(),
-                                  type,
+                                  static_cast<std::int32_t>(type),
                                   spdlog::to_hex(metadata));
                 }
 

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -705,7 +705,7 @@ std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(s
         std::string errorMsg;
         std::tie(success, errorMsg) = flashConfigData(configJson);
         if(success) {
-            spdlog::debug("Success flashing the appMem configuration to '{}'", finalAppMem);
+            spdlog::debug("Success flashing the appMem configuration to '{}'", static_cast<std::int32_t>(finalAppMem));
         } else {
             throw std::runtime_error(errorMsg);
         }

--- a/src/utility/spdlog-fmt.hpp
+++ b/src/utility/spdlog-fmt.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/fmt.h>
 
 #include "depthai/utility/Path.hpp"
 


### PR DESCRIPTION
Implicit casting of enum class to integers have been disabled in fmt v8.1.0 and newer, which causes depthai-core compilation to fail when using external fmtlib with spdlog. This PR resolves that through explicit casts and also corrects an include which bypasses the SPDLOG_FMT_EXTERNAL macro.

Related fmtlib issue: https://github.com/fmtlib/fmt/issues/1841

Signed-off-by: Øystein Sture <os@skarvtech.com>