### PR TITLE
Fixed check for user-provided toolchain file when given relative path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ if(NOT WIN32)
     set(HUNTER_CONFIGURATION_TYPES "Release" CACHE STRING "Hunter dependencies list of build configurations")
 endif()
 
+# Set type to canonicalize relative paths for user-provided toolchain
+set(CMAKE_TOOLCHAIN_FILE "" CACHE FILEPATH "CMake toolchain path")
+
 # Create a custom toolchain to pass certain options to dependencies
 set(gen_toolchain "${CMAKE_CURRENT_BINARY_DIR}/generated/toolchain.cmake")
 

--- a/cmake/toolchain/custom.cmake.in
+++ b/cmake/toolchain/custom.cmake.in
@@ -26,12 +26,11 @@ if(NOT "@CMAKE_TOOLCHAIN_FILE@" STREQUAL "")
   if("@_INTERNAL_DEPTHAI_ORIGINAL_CMAKE_TOOLCHAIN_FILE@" STREQUAL "")
     # Variable not set, initial project configuration.
     # Path to original toolchain saved in CMAKE_TOOLCHAIN_FILE.
-    if(NOT EXISTS "@CMAKE_TOOLCHAIN_FILE@")
-      message(
-          FATAL_ERROR "File not found: '@CMAKE_TOOLCHAIN_FILE@'"
-      )
-    endif()
-    set(_original_toolchain_file "@CMAKE_TOOLCHAIN_FILE@")
+    
+    get_filename_component(
+      _original_toolchain_file "@CMAKE_TOOLCHAIN_FILE@"
+      ABSOLUTE BASE_DIR @CMAKE_CURRENT_SOURCE_DIR@
+    )
   else()
     set(_original_toolchain_file "@_INTERNAL_DEPTHAI_ORIGINAL_CMAKE_TOOLCHAIN_FILE@")
   endif()

--- a/cmake/toolchain/custom.cmake.in
+++ b/cmake/toolchain/custom.cmake.in
@@ -26,11 +26,12 @@ if(NOT "@CMAKE_TOOLCHAIN_FILE@" STREQUAL "")
   if("@_INTERNAL_DEPTHAI_ORIGINAL_CMAKE_TOOLCHAIN_FILE@" STREQUAL "")
     # Variable not set, initial project configuration.
     # Path to original toolchain saved in CMAKE_TOOLCHAIN_FILE.
-    
-    get_filename_component(
-      _original_toolchain_file "@CMAKE_TOOLCHAIN_FILE@"
-      ABSOLUTE BASE_DIR @CMAKE_CURRENT_SOURCE_DIR@
-    )
+    if(NOT EXISTS "@CMAKE_TOOLCHAIN_FILE@")
+      message(
+          FATAL_ERROR "File not found: '@CMAKE_TOOLCHAIN_FILE@'"
+      )
+    endif()
+    set(_original_toolchain_file "@CMAKE_TOOLCHAIN_FILE@")
   else()
     set(_original_toolchain_file "@_INTERNAL_DEPTHAI_ORIGINAL_CMAKE_TOOLCHAIN_FILE@")
   endif()


### PR DESCRIPTION
`if(EXISTS path-to-file-or-directory)` was used to check for the existence of a user-provided toolchain file. According to the CMake docs, "[EXISTS] is well-defined only for explicit full paths (a leading \~/ is not expanded as a home directory and is considered a relative path)". This leads to two problems. First, we cannot pass a relative path as a toolchain as it may not be detected correctly. Second, we cannot use `if(IS_ABSOLUTE path)` to enforce an absolute path or correct a relative one because "On non-Windows hosts, any path that begins with a tilde (\~) evaluates to true." (It appears the left hand of Kitware doesn't know what the right hand is doing...)

To fix this, use `get_filename_component` to canonicalize a relative path while keeping absolute paths unchanged. If the file doesn't exist, CMake will exit with a more obnoxious error than what came before it. Unfortunately, I don't think there's much to be done about that.

`@CMAKE_CURRENT_SOURCE_DIR@` is passed in as the base for relative paths, forcing the path relative to the depthai-core root when the toolchain file is generated. This is less than ideal if the library is configured as part of a larger project using `add_subdirectory`, but I suppose not every workflow can be accommodated perfectly. 
This may also appear strange as the default base is `CMAKE_CURRENT_SOURCE_DIR`. It turns out that the custom toolchain file is invoked multiple times by CMake and that the value of `CMAKE_CURRENT_SOURCE_DIR` will change in at least one invocation. This explains why it appeared that relative paths would break completely rather than just finding some path that would work as expected.

Closes #644 