### PR TITLE
Move hunter to install in the build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ else()
     message(STATUS "Using toolchain file: ${CMAKE_TOOLCHAIN_FILE}")
 endif()
 
+set(HUNTER_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 include("cmake/HunterGate.cmake")
 HunterGate(
     URL "https://github.com/cpp-pm/hunter/archive/v0.23.322.tar.gz"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,7 @@ else()
     message(STATUS "Using toolchain file: ${CMAKE_TOOLCHAIN_FILE}")
 endif()
 
-if(NOT WIN32)
-    set(HUNTER_ROOT ${CMAKE_CURRENT_BINARY_DIR}/hunter)
-endif()
-
+set(HUNTER_ROOT ${CMAKE_CURRENT_BINARY_DIR}/hunter)
 include("cmake/HunterGate.cmake")
 HunterGate(
     URL "https://github.com/cpp-pm/hunter/archive/v0.23.322.tar.gz"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ else()
     message(STATUS "Using toolchain file: ${CMAKE_TOOLCHAIN_FILE}")
 endif()
 
+# Move binary dir if windows, to shorten the path
+if(WIN32)
+    set(HUNTER_BINARY_DIR "${HUNTER_GATE_ROOT}/_bin" CACHE STRING "Hunter binary directory")
+endif()
+
 set(HUNTER_ROOT ${CMAKE_CURRENT_BINARY_DIR}/hunter)
 include("cmake/HunterGate.cmake")
 HunterGate(
@@ -35,10 +40,6 @@ HunterGate(
     LOCAL # Local config for dependencies
 )
 
-# Move binary dir if windows, to shorten the path
-if(WIN32)
-    set(HUNTER_BINARY_DIR "${HUNTER_GATE_ROOT}/_bin" CACHE STRING "Hunter binary directory")
-endif()
 
 # Create depthai project
 project(depthai VERSION "2.19.1" LANGUAGES CXX C)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
     message(STATUS "Using toolchain file: ${CMAKE_TOOLCHAIN_FILE}")
 endif()
 
-set(HUNTER_ROOT ${CMAKE_CURRENT_BINARY_DIR})
+set(HUNTER_ROOT ${CMAKE_CURRENT_BINARY_DIR}/hunter)
 include("cmake/HunterGate.cmake")
 HunterGate(
     URL "https://github.com/cpp-pm/hunter/archive/v0.23.322.tar.gz"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,10 @@ else()
     message(STATUS "Using toolchain file: ${CMAKE_TOOLCHAIN_FILE}")
 endif()
 
-set(HUNTER_ROOT ${CMAKE_CURRENT_BINARY_DIR}/hunter)
+if(NOT WIN32)
+    set(HUNTER_ROOT ${CMAKE_CURRENT_BINARY_DIR}/hunter)
+endif()
+
 include("cmake/HunterGate.cmake")
 HunterGate(
     URL "https://github.com/cpp-pm/hunter/archive/v0.23.322.tar.gz"

--- a/README.md
+++ b/README.md
@@ -206,12 +206,6 @@ After that specify CMake define `-D'DEPTHAI_BUILD_DOCS=ON`' and build the target
 Debugging can be done using **Visual Studio Code** and either **GDB** or **LLDB** (extension 'CodeLLDB').
 LLDB in some cases was much faster to step with and resolved more `incomplete_type` variables than GDB. Your mileage may vary though.
 
-
-If there is a need to step into **Hunter** libraries, that can be achieved by removing previous built artifacts
-```
-rm -r ~/.hunter
-```
-
 And configuring the project with the following CMake option set to `ON`
 ```
 cmake . -D'HUNTER_KEEP_PACKAGE_SOURCES=ON'
@@ -241,17 +235,3 @@ If you are stuck with error message which mentions external libraries (subdirect
 /usr/bin/ld: /home/[user]/.hunter/_Base/062a19a/ccfed35/a84a713/Install/lib/liblzma.a(stream_flags_decoder.c.o): warning: relocation against `lzma_footer_magic' in read-only section `.text'
 ```
 
-Try erasing the **Hunter** cache folder.
-
-Linux/MacOS:
-```
-rm -r ~/.hunter
-```
-Windows:
-```
-del C:/.hunter
-```
-or
-```
-del C:/[user]/.hunter
-```


### PR DESCRIPTION
Adding a build dependency to a relatively random location in the user's home directory is, well, a bit random and causes a couple of issues.
A clean build required removal of that directory
It clutters the users home directory
in cases where the home directory is always new (such as building in a docker container) requires rebuild of the hunter package at each build. (assuming that the build directory is bind mounted to the build container)

This change moves the default location for the hunter archive and make to the build directory.

This has been tested on the main branch, but merging into develop branch.