### PR TITLE
add ability to clear out contents of ImgFrame

### DIFF
--- a/include/depthai/pipeline/datatype/ADatatype.hpp
+++ b/include/depthai/pipeline/datatype/ADatatype.hpp
@@ -18,7 +18,7 @@ class ADatatype {
     explicit ADatatype(std::shared_ptr<RawBuffer> r) : raw(std::move(r)) {}
     virtual ~ADatatype() = default;
     virtual std::shared_ptr<dai::RawBuffer> serialize() const = 0;
-    std::shared_ptr<RawBuffer> getRaw() const {
+    const std::shared_ptr<RawBuffer>& getRaw() const {
         return raw;
     }
 };

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -23,7 +23,7 @@ namespace dai {
  */
 class ImgFrame : public Buffer {
     std::shared_ptr<RawBuffer> serialize() const override;
-    RawImgFrame& img;
+    RawImgFrame* img;
 
    public:
     // Raw* mirror
@@ -38,6 +38,14 @@ class ImgFrame : public Buffer {
     ImgFrame();
     explicit ImgFrame(std::shared_ptr<RawImgFrame> ptr);
     virtual ~ImgFrame() = default;
+
+    ImgFrame& operator=(const ImgFrame&) = delete;
+
+    // helpers
+    /**
+     * Clears the contents of this class.
+     */
+    void clear();
 
     // getters
     /**

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -8,52 +8,56 @@ std::shared_ptr<RawBuffer> ImgFrame::serialize() const {
     return raw;
 }
 
-ImgFrame::ImgFrame() : Buffer(std::make_shared<RawImgFrame>()), img(*dynamic_cast<RawImgFrame*>(raw.get())) {
+ImgFrame::ImgFrame() : Buffer(std::make_shared<RawImgFrame>()), img(dynamic_cast<RawImgFrame*>(raw.get())) {
     // set timestamp to now
     setTimestamp(std::chrono::steady_clock::now());
 }
-ImgFrame::ImgFrame(std::shared_ptr<RawImgFrame> ptr) : Buffer(std::move(ptr)), img(*dynamic_cast<RawImgFrame*>(raw.get())) {}
+ImgFrame::ImgFrame(std::shared_ptr<RawImgFrame> ptr) : Buffer(std::move(ptr)), img(dynamic_cast<RawImgFrame*>(raw.get())) {}
 
 // helpers
+void ImgFrame::clear() {
+    raw = std::make_shared<RawImgFrame>();
+    img = dynamic_cast<RawImgFrame*>(raw.get());
+}
 
 // getters
 std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestamp() const {
     using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(img.ts.sec) + nanoseconds(img.ts.nsec)};
+    return time_point<steady_clock, steady_clock::duration>{seconds(img->ts.sec) + nanoseconds(img->ts.nsec)};
 }
 std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestampDevice() const {
     using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(img.tsDevice.sec) + nanoseconds(img.tsDevice.nsec)};
+    return time_point<steady_clock, steady_clock::duration>{seconds(img->tsDevice.sec) + nanoseconds(img->tsDevice.nsec)};
 }
 unsigned int ImgFrame::getInstanceNum() const {
-    return img.instanceNum;
+    return img->instanceNum;
 }
 unsigned int ImgFrame::getCategory() const {
-    return img.category;
+    return img->category;
 }
 int64_t ImgFrame::getSequenceNum() const {
-    return img.sequenceNum;
+    return img->sequenceNum;
 }
 unsigned int ImgFrame::getWidth() const {
-    return img.fb.width;
+    return img->fb.width;
 }
 unsigned int ImgFrame::getHeight() const {
-    return img.fb.height;
+    return img->fb.height;
 }
 RawImgFrame::Type ImgFrame::getType() const {
-    return img.fb.type;
+    return img->fb.type;
 }
 std::chrono::microseconds ImgFrame::getExposureTime() const {
-    return std::chrono::microseconds(img.cam.exposureTimeUs);
+    return std::chrono::microseconds(img->cam.exposureTimeUs);
 }
 int ImgFrame::getSensitivity() const {
-    return img.cam.sensitivityIso;
+    return img->cam.sensitivityIso;
 }
 int ImgFrame::getColorTemperature() const {
-    return img.cam.wbColorTemp;
+    return img->cam.wbColorTemp;
 }
 int ImgFrame::getLensPosition() const {
-    return img.cam.lensPosition;
+    return img->cam.lensPosition;
 }
 
 // setters
@@ -61,37 +65,37 @@ ImgFrame& ImgFrame::setTimestamp(std::chrono::time_point<std::chrono::steady_clo
     // Set timestamp from timepoint
     using namespace std::chrono;
     auto ts = tp.time_since_epoch();
-    img.ts.sec = duration_cast<seconds>(ts).count();
-    img.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
+    img->ts.sec = duration_cast<seconds>(ts).count();
+    img->ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
     return *this;
 }
 ImgFrame& ImgFrame::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
     using namespace std::chrono;
     auto ts = tp.time_since_epoch();
-    img.tsDevice.sec = duration_cast<seconds>(ts).count();
-    img.tsDevice.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
+    img->tsDevice.sec = duration_cast<seconds>(ts).count();
+    img->tsDevice.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
     return *this;
 }
 ImgFrame& ImgFrame::setInstanceNum(unsigned int instanceNum) {
-    img.instanceNum = instanceNum;
+    img->instanceNum = instanceNum;
     return *this;
 }
 ImgFrame& ImgFrame::setCategory(unsigned int category) {
-    img.category = category;
+    img->category = category;
     return *this;
 }
 ImgFrame& ImgFrame::setSequenceNum(int64_t sequenceNum) {
-    img.sequenceNum = sequenceNum;
+    img->sequenceNum = sequenceNum;
     return *this;
 }
 ImgFrame& ImgFrame::setWidth(unsigned int width) {
-    img.fb.width = width;
-    img.fb.stride = width;
+    img->fb.width = width;
+    img->fb.stride = width;
     return *this;
 }
 ImgFrame& ImgFrame::setHeight(unsigned int height) {
-    img.fb.height = height;
+    img->fb.height = height;
     return *this;
 }
 ImgFrame& ImgFrame::setSize(unsigned int width, unsigned int height) {
@@ -104,8 +108,8 @@ ImgFrame& ImgFrame::setSize(std::tuple<unsigned int, unsigned int> size) {
     return *this;
 }
 ImgFrame& ImgFrame::setType(RawImgFrame::Type type) {
-    img.fb.type = type;
-    img.fb.bytesPP = RawImgFrame::typeToBpp(img.fb.type);
+    img->fb.type = type;
+    img->fb.bytesPP = RawImgFrame::typeToBpp(img->fb.type);
     return *this;
 }
 


### PR DESCRIPTION
also return a reference to the shared_ptr buffer, so the caller can decide if they want to incur an ref-count increment or not.

Really the 'img' member seems unnecessary, and can be replaced with a get function that does the cast each time the buffer is needed. I'm not sure if keeping the size of the class the same is a requirement (which is why I left it as a * for now).

If this workflow is acceptable, I'd expand it to the other data types as well.
