### PR TITLE
Disable Extrinsic connection check

### DIFF
--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -350,6 +350,14 @@ class CalibrationHandler {
                       std::string boardCustom = "");
 
     /**
+     * Set the productName which acts as alisas for users to identify the device
+     *
+     * @param productName Sets product name (alias).
+     */
+
+    void setProductName(std::string productName);
+
+    /**
      * Set the Camera Intrinsics object
      *
      * @param cameraId CameraId of the camera for which Camera intrinsics are being loaded

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -564,6 +564,11 @@ void CalibrationHandler::setBoardInfo(std::string productName,
     eepromData.version = 7;
 }
 
+void setProductName(std::string productName){
+    eepromData.productName = productName;
+}
+
+
 void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, std::vector<std::vector<float>> intrinsics, int width, int height) {
     if(intrinsics.size() != 3 || intrinsics[0].size() != 3) {
         throw std::runtime_error("Intrinsic Matrix size should always be 3x3 ");

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -564,7 +564,7 @@ void CalibrationHandler::setBoardInfo(std::string productName,
     eepromData.version = 7;
 }
 
-void setProductName(std::string productName){
+void CalibrationHandler::setProductName(std::string productName){
     eepromData.productName = productName;
 }
 

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -564,10 +564,12 @@ void CalibrationHandler::setBoardInfo(std::string productName,
     eepromData.version = 7;
 }
 
-void CalibrationHandler::setProductName(std::string productName){
+void CalibrationHandler::setProductName(std::string productName) {
     eepromData.productName = productName;
-}
 
+    // Bump version to V7
+    eepromData.version = 7;
+}
 
 void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, std::vector<std::vector<float>> intrinsics, int width, int height) {
     if(intrinsics.size() != 3 || intrinsics[0].size() != 3) {

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -941,9 +941,9 @@ void DeviceBase::flashCalibration2(CalibrationHandler calibrationDataHandler) {
     getFlashingPermissions(factoryPermissions, protectedPermissions);
     spdlog::debug("Flashing calibration. Factory permissions {}, Protected permissions {}", factoryPermissions, protectedPermissions);
 
-    if(!calibrationDataHandler.validateCameraArray()) {
+    /* if(!calibrationDataHandler.validateCameraArray()) {
         throw std::runtime_error("Failed to validate the extrinsics connection. Enable debug mode for more information.");
-    }
+    } */
 
     bool success;
     std::string errorMsg;

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -989,9 +989,9 @@ void DeviceBase::flashFactoryCalibration(CalibrationHandler calibrationDataHandl
         throw std::runtime_error("Calling factory API is not allowed in current configuration");
     }
 
-    if(!calibrationDataHandler.validateCameraArray()) {
+    /* if(!calibrationDataHandler.validateCameraArray()) {
         throw std::runtime_error("Failed to validate the extrinsics connection. Enable debug mode for more information.");
-    }
+    } */
 
     bool success;
     std::string errorMsg;

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -440,9 +440,9 @@ void PipelineImpl::unlink(const Node::Output& out, const Node::Input& in) {
 }
 
 void PipelineImpl::setCalibrationData(CalibrationHandler calibrationDataHandler) {
-    if(!calibrationDataHandler.validateCameraArray()) {
+    /* if(!calibrationDataHandler.validateCameraArray()) {
         throw std::runtime_error("Failed to validate the extrinsics connection. Enable debug mode for more information.");
-    }
+    } */
     globalProperties.calibData = calibrationDataHandler.getEepromData();
 }
 


### PR DESCRIPTION
This was more like hardcoded for OAK devices configuration. Which will affect the custom devices. So disabling it for now. 