### PR TITLE
Update SPIOut.hpp

### DIFF
--- a/include/depthai/pipeline/node/SPIOut.hpp
+++ b/include/depthai/pipeline/node/SPIOut.hpp
@@ -43,8 +43,8 @@ class SPIOut : public NodeCRTP<Node, SPIOut, SPIOutProperties> {
      * Specifies SPI Bus number to use
      * @param id SPI Bus id
      */
-    void setBusId(int id) {
-        properties.busId = id;
+    void setBusId(int newId) {
+        properties.busId = newId;
     }
 };
 


### PR DESCRIPTION
to silence warning C4458, which in our build system we've actually promoted to an error.

`error C4458: declaration of 'id' hides class member`