### PR TITLE
Removed possible spdlog calls from destructors

### DIFF
--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -96,7 +96,7 @@ void DataOutputQueue::close() {
     if((readingThread.get_id() != std::this_thread::get_id()) && readingThread.joinable()) readingThread.join();
 
     // Log
-    spdlog::debug("DataOutputQueue ({}) closed", name);
+    // spdlog::debug("DataOutputQueue ({}) closed", name);
 }
 
 DataOutputQueue::~DataOutputQueue() {
@@ -232,7 +232,7 @@ void DataInputQueue::close() {
     if((writingThread.get_id() != std::this_thread::get_id()) && writingThread.joinable()) writingThread.join();
 
     // Log
-    spdlog::debug("DataInputQueue ({}) closed", name);
+    // spdlog::debug("DataInputQueue ({}) closed", name);
 }
 
 DataInputQueue::~DataInputQueue() {

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -143,7 +143,7 @@ std::tuple<bool, DeviceInfo> DeviceBase::getAnyAvailableDevice(std::chrono::dura
     // Check if its an invalid device
     if(invalidDeviceFound) {
         // Warn
-        spdlog::warn("skipping {} device having name \"{}\"", XLinkDeviceStateToStr(invalidDeviceInfo.state), invalidDeviceInfo.desc.name);
+        // spdlog::warn("skipping {} device having name \"{}\"", XLinkDeviceStateToStr(invalidDeviceInfo.state), invalidDeviceInfo.desc.name);
     }
 
     // If none were found, try BOOTED
@@ -393,7 +393,7 @@ void DeviceBase::close() {
 void DeviceBase::closeImpl() {
     using namespace std::chrono;
     auto t1 = steady_clock::now();
-    spdlog::debug("Device about to be closed...");
+    // spdlog::debug("Device about to be closed...");
 
     // Close connection first; causes Xlink internal calls to unblock semaphore waits and
     // return error codes, which then allows queues to unblock
@@ -417,7 +417,7 @@ void DeviceBase::closeImpl() {
     // Close rpcStream
     pimpl->rpcStream = nullptr;
 
-    spdlog::debug("Device closed, {}", duration_cast<milliseconds>(steady_clock::now() - t1).count());
+    // spdlog::debug("Device closed, {}", duration_cast<milliseconds>(steady_clock::now() - t1).count());
 }
 
 bool DeviceBase::isClosed() const {
@@ -614,7 +614,7 @@ void DeviceBase::init2(Config cfg, const std::string& pathToMvcmd, tl::optional<
                 }
             } catch(const std::exception& ex) {
                 // ignore
-                spdlog::debug("Watchdog thread exception caught: {}", ex.what());
+                // spdlog::debug("Watchdog thread exception caught: {}", ex.what());
             }
 
             // Watchdog ended. Useful for checking disconnects
@@ -647,7 +647,7 @@ void DeviceBase::init2(Config cfg, const std::string& pathToMvcmd, tl::optional<
             }
         } catch(const std::exception& ex) {
             // ignore
-            spdlog::debug("Timesync thread exception caught: {}", ex.what());
+            // spdlog::debug("Timesync thread exception caught: {}", ex.what());
         }
 
         timesyncRunning = false;
@@ -667,7 +667,7 @@ void DeviceBase::init2(Config cfg, const std::string& pathToMvcmd, tl::optional<
                     // Deserialize incoming messages
                     utility::deserialize(log, messages);
 
-                    spdlog::trace("Log vector decoded, size: {}", messages.size());
+                    // spdlog::trace("Log vector decoded, size: {}", messages.size());
 
                     // log the messages in incremental order (0 -> size-1)
                     for(const auto& msg : messages) {
@@ -688,12 +688,12 @@ void DeviceBase::init2(Config cfg, const std::string& pathToMvcmd, tl::optional<
                     }
 
                 } catch(const nlohmann::json::exception& ex) {
-                    spdlog::error("Exception while parsing or calling callbacks for log message from device: {}", ex.what());
+                    // spdlog::error("Exception while parsing or calling callbacks for log message from device: {}", ex.what());
                 }
             }
         } catch(const std::exception& ex) {
             // ignore exception from logging
-            spdlog::debug("Log thread exception caught: {}", ex.what());
+            // spdlog::debug("Log thread exception caught: {}", ex.what());
         }
 
         loggingRunning = false;

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -435,7 +435,7 @@ void DeviceBootloader::close() {
 
     using namespace std::chrono;
     auto t1 = steady_clock::now();
-    spdlog::debug("DeviceBootloader about to be closed...");
+    // spdlog::debug("DeviceBootloader about to be closed...");
 
     // Close connection first; causes Xlink internal calls to unblock semaphore waits and
     // return error codes, which then allows queues to unblock
@@ -454,7 +454,7 @@ void DeviceBootloader::close() {
     // BUGBUG investigate ownership; can another thread accessing this at the same time?
     stream = nullptr;
 
-    spdlog::debug("DeviceBootloader closed, {}", duration_cast<milliseconds>(steady_clock::now() - t1).count());
+    // spdlog::debug("DeviceBootloader closed, {}", duration_cast<milliseconds>(steady_clock::now() - t1).count());
 }
 
 bool DeviceBootloader::isClosed() const {

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -38,7 +38,7 @@ static XLinkProtocol_t getDefaultProtocol() {
     } else if(protocolStr == "tcpip") {
         defaultProtocol = X_LINK_TCP_IP;
     } else {
-        spdlog::warn("Unsupported protocol specified");
+        // spdlog::warn("Unsupported protocol specified");
     }
 
     return defaultProtocol;
@@ -109,7 +109,7 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
         for(unsigned i = 0; i < numdev; i++) {
             DeviceInfo info = {};
             if(skipInvalidDevices && std::strcmp("<error>", deviceDescAll.at(i).name) == 0) {
-                spdlog::warn("skipping {} device having name \"{}\"", XLinkDeviceStateToStr(state), deviceDescAll.at(i).name);
+                // spdlog::warn("skipping {} device having name \"{}\"", XLinkDeviceStateToStr(state), deviceDescAll.at(i).name);
                 continue;
             }
             info.desc = deviceDescAll.at(i);
@@ -244,7 +244,7 @@ void XLinkConnection::close() {
 
         auto ret = XLinkResetRemoteTimeout(deviceLinkId, duration_cast<milliseconds>(RESET_TIMEOUT).count());
         if(ret != X_LINK_SUCCESS) {
-            spdlog::debug("XLinkResetRemoteTimeout returned: {}", XLinkErrorToStr(ret));
+            // spdlog::debug("XLinkResetRemoteTimeout returned: {}", XLinkErrorToStr(ret));
         }
 
         deviceLinkId = -1;
@@ -265,7 +265,7 @@ void XLinkConnection::close() {
             } while(!found && steady_clock::now() - t1 < BOOTUP_SEARCH);
         }
 
-        spdlog::debug("XLinkResetRemote of linkId: ({})", tmp);
+        // spdlog::debug("XLinkResetRemote of linkId: ({})", tmp);
     }
 }
 


### PR DESCRIPTION
Can help eliviate some segfaults when `Device` is a global object.

TODO: Proper fix on spdlog side