### PR TITLE
Unchain node constructors

### DIFF
--- a/include/depthai/pipeline/node/DetectionParser.hpp
+++ b/include/depthai/pipeline/node/DetectionParser.hpp
@@ -21,9 +21,6 @@ class DetectionParser : public NodeCRTP<DeviceNode, DetectionParser, DetectionPa
    protected:
     Properties& getProperties();
 
-   private:
-    std::shared_ptr<RawEdgeDetectorConfig> rawConfig;
-
    public:
     DetectionParser(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId);
     DetectionParser(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props);

--- a/src/pipeline/node/AprilTag.cpp
+++ b/src/pipeline/node/AprilTag.cpp
@@ -5,10 +5,17 @@
 namespace dai {
 namespace node {
 
-AprilTag::AprilTag(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : AprilTag(par, nodeId, std::make_unique<AprilTag::Properties>()) {}
+AprilTag::AprilTag(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, AprilTag, AprilTagProperties>(par, nodeId, std::make_unique<AprilTag::Properties>()),
+      rawConfig(std::make_shared<RawAprilTagConfig>()),
+      initialConfig(rawConfig) {
+    setInputRefs({&inputConfig, &inputImage});
+    setOutputRefs({&out, &passthroughInputImage});
+}
+
 AprilTag::AprilTag(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, AprilTag, AprilTagProperties>(par, nodeId, std::move(props)),
-      rawConfig(std::make_shared<RawAprilTagConfig>()),
+      rawConfig(std::make_shared<RawAprilTagConfig>(properties.initialConfig)),
       initialConfig(rawConfig) {
     setInputRefs({&inputConfig, &inputImage});
     setOutputRefs({&out, &passthroughInputImage});

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -7,9 +7,8 @@
 namespace dai {
 namespace node {
 
-ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : ColorCamera(par, nodeId, std::make_unique<ColorCamera::Properties>()) {}
-ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
-    : NodeCRTP<DeviceNode, ColorCamera, ColorCameraProperties>(par, nodeId, std::move(props)),
+ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, ColorCamera, ColorCameraProperties>(par, nodeId, std::make_unique<ColorCamera::Properties>()),
       rawControl(std::make_shared<RawCameraControl>()),
       initialControl(rawControl) {
     properties.boardSocket = CameraBoardSocket::AUTO;
@@ -22,6 +21,14 @@ ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeI
     properties.fps = 30.0;
     properties.previewKeepAspectRatio = true;
 
+    setInputRefs({&inputConfig, &inputControl});
+    setOutputRefs({&video, &preview, &still, &isp, &raw});
+}
+
+ColorCamera::ColorCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
+    : NodeCRTP<DeviceNode, ColorCamera, ColorCameraProperties>(par, nodeId, std::move(props)),
+      rawControl(std::make_shared<RawCameraControl>(properties.initialControl)),
+      initialControl(rawControl) {
     setInputRefs({&inputConfig, &inputControl});
     setOutputRefs({&video, &preview, &still, &isp, &raw});
 }

--- a/src/pipeline/node/DetectionNetwork.cpp
+++ b/src/pipeline/node/DetectionNetwork.cpp
@@ -11,14 +11,20 @@ namespace node {
 //--------------------------------------------------------------------
 // Base Detection Network Class
 //--------------------------------------------------------------------
-DetectionNetwork::DetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : DetectionNetwork(par, nodeId, std::make_unique<Properties>()) {}
-DetectionNetwork::DetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
-    : NodeCRTP<NeuralNetwork, DetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::move(props)) {
+DetectionNetwork::DetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<NeuralNetwork, DetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::make_unique<Properties>()) {
     setInputRefs({&input});
     setOutputRefs({&out, &passthrough});
 
     // Default confidence threshold
     properties.parser.confidenceThreshold = 0.5;
+}
+
+
+DetectionNetwork::DetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
+    : NodeCRTP<NeuralNetwork, DetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::move(props)) {
+    setInputRefs({&input});
+    setOutputRefs({&out, &passthrough});
 }
 
 void DetectionNetwork::setConfidenceThreshold(float thresh) {
@@ -33,21 +39,22 @@ float DetectionNetwork::getConfidenceThreshold() const {
 // MobileNet
 //--------------------------------------------------------------------
 MobileNetDetectionNetwork::MobileNetDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : MobileNetDetectionNetwork(par, nodeId, std::make_unique<Properties>()) {}
-MobileNetDetectionNetwork::MobileNetDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
-    : NodeCRTP<DetectionNetwork, MobileNetDetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::move(props)) {
+    : NodeCRTP<DetectionNetwork, MobileNetDetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::make_unique<Properties>()) {
     properties.parser.nnFamily = DetectionNetworkType::MOBILENET;
 }
+MobileNetDetectionNetwork::MobileNetDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
+    : NodeCRTP<DetectionNetwork, MobileNetDetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::move(props)) {}
 
 //--------------------------------------------------------------------
 // YOLO
 //--------------------------------------------------------------------
 YoloDetectionNetwork::YoloDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : YoloDetectionNetwork(par, nodeId, std::make_unique<Properties>()) {}
-YoloDetectionNetwork::YoloDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
-    : NodeCRTP<DetectionNetwork, YoloDetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::move(props)) {
+    : NodeCRTP<DetectionNetwork, YoloDetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::make_unique<Properties>()) {
     properties.parser.nnFamily = DetectionNetworkType::YOLO;
 }
+
+YoloDetectionNetwork::YoloDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
+    : NodeCRTP<DetectionNetwork, YoloDetectionNetwork, DetectionNetworkProperties>(par, nodeId, std::move(props)) {}
 
 void YoloDetectionNetwork::setNumClasses(const int numClasses) {
     properties.parser.classes = numClasses;

--- a/src/pipeline/node/DetectionParser.cpp
+++ b/src/pipeline/node/DetectionParser.cpp
@@ -6,14 +6,13 @@ namespace dai {
 namespace node {
 
 DetectionParser::DetectionParser(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : NodeCRTP<DeviceNode, DetectionParser, DetectionParserProperties>(par, nodeId, std::make_unique<DetectionParser::Properties>()),
-      rawConfig(std::make_shared<RawEdgeDetectorConfig>()) {
+    : NodeCRTP<DeviceNode, DetectionParser, DetectionParserProperties>(par, nodeId, std::make_unique<DetectionParser::Properties>()) {
     setInputRefs({&input});
     setOutputRefs({&out});
 }
 
 DetectionParser::DetectionParser(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
-    : NodeCRTP<DeviceNode, DetectionParser, DetectionParserProperties>(par, nodeId, std::move(props)), rawConfig(std::make_shared<RawEdgeDetectorConfig>()) {
+    : NodeCRTP<DeviceNode, DetectionParser, DetectionParserProperties>(par, nodeId, std::move(props)) {
     setInputRefs({&input});
     setOutputRefs({&out});
 }

--- a/src/pipeline/node/DetectionParser.cpp
+++ b/src/pipeline/node/DetectionParser.cpp
@@ -6,7 +6,12 @@ namespace dai {
 namespace node {
 
 DetectionParser::DetectionParser(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : DetectionParser(par, nodeId, std::make_unique<DetectionParser::Properties>()) {}
+    : NodeCRTP<DeviceNode, DetectionParser, DetectionParserProperties>(par, nodeId, std::make_unique<DetectionParser::Properties>()),
+      rawConfig(std::make_shared<RawEdgeDetectorConfig>()) {
+    setInputRefs({&input});
+    setOutputRefs({&out});
+}
+
 DetectionParser::DetectionParser(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, DetectionParser, DetectionParserProperties>(par, nodeId, std::move(props)), rawConfig(std::make_shared<RawEdgeDetectorConfig>()) {
     setInputRefs({&input});

--- a/src/pipeline/node/EdgeDetector.cpp
+++ b/src/pipeline/node/EdgeDetector.cpp
@@ -6,10 +6,16 @@ namespace dai {
 namespace node {
 
 EdgeDetector::EdgeDetector(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : EdgeDetector(par, nodeId, std::make_unique<EdgeDetector::Properties>()) {}
+    : NodeCRTP<DeviceNode, EdgeDetector, EdgeDetectorProperties>(par, nodeId, std::make_unique<EdgeDetector::Properties>()),
+      rawConfig(std::make_shared<RawEdgeDetectorConfig>()),
+      initialConfig(rawConfig) {
+    setInputRefs({&inputConfig, &inputImage});
+    setOutputRefs({&outputImage, &passthroughInputImage});
+}
+
 EdgeDetector::EdgeDetector(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, EdgeDetector, EdgeDetectorProperties>(par, nodeId, std::move(props)),
-      rawConfig(std::make_shared<RawEdgeDetectorConfig>()),
+      rawConfig(std::make_shared<RawEdgeDetectorConfig>(properties.initialConfig)),
       initialConfig(rawConfig) {
     setInputRefs({&inputConfig, &inputImage});
     setOutputRefs({&outputImage, &passthroughInputImage});

--- a/src/pipeline/node/FeatureTracker.cpp
+++ b/src/pipeline/node/FeatureTracker.cpp
@@ -6,10 +6,16 @@ namespace dai {
 namespace node {
 
 FeatureTracker::FeatureTracker(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : FeatureTracker(par, nodeId, std::make_unique<FeatureTracker::Properties>()) {}
+    : NodeCRTP<DeviceNode, FeatureTracker, FeatureTrackerProperties>(par, nodeId, std::make_unique<FeatureTracker::Properties>()),
+      rawConfig(std::make_shared<RawFeatureTrackerConfig>()),
+      initialConfig(rawConfig) {
+    setInputRefs({&inputConfig, &inputImage});
+    setOutputRefs({&outputFeatures, &passthroughInputImage});
+}
+
 FeatureTracker::FeatureTracker(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, FeatureTracker, FeatureTrackerProperties>(par, nodeId, std::move(props)),
-      rawConfig(std::make_shared<RawFeatureTrackerConfig>()),
+      rawConfig(std::make_shared<RawFeatureTrackerConfig>(properties.initialConfig)),
       initialConfig(rawConfig) {
     setInputRefs({&inputConfig, &inputImage});
     setOutputRefs({&outputFeatures, &passthroughInputImage});

--- a/src/pipeline/node/IMU.cpp
+++ b/src/pipeline/node/IMU.cpp
@@ -5,7 +5,11 @@
 namespace dai {
 namespace node {
 
-IMU::IMU(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : IMU(par, nodeId, std::make_unique<IMU::Properties>()) {}
+IMU::IMU(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, IMU, IMUProperties>(par, nodeId, std::make_unique<IMU::Properties>()) {
+    setOutputRefs({&out});
+}
+
 IMU::IMU(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, IMU, IMUProperties>(par, nodeId, std::move(props)) {
     setOutputRefs({&out});

--- a/src/pipeline/node/ImageManip.cpp
+++ b/src/pipeline/node/ImageManip.cpp
@@ -2,10 +2,17 @@
 namespace dai {
 namespace node {
 
-ImageManip::ImageManip(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : ImageManip(par, nodeId, std::make_unique<ImageManip::Properties>()) {}
+ImageManip::ImageManip(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, ImageManip, ImageManipProperties>(par, nodeId, std::make_unique<ImageManip::Properties>()),
+      rawConfig(std::make_shared<RawImageManipConfig>()),
+      initialConfig(rawConfig) {
+    setInputRefs({&inputConfig, &inputImage});
+    setOutputRefs({&out});
+}
+
 ImageManip::ImageManip(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, ImageManip, ImageManipProperties>(par, nodeId, std::move(props)),
-      rawConfig(std::make_shared<RawImageManipConfig>()),
+      rawConfig(std::make_shared<RawImageManipConfig>(properties.initialConfig)),
       initialConfig(rawConfig) {
     setInputRefs({&inputConfig, &inputImage});
     setOutputRefs({&out});

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -5,14 +5,22 @@
 namespace dai {
 namespace node {
 
-MonoCamera::MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : MonoCamera(par, nodeId, std::make_unique<MonoCamera::Properties>()) {}
-MonoCamera::MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
-    : NodeCRTP<DeviceNode, MonoCamera, MonoCameraProperties>(par, nodeId, std::move(props)),
+MonoCamera::MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, MonoCamera, MonoCameraProperties>(par, nodeId, std::make_unique<MonoCamera::Properties>()),
       rawControl(std::make_shared<RawCameraControl>()),
       initialControl(rawControl) {
     properties.boardSocket = CameraBoardSocket::AUTO;
     properties.resolution = MonoCameraProperties::SensorResolution::THE_720_P;
     properties.fps = 30.0;
+
+    setInputRefs({&inputControl});
+    setOutputRefs({&out, &raw});
+}
+
+MonoCamera::MonoCamera(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
+    : NodeCRTP<DeviceNode, MonoCamera, MonoCameraProperties>(par, nodeId, std::move(props)),
+      rawControl(std::make_shared<RawCameraControl>(properties.initialControl)),
+      initialControl(rawControl) {
 
     setInputRefs({&inputControl});
     setOutputRefs({&out, &raw});

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -7,7 +7,15 @@ namespace dai {
 namespace node {
 
 NeuralNetwork::NeuralNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : NeuralNetwork(par, nodeId, std::make_unique<NeuralNetwork::Properties>()) {}
+    : NodeCRTP<DeviceNode, NeuralNetwork, NeuralNetworkProperties>(par, nodeId, std::make_unique<NeuralNetwork::Properties>()),
+      inputs("inputs", Input(*this, "", Input::Type::SReceiver, false, 1, true, {{DatatypeEnum::Buffer, true}})),
+      passthroughs("passthroughs", Output(*this, "", Output::Type::MSender, {{DatatypeEnum::Buffer, true}})) {
+    setInputRefs({&input});
+    setOutputRefs({&out, &passthrough});
+    setInputMapRefs({&inputs});
+    setOutputMapRefs({&passthroughs});
+}
+
 NeuralNetwork::NeuralNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, NeuralNetwork, NeuralNetworkProperties>(par, nodeId, std::move(props)),
       inputs("inputs", Input(*this, "", Input::Type::SReceiver, false, 1, true, {{DatatypeEnum::Buffer, true}})),

--- a/src/pipeline/node/ObjectTracker.cpp
+++ b/src/pipeline/node/ObjectTracker.cpp
@@ -6,7 +6,11 @@ namespace dai {
 namespace node {
 
 ObjectTracker::ObjectTracker(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : ObjectTracker(par, nodeId, std::make_unique<ObjectTracker::Properties>()) {}
+    : NodeCRTP<DeviceNode, ObjectTracker, ObjectTrackerProperties>(par, nodeId, std::make_unique<ObjectTracker::Properties>()) {
+    setInputRefs({&inputTrackerFrame, &inputDetectionFrame, &inputDetections});
+    setOutputRefs({&out, &passthroughTrackerFrame, &passthroughDetectionFrame, &passthroughDetections});
+}
+
 ObjectTracker::ObjectTracker(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, ObjectTracker, ObjectTrackerProperties>(par, nodeId, std::move(props)) {
     setInputRefs({&inputTrackerFrame, &inputDetectionFrame, &inputDetections});

--- a/src/pipeline/node/SPIIn.cpp
+++ b/src/pipeline/node/SPIIn.cpp
@@ -3,10 +3,13 @@
 namespace dai {
 namespace node {
 
-SPIIn::SPIIn(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : SPIIn(par, nodeId, std::make_unique<SPIIn::Properties>()) {}
+SPIIn::SPIIn(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, SPIIn, SPIInProperties>(par, nodeId, std::make_unique<SPIIn::Properties>()) {
+    properties.busId = 0;
+    setOutputRefs({&out});
+}
 SPIIn::SPIIn(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, SPIIn, SPIInProperties>(par, nodeId, std::move(props)) {
-    properties.busId = 0;
     setOutputRefs({&out});
 }
 

--- a/src/pipeline/node/Script.cpp
+++ b/src/pipeline/node/Script.cpp
@@ -6,14 +6,22 @@
 namespace dai {
 namespace node {
 
-Script::Script(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : Script(par, nodeId, std::make_unique<Script::Properties>()) {}
-Script::Script(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
-    : NodeCRTP<DeviceNode, Script, ScriptProperties>(par, nodeId, std::move(props)),
+Script::Script(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, Script, ScriptProperties>(par, nodeId, std::make_unique<Script::Properties>()),
       inputs("io", Input(*this, "", Input::Type::SReceiver, {{DatatypeEnum::Buffer, true}})),
       outputs("io", Output(*this, "", Output::Type::MSender, {{DatatypeEnum::Buffer, true}})) {
     properties.scriptUri = "";
     properties.scriptName = "<script>";
     properties.processor = ProcessorType::LEON_MSS;
+
+    setInputMapRefs(&inputs);
+    setOutputMapRefs(&outputs);
+}
+
+Script::Script(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
+    : NodeCRTP<DeviceNode, Script, ScriptProperties>(par, nodeId, std::move(props)),
+      inputs("io", Input(*this, "", Input::Type::SReceiver, {{DatatypeEnum::Buffer, true}})),
+      outputs("io", Output(*this, "", Output::Type::MSender, {{DatatypeEnum::Buffer, true}})) {
 
     setInputMapRefs(&inputs);
     setOutputMapRefs(&outputs);

--- a/src/pipeline/node/SpatialDetectionNetwork.cpp
+++ b/src/pipeline/node/SpatialDetectionNetwork.cpp
@@ -12,7 +12,11 @@ namespace node {
 // Base Detection Network Class
 //--------------------------------------------------------------------
 SpatialDetectionNetwork::SpatialDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : SpatialDetectionNetwork(par, nodeId, std::make_unique<Properties>()) {}
+    : NodeCRTP<DetectionNetwork, SpatialDetectionNetwork, SpatialDetectionNetworkProperties>(par, nodeId, std::make_unique<Properties>()) {
+    setInputRefs({&input, &inputDepth});
+    setOutputRefs({&out, &boundingBoxMapping, &passthrough, &passthroughDepth});
+}
+
 SpatialDetectionNetwork::SpatialDetectionNetwork(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DetectionNetwork, SpatialDetectionNetwork, SpatialDetectionNetworkProperties>(par, nodeId, std::move(props)) {
     setInputRefs({&input, &inputDepth});

--- a/src/pipeline/node/SpatialLocationCalculator.cpp
+++ b/src/pipeline/node/SpatialLocationCalculator.cpp
@@ -6,10 +6,16 @@ namespace dai {
 namespace node {
 
 SpatialLocationCalculator::SpatialLocationCalculator(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : SpatialLocationCalculator(par, nodeId, std::make_unique<SpatialLocationCalculator::Properties>()) {}
+    : NodeCRTP<DeviceNode, SpatialLocationCalculator, SpatialLocationCalculatorProperties>(par, nodeId, std::make_unique<SpatialLocationCalculator::Properties>()),
+      rawConfig(std::make_shared<RawSpatialLocationCalculatorConfig>()),
+      initialConfig(rawConfig) {
+    setInputRefs({&inputConfig, &inputDepth});
+    setOutputRefs({&out, &passthroughDepth});
+}
+
 SpatialLocationCalculator::SpatialLocationCalculator(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, SpatialLocationCalculator, SpatialLocationCalculatorProperties>(par, nodeId, std::move(props)),
-      rawConfig(std::make_shared<RawSpatialLocationCalculatorConfig>()),
+      rawConfig(std::make_shared<RawSpatialLocationCalculatorConfig>(properties.roiConfig)),
       initialConfig(rawConfig) {
     setInputRefs({&inputConfig, &inputDepth});
     setOutputRefs({&out, &passthroughDepth});

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -9,10 +9,32 @@
 namespace dai {
 namespace node {
 
-StereoDepth::StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : StereoDepth(par, nodeId, std::make_unique<StereoDepth::Properties>()) {}
+StereoDepth::StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, StereoDepth, StereoDepthProperties>(par, nodeId, std::make_unique<StereoDepth::Properties>()),
+      rawConfig(std::make_shared<RawStereoDepthConfig>()),
+      initialConfig(rawConfig) {
+    // 'properties' defaults already set
+    setInputRefs({&inputConfig, &left, &right});
+    setOutputRefs({&depth,
+                   &disparity,
+                   &syncedLeft,
+                   &syncedRight,
+                   &rectifiedLeft,
+                   &rectifiedRight,
+                   &outConfig,
+                   &debugDispLrCheckIt1,
+                   &debugDispLrCheckIt2,
+                   &debugExtDispLrCheckIt1,
+                   &debugExtDispLrCheckIt2,
+                   &debugDispCostDump,
+                   &confidenceMap});
+
+    setDefaultProfilePreset(presetMode);
+}
+
 StereoDepth::StereoDepth(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, StereoDepth, StereoDepthProperties>(par, nodeId, std::move(props)),
-      rawConfig(std::make_shared<RawStereoDepthConfig>()),
+      rawConfig(std::make_shared<RawStereoDepthConfig>(properties.initialConfig)),
       initialConfig(rawConfig) {
     // 'properties' defaults already set
     setInputRefs({&inputConfig, &left, &right});

--- a/src/pipeline/node/SystemLogger.cpp
+++ b/src/pipeline/node/SystemLogger.cpp
@@ -4,11 +4,15 @@ namespace dai {
 namespace node {
 
 SystemLogger::SystemLogger(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : SystemLogger(par, nodeId, std::make_unique<SystemLogger::Properties>()) {}
-SystemLogger::SystemLogger(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
-    : NodeCRTP<DeviceNode, SystemLogger, SystemLoggerProperties>(par, nodeId, std::move(props)) {
+    : NodeCRTP<DeviceNode, SystemLogger, SystemLoggerProperties>(par, nodeId, std::make_unique<SystemLogger::Properties>()) {
     properties.rateHz = 1.0f;
 
+    setOutputRefs(&out);
+}
+
+
+SystemLogger::SystemLogger(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
+    : NodeCRTP<DeviceNode, SystemLogger, SystemLoggerProperties>(par, nodeId, std::move(props)) {
     setOutputRefs(&out);
 }
 

--- a/src/pipeline/node/VideoEncoder.cpp
+++ b/src/pipeline/node/VideoEncoder.cpp
@@ -10,7 +10,11 @@ namespace dai {
 namespace node {
 
 VideoEncoder::VideoEncoder(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
-    : VideoEncoder(par, nodeId, std::make_unique<VideoEncoder::Properties>()) {}
+    : NodeCRTP<DeviceNode, VideoEncoder, VideoEncoderProperties>(par, nodeId, std::make_unique<VideoEncoder::Properties>()) {
+    setInputRefs({&input});
+    setOutputRefs({&bitstream});
+}
+
 VideoEncoder::VideoEncoder(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, VideoEncoder, VideoEncoderProperties>(par, nodeId, std::move(props)) {
     setInputRefs({&input});

--- a/src/pipeline/node/XLinkIn.cpp
+++ b/src/pipeline/node/XLinkIn.cpp
@@ -3,7 +3,11 @@
 namespace dai {
 namespace node {
 
-XLinkIn::XLinkIn(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : XLinkIn(par, nodeId, std::make_unique<XLinkIn::Properties>()) {}
+XLinkIn::XLinkIn(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, XLinkIn, XLinkInProperties>(par, nodeId, std::make_unique<XLinkIn::Properties>()) {
+    setOutputRefs(&out);
+}
+
 XLinkIn::XLinkIn(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, XLinkIn, XLinkInProperties>(par, nodeId, std::move(props)) {
     setOutputRefs(&out);

--- a/src/pipeline/node/XLinkOut.cpp
+++ b/src/pipeline/node/XLinkOut.cpp
@@ -3,10 +3,14 @@
 namespace dai {
 namespace node {
 
-XLinkOut::XLinkOut(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId) : XLinkOut(par, nodeId, std::make_unique<XLinkOut::Properties>()) {}
+XLinkOut::XLinkOut(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId)
+    : NodeCRTP<DeviceNode, XLinkOut, XLinkOutProperties>(par, nodeId, std::make_unique<XLinkOut::Properties>()) {
+    properties.maxFpsLimit = -1;
+    setInputRefs(&input);
+}
+
 XLinkOut::XLinkOut(const std::shared_ptr<PipelineImpl>& par, int64_t nodeId, std::unique_ptr<Properties> props)
     : NodeCRTP<DeviceNode, XLinkOut, XLinkOutProperties>(par, nodeId, std::move(props)) {
-    properties.maxFpsLimit = -1;
     setInputRefs(&input);
 }
 


### PR DESCRIPTION
Use a separate constructor for when the node is constructed on the node (with the properties given)
and for when the node is constructed on the host (no properties given).

This is done to avoid properties being overridden by defaults when recreating the node on the device.