### PR TITLE
Fix ColorCamera::getSensorCrop calculation for AUTO

### DIFF
--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -363,8 +363,8 @@ void ColorCamera::setSensorCrop(float x, float y) {
 std::tuple<float, float> ColorCamera::getSensorCrop() const {
     // AUTO - center crop by default
     if(properties.sensorCropX == ColorCameraProperties::AUTO || properties.sensorCropY == ColorCameraProperties::AUTO) {
-        float x = std::floor(((getResolutionWidth() - getVideoWidth()) / 2.0f) / getResolutionWidth());
-        float y = std::floor(((getResolutionHeight() - getVideoHeight()) / 2.0f) / getResolutionHeight());
+        float x = std::floor(((getResolutionWidth() - getVideoWidth()) / 2.0f)) / getResolutionWidth();
+        float y = std::floor(((getResolutionHeight() - getVideoHeight()) / 2.0f)) / getResolutionHeight();
         return {x, y};
     }
     return {properties.sensorCropX, properties.sensorCropY};


### PR DESCRIPTION
 ```
camRgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_4_K)
camRgb.setVideoSize(1920, 1080)
print(f'sensor crop: {camRgb.getSensorCropX()}, {camRgb.getSensorCropY()}')
```
returned `(0, 0)` instead of `(0.25, 0.25)`

Rounding for the normalized float value (< 1) was applied to the final result.