### PR TITLE
fix luxonis/depthai-core#650 missing XLinkProtocolToStr()

### DIFF
--- a/examples/bootloader/flash_bootloader.cpp
+++ b/examples/bootloader/flash_bootloader.cpp
@@ -5,6 +5,21 @@
 #include "depthai/depthai.hpp"
 #include "depthai/xlink/XLinkConnection.hpp"
 
+static const char* ProtocolToStr(XLinkProtocol_t val) {
+    switch (val) {
+        case X_LINK_USB_VSC: return "X_LINK_USB_VSC";
+        case X_LINK_USB_CDC: return "X_LINK_USB_CDC";
+        case X_LINK_PCIE: return "X_LINK_PCIE";
+        case X_LINK_IPC: return "X_LINK_IPC";
+        case X_LINK_TCP_IP: return "X_LINK_TCP_IP";
+        case X_LINK_NMB_OF_PROTOCOLS: return "X_LINK_NMB_OF_PROTOCOLS";
+        case X_LINK_ANY_PROTOCOL: return "X_LINK_ANY_PROTOCOL";
+        default:
+            return "INVALID_ENUM_VALUE";
+            break;
+    }
+}
+
 int main(int argc, char** argv) {
     using namespace std::chrono;
 
@@ -29,7 +44,7 @@ int main(int argc, char** argv) {
     } else {
         for(int i = 0; i < deviceInfos.size(); i++) {
             const auto& devInfo = deviceInfos[i];
-            std::cout << "[" << i << "] " << devInfo.getMxId() << "[" << XLinkProtocolToStr(devInfo.protocol) << "]";
+            std::cout << "[" << i << "] " << devInfo.getMxId() << "[" << ProtocolToStr(devInfo.protocol) << "]";
             if(devInfo.state == X_LINK_BOOTLOADER) {
                 dai::DeviceBootloader bl(devInfo);
                 std::cout << " current bootloader: " << bl.getVersion();

--- a/examples/bootloader/flash_user_bootloader.cpp
+++ b/examples/bootloader/flash_user_bootloader.cpp
@@ -5,6 +5,21 @@
 #include "depthai/depthai.hpp"
 #include "depthai/xlink/XLinkConnection.hpp"
 
+static const char* ProtocolToStr(XLinkProtocol_t val) {
+    switch (val) {
+        case X_LINK_USB_VSC: return "X_LINK_USB_VSC";
+        case X_LINK_USB_CDC: return "X_LINK_USB_CDC";
+        case X_LINK_PCIE: return "X_LINK_PCIE";
+        case X_LINK_IPC: return "X_LINK_IPC";
+        case X_LINK_TCP_IP: return "X_LINK_TCP_IP";
+        case X_LINK_NMB_OF_PROTOCOLS: return "X_LINK_NMB_OF_PROTOCOLS";
+        case X_LINK_ANY_PROTOCOL: return "X_LINK_ANY_PROTOCOL";
+        default:
+            return "INVALID_ENUM_VALUE";
+            break;
+    }
+}
+
 int main(int argc, char** argv) try {
     using namespace std::chrono;
 
@@ -16,7 +31,7 @@ int main(int argc, char** argv) try {
     } else {
         for(int i = 0; i < deviceInfos.size(); i++) {
             const auto& devInfo = deviceInfos[i];
-            std::cout << "[" << i << "] " << devInfo.getMxId() << "[" << XLinkProtocolToStr(devInfo.protocol) << "]";
+            std::cout << "[" << i << "] " << devInfo.getMxId() << "[" << ProtocolToStr(devInfo.protocol) << "]";
             if(devInfo.state == X_LINK_BOOTLOADER) {
                 dai::DeviceBootloader bl(devInfo);
                 std::cout << " current bootloader: " << bl.getVersion();


### PR DESCRIPTION
fixes luxonis/depthai-core#650

* add local xlinkproto -> string func from luxonis/XLink/tree/5c61615066af6539e50a4a17b5df3466e4350b21
* local compile works ok
* I didn't run the two examples affected by this as they change my bootloader 😬
