### PR TITLE
Release v2.19.0

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
@@ -71,23 +71,23 @@ jobs:
     steps:
     - name: Cache .hunter folder
       if: matrix.os != 'windows-latest'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.hunter/
         key: hunter-${{ matrix.os }}-${{ matrix.cmake }}
     - name: Cache .hunter folder
       if: matrix.os == 'windows-latest'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: C:/.hunter/
         key: hunter-${{ matrix.os }}-${{ matrix.cmake }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.9
+      uses: jwlawson/actions-setup-cmake@v1.13
       with:
         cmake-version: ${{ matrix.cmake }}
 
@@ -147,18 +147,18 @@ jobs:
     steps:
     - name: Cache .hunter folder
       if: matrix.os != 'windows-latest'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.hunter/
         key: hunter-${{ matrix.os }}-shared_${{ matrix.shared }}
     - name: Cache .hunter folder
       if: matrix.os == 'windows-latest'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: C:/.hunter/
         key: hunter-${{ matrix.os }}-shared_${{ matrix.shared }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
@@ -193,14 +193,14 @@ jobs:
 
     - name: Upload Win64 shared library
       if: matrix.os == 'windows-latest' && matrix.shared && matrix.platform == 'x64'
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v3
       with:
         name: windows-prebuilt-win64
         path: ${{ env.GITHUB_WORKSPACE }}/depthai_install/
 
     - name: Upload Win32 shared library
       if: matrix.os == 'windows-latest' && matrix.shared && matrix.platform == 'Win32'
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v3
       with:
         name: windows-prebuilt-win32-no-opencv
         path: ${{ env.GITHUB_WORKSPACE }}/depthai_install/
@@ -234,11 +234,12 @@ jobs:
 
     # Clone repository
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
     # Get tag version
+    # TODO(themarpe) - Node12, has to be updated
     - name: Get latest release version number
       id: tag
       uses: battila7/get-version-action@v2
@@ -247,20 +248,20 @@ jobs:
     #- name: Check if version matches
     #   run: |
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: '3.8'
     - name: Install dependencies
       run: python3.8 -m pip install git-archive-all
 
     - name: Download Win64 artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: 'windows-prebuilt-win64'
         path: depthai-core-${{ steps.tag.outputs.version }}-win64
 
     - name: Download Win32 artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: 'windows-prebuilt-win32-no-opencv'
         path: depthai-core-${{ steps.tag.outputs.version }}-win32-no-opencv

--- a/.github/workflows/stability.workflow.yml
+++ b/.github/workflows/stability.workflow.yml
@@ -26,11 +26,11 @@ jobs:
     timeout-minutes: 1450 # 24h & 10minutes
     steps:
     - name: Cache .hunter folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: $HOME/.hun_vanilla
         key: hunter-linux-stability-vanilla
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Cache .hunter folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: $HOME/.hun2_${{ matrix.flavor }}
         key: hunter-${{ matrix.os }}-${{ matrix.cmake }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if(WIN32)
 endif()
 
 # Create depthai project
-project(depthai VERSION "2.18.0" LANGUAGES CXX C)
+project(depthai VERSION "2.19.0" LANGUAGES CXX C)
 get_directory_property(has_parent PARENT_DIRECTORY)
 if(has_parent)
     set(DEPTHAI_VERSION ${PROJECT_VERSION} PARENT_SCOPE)

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "29ed0ecddecc052d23200a56b0a717eacf5e18cc")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "b3aeaf23ff5857fc8f79d412ceefc08da23e7aad")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "e71909589f2e3c3eba87e28d2e2ef0b05523eb1c")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "6d514c337c5f893f0a63bfd1781af6bcffb72bca")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "c62955ce3e726f06e81eb5b0b868c3cb0866a5bf")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "e71909589f2e3c3eba87e28d2e2ef0b05523eb1c")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "313a7065c10a61c2651105b0e3cde7b4d159ebd8")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "29ed0ecddecc052d23200a56b0a717eacf5e18cc")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "6d514c337c5f893f0a63bfd1781af6bcffb72bca")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "313a7065c10a61c2651105b0e3cde7b4d159ebd8")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a555263a9dbff1166088bcb758ab4306dca9ae1a")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "c62955ce3e726f06e81eb5b0b868c3cb0866a5bf")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,8 +8,8 @@ hunter_config(
 hunter_config(
     XLink
     VERSION "luxonis-2021.4.2-develop"
-    URL "https://github.com/luxonis/XLink/archive/4f8cd1f9b2ab1b44e36c448a4b7d5d80255f5872.tar.gz"
-    SHA1 "fe7aaa8a61ddd7e9030c6c2720978e35a1449fba"
+    URL "https://github.com/luxonis/XLink/archive/5c61615066af6539e50a4a17b5df3466e4350b21.tar.gz"
+    SHA1 "25fba41da891743bf0bdff5bc9a5cda07535be49"
 )
 
 hunter_config(

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -659,6 +659,13 @@ class DeviceBase {
     void setTimesync(std::chrono::milliseconds period, int numSamples, bool random);
 
     /**
+     * Enables or disables Timesync service on device. It keeps host and device clocks in sync.
+     *
+     * @param enable Enables or disables consistent timesyncing
+     */
+    void setTimesync(bool enable);
+
+    /**
      * Explicitly closes connection to device.
      * @note This function does not need to be explicitly called
      * as destructor closes the device automatically

--- a/include/depthai/device/DeviceBootloader.hpp
+++ b/include/depthai/device/DeviceBootloader.hpp
@@ -405,6 +405,12 @@ class DeviceBootloader {
     MemoryInfo getMemoryInfo(Memory memory);
 
     /**
+     * Checks whether User Bootloader is supported with current bootloader
+     * @returns true of User Bootloader is supported, false otherwise
+     */
+    bool isUserBootloaderSupported();
+
+    /**
      * Retrieves whether current bootloader is User Bootloader (B out of A/B configuration)
      */
     bool isUserBootloader();

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -948,8 +948,20 @@ bool DeviceBase::removeLogCallback(int callbackId) {
 void DeviceBase::setTimesync(std::chrono::milliseconds period, int numSamples, bool random) {
     checkClosed();
 
+    if(period < std::chrono::milliseconds(10)) {
+        throw std::invalid_argument("Period must be greater or equal than 10ms");
+    }
+
     using namespace std::chrono;
     pimpl->rpcClient->call("setTimesync", duration_cast<milliseconds>(period).count(), numSamples, random);
+}
+
+void DeviceBase::setTimesync(bool enable) {
+    if(enable) {
+        setTimesync(DEFAULT_TIMESYNC_PERIOD, DEFAULT_TIMESYNC_NUM_SAMPLES, DEFAULT_TIMESYNC_RANDOM);
+    } else {
+        setTimesync(std::chrono::milliseconds(1000), 0, false);
+    }
 }
 
 void DeviceBase::setSystemInformationLoggingRate(float rateHz) {

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -309,7 +309,14 @@ void DeviceBase::tryGetDevice() {
     std::tie(found, deviceInfo) = getAnyAvailableDevice();
 
     // If no device found, throw
-    if(!found) throw std::runtime_error("No available devices");
+    if(!found) {
+        auto numConnected = getAllAvailableDevices().size();
+        if(numConnected > 0) {
+            throw std::runtime_error(fmt::format("No available devices ({} connected, but in use)", numConnected));
+        } else {
+            throw std::runtime_error("No available devices");
+        }
+    }
 }
 
 DeviceBase::DeviceBase(OpenVINO::Version version, const DeviceInfo& devInfo) : DeviceBase(version, devInfo, DeviceBase::DEFAULT_USB_SPEED) {}

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -664,6 +664,21 @@ DeviceBootloader::MemoryInfo DeviceBootloader::getMemoryInfo(Memory memory) {
     return mem;
 }
 
+bool DeviceBootloader::isUserBootloaderSupported() {
+    // Check that type is NETWORK
+    const auto type = Type::NETWORK;
+    if(getType() != Type::NETWORK) {
+        return false;
+    }
+
+    // Check if bootloader version is adequate
+    if(getVersion().getSemver() < Version(Request::IsUserBootloader::VERSION)) {
+        return false;
+    }
+
+    return true;
+}
+
 bool DeviceBootloader::isUserBootloader() {
     // Check if bootloader version is adequate
     if(getVersion().getSemver() < Version(Request::IsUserBootloader::VERSION)) {
@@ -884,7 +899,7 @@ std::tuple<bool, std::string> DeviceBootloader::flashUserBootloader(std::functio
     // }
 
     // Check if bootloader version is adequate
-    if(getVersion().getSemver() < Version("0.0.21")) {
+    if(getVersion().getSemver() < Version(Request::IsUserBootloader::VERSION)) {
         throw std::runtime_error("Current bootloader version doesn't support User Bootloader");
     }
 

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -666,7 +666,6 @@ DeviceBootloader::MemoryInfo DeviceBootloader::getMemoryInfo(Memory memory) {
 
 bool DeviceBootloader::isUserBootloaderSupported() {
     // Check that type is NETWORK
-    const auto type = Type::NETWORK;
     if(getType() != Type::NETWORK) {
         return false;
     }


### PR DESCRIPTION
Major stability improvements and many bugfixes that arose along the big v2.18.0 feature set

## Features
 - Stability improvements #616 
 - `isUserBootloaderSupported` API 
 - `Device.setTimesync(true/false)` convenience function to enable or disable subsequent timesyncing
 - Windows improvements with listing `BOOTED` devices ("udev permissions" issue)

## Bug fixes
 - Fix OV9282 as MonoCamera on RGB socket (issue was black image)
 - Fix crash under high load (regression with camera events streaming)
 - Fix YOLOv5/7 decoding in case of a single class
 - Fix image size when decimation filter is enabled
 - Fix for certain OV9782 and OV9282 permutations/configs

## Misc
 - Reset Device timestamp on boot to zero
 - Reworded "No available devices" error message when there are other connected devices connected.
 - Update CI to Node16 compatible actions