### PR TITLE
StereoDepth: Implement brightness filter

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "1adfd5eed0bf4a985b040b69d0c2601d737d2363")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a41ee6323b48c3e65664501fdcefa94e9a6c90f5")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
        /**
         * Brightness filtering.
         * If input frame pixel is too dark or too bright, disparity will be invalidated.
         * The idea is that for too dark/too bright pixels we have low confidence,
         * since that area was under/over exposed and details were lost.
         */