### PR TITLE
Deprecation of named CameraBoardSocket enums

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "97fc2b14eb0eb9ffdc3a941d47e8cb4d1412cdc6")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "e148c4ba300f23a6c57bb44055c897eebe60ce0f")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "e148c4ba300f23a6c57bb44055c897eebe60ce0f")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "ba5e1cf8caab2f5f0782447d691c51d3a27ba21b")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/AprilTag/apriltag.cpp
+++ b/examples/AprilTag/apriltag.cpp
@@ -23,7 +23,7 @@ int main() {
 
     // Properties
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
 
     aprilTag->initialConfig.setFamily(dai::AprilTagConfig::Family::TAG_36H11);
 

--- a/examples/AprilTag/apriltag_rgb.cpp
+++ b/examples/AprilTag/apriltag_rgb.cpp
@@ -24,7 +24,7 @@ int main() {
 
     // Properties
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
-    camRgb->setCamera("center");
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
 
     manip->initialConfig.setResize(480, 270);
     manip->initialConfig.setFrameType(dai::ImgFrame::Type::GRAY8);

--- a/examples/AprilTag/apriltag_rgb.cpp
+++ b/examples/AprilTag/apriltag_rgb.cpp
@@ -24,7 +24,7 @@ int main() {
 
     // Properties
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setCamera("center");
 
     manip->initialConfig.setResize(480, 270);
     manip->initialConfig.setFrameType(dai::ImgFrame::Type::GRAY8);

--- a/examples/ColorCamera/rgb_isp_scale.cpp
+++ b/examples/ColorCamera/rgb_isp_scale.cpp
@@ -14,7 +14,7 @@ int main() {
     xoutVideo->setStreamName("video");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_4_K);
     camRgb->setIspScale(1, 2);
     camRgb->setVideoSize(1920, 1080);

--- a/examples/ColorCamera/rgb_preview.cpp
+++ b/examples/ColorCamera/rgb_preview.cpp
@@ -16,7 +16,7 @@ int main() {
 
     // Properties
     camRgb->setPreviewSize(300, 300);
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setInterleaved(false);
     camRgb->setColorOrder(dai::ColorCameraProperties::ColorOrder::RGB);

--- a/examples/ColorCamera/rgb_video.cpp
+++ b/examples/ColorCamera/rgb_video.cpp
@@ -14,7 +14,7 @@ int main() {
     xoutVideo->setStreamName("video");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setVideoSize(1920, 1080);
 

--- a/examples/EdgeDetector/edge_detector.cpp
+++ b/examples/EdgeDetector/edge_detector.cpp
@@ -34,13 +34,13 @@ int main() {
     xinEdgeCfg->setStreamName(edgeCfgStr);
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
 
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     edgeDetectorRgb->setMaxOutputFrameSize(camRgb->getVideoWidth() * camRgb->getVideoHeight());
 

--- a/examples/FeatureTracker/feature_detector.cpp
+++ b/examples/FeatureTracker/feature_detector.cpp
@@ -40,9 +40,9 @@ int main() {
 
     // Properties
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     // Disable optical flow
     featureTrackerLeft->initialConfig.setMotionEstimator(false);

--- a/examples/FeatureTracker/feature_tracker.cpp
+++ b/examples/FeatureTracker/feature_tracker.cpp
@@ -106,9 +106,9 @@ int main() {
 
     // Properties
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     // Linking
     monoLeft->out.link(featureTrackerLeft->inputImage);

--- a/examples/ImageManip/image_manip_rotate.cpp
+++ b/examples/ImageManip/image_manip_rotate.cpp
@@ -29,7 +29,7 @@ int main() {
     // Rotate mono frames
     auto monoLeft = pipeline.create<dai::node::MonoCamera>();
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
 
     auto manipLeft = pipeline.create<dai::node::ImageManip>();
     dai::RotatedRect rr = {{monoLeft->getResolutionWidth() / 2.0f, monoLeft->getResolutionHeight() / 2.0f},  // center

--- a/examples/MobileNet/mono_mobilenet.cpp
+++ b/examples/MobileNet/mono_mobilenet.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     nnOut->setStreamName("nn");
 
     // Properties
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
 
     // Convert the grayscale frame into the nn-acceptable form

--- a/examples/MonoCamera/mono_camera_control.cpp
+++ b/examples/MonoCamera/mono_camera_control.cpp
@@ -50,8 +50,8 @@ int main() {
     dai::Point2f bottomRight(0.8f, 0.8f);
 
     // Properties
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoRight->setCamera("right");
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
     manipRight->initialConfig.setCropRect(topLeft.x, topLeft.y, bottomRight.x, bottomRight.y);

--- a/examples/MonoCamera/mono_full_resolution_saver.cpp
+++ b/examples/MonoCamera/mono_full_resolution_saver.cpp
@@ -17,7 +17,7 @@ int main() {
     xoutRight->setStreamName("right");
 
     // Properties
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
 
     // Linking

--- a/examples/MonoCamera/mono_preview.cpp
+++ b/examples/MonoCamera/mono_preview.cpp
@@ -17,9 +17,9 @@ int main() {
     xoutRight->setStreamName("right");
 
     // Properties
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
 
     // Linking

--- a/examples/NeuralNetwork/concat_multi_input.cpp
+++ b/examples/NeuralNetwork/concat_multi_input.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
     camRgb->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
 
     auto right = pipeline.create<dai::node::MonoCamera>();
-    right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    right->setCamera("right");
     right->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
 
     auto manipRight = pipeline.create<dai::node::ImageManip>();
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
     right->out.link(manipRight->inputImage);
 
     auto left = pipeline.create<dai::node::MonoCamera>();
-    left->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    left->setCamera("left");
     left->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
 
     auto manipLeft = pipeline.create<dai::node::ImageManip>();

--- a/examples/ObjectTracker/spatial_object_tracker.cpp
+++ b/examples/ObjectTracker/spatial_object_tracker.cpp
@@ -48,14 +48,14 @@ int main(int argc, char** argv) {
     camRgb->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
 
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     // setting node configs
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);
     // Align depth map to the perspective of RGB camera, on which inference is done
-    stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+    stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
     stereo->setOutputSize(monoLeft->getResolutionWidth(), monoLeft->getResolutionHeight());
 
     spatialDetectionNetwork->setBlobPath(nnPath);

--- a/examples/Script/script_change_pipeline_flow.cpp
+++ b/examples/Script/script_change_pipeline_flow.cpp
@@ -7,7 +7,7 @@ int main() {
     dai::Pipeline pipeline;
 
     auto cam = pipeline.create<dai::node::ColorCamera>();
-    cam->setBoardSocket(dai::CameraBoardSocket::RGB);
+    cam->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     cam->setInterleaved(false);
     cam->setIspScale(2, 3);
     cam->setVideoSize(720, 720);

--- a/examples/SpatialDetection/spatial_calculator_multi_roi.cpp
+++ b/examples/SpatialDetection/spatial_calculator_multi_roi.cpp
@@ -31,9 +31,9 @@ int main() {
 
     // Properties
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);
     stereo->setLeftRightCheck(true);

--- a/examples/SpatialDetection/spatial_location_calculator.cpp
+++ b/examples/SpatialDetection/spatial_location_calculator.cpp
@@ -31,9 +31,9 @@ int main() {
 
     // Properties
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     bool lrcheck = false;
     bool subpixel = false;

--- a/examples/SpatialDetection/spatial_mobilenet.cpp
+++ b/examples/SpatialDetection/spatial_mobilenet.cpp
@@ -48,14 +48,14 @@ int main(int argc, char** argv) {
     camRgb->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
 
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     // Setting node configs
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);
     // Align depth map to the perspective of RGB camera, on which inference is done
-    stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+    stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
     stereo->setOutputSize(monoLeft->getResolutionWidth(), monoLeft->getResolutionHeight());
 
     spatialDetectionNetwork->setBlobPath(nnPath);

--- a/examples/SpatialDetection/spatial_mobilenet_mono.cpp
+++ b/examples/SpatialDetection/spatial_mobilenet_mono.cpp
@@ -47,9 +47,9 @@ int main(int argc, char** argv) {
     imageManip->initialConfig.setFrameType(dai::ImgFrame::Type::BGR888p);
 
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     // StereoDepth
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);

--- a/examples/SpatialDetection/spatial_tiny_yolo.cpp
+++ b/examples/SpatialDetection/spatial_tiny_yolo.cpp
@@ -58,14 +58,14 @@ int main(int argc, char** argv) {
     camRgb->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
 
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     // setting node configs
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);
     // Align depth map to the perspective of RGB camera, on which inference is done
-    stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+    stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
     stereo->setOutputSize(monoLeft->getResolutionWidth(), monoLeft->getResolutionHeight());
 
     spatialDetectionNetwork->setBlobPath(nnPath);

--- a/examples/StereoDepth/depth_crop_control.cpp
+++ b/examples/StereoDepth/depth_crop_control.cpp
@@ -31,8 +31,8 @@ int main() {
     dai::Point2f bottomRight(0.8f, 0.8f);
 
     // Properties
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoRight->setCamera("right");
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
 

--- a/examples/StereoDepth/depth_post_processing.cpp
+++ b/examples/StereoDepth/depth_post_processing.cpp
@@ -24,9 +24,9 @@ int main() {
 
     // Properties
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     // Create a node that will produce the depth map (using disparity output as it's easier to visualize depth this way)
     depth->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);

--- a/examples/StereoDepth/depth_preview.cpp
+++ b/examples/StereoDepth/depth_preview.cpp
@@ -24,9 +24,9 @@ int main() {
 
     // Properties
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     // Create a node that will produce the depth map (using disparity output as it's easier to visualize depth this way)
     depth->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);

--- a/examples/StereoDepth/rgb_depth_aligned.cpp
+++ b/examples/StereoDepth/rgb_depth_aligned.cpp
@@ -44,7 +44,7 @@ int main() {
     queueNames.push_back("depth");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setFps(fps);
     if(downscaleColor) camRgb->setIspScale(2, 3);
@@ -52,7 +52,7 @@ int main() {
     // This value was used during calibration
     try {
         auto calibData = device.readCalibration2();
-        auto lensPosition = calibData.getLensPosition(dai::CameraBoardSocket::RGB);
+        auto lensPosition = calibData.getLensPosition(dai::CameraBoardSocket::CAM_A);
         if(lensPosition) {
             camRgb->initialControl.setManualFocus(lensPosition);
         }
@@ -62,16 +62,16 @@ int main() {
     }
 
     left->setResolution(monoRes);
-    left->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    left->setCamera("left");
     left->setFps(fps);
     right->setResolution(monoRes);
-    right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    right->setCamera("right");
     right->setFps(fps);
 
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);
     // LR-check is required for depth alignment
     stereo->setLeftRightCheck(true);
-    stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+    stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
 
     // Linking
     camRgb->isp.link(rgbOut->input);

--- a/examples/StereoDepth/rgb_depth_confidence_aligned.cpp
+++ b/examples/StereoDepth/rgb_depth_confidence_aligned.cpp
@@ -51,7 +51,7 @@ int main() {
     queueNames.push_back("conf");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setFps(fps);
     if(downscaleColor) camRgb->setIspScale(2, 3);
@@ -59,7 +59,7 @@ int main() {
     // This value was used during calibration
     try {
         auto calibData = device.readCalibration2();
-        auto lensPosition = calibData.getLensPosition(dai::CameraBoardSocket::RGB);
+        auto lensPosition = calibData.getLensPosition(dai::CameraBoardSocket::CAM_A);
         if(lensPosition) {
             camRgb->initialControl.setManualFocus(lensPosition);
         }
@@ -69,16 +69,16 @@ int main() {
     }
 
     left->setResolution(monoRes);
-    left->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    left->setCamera("left");
     left->setFps(fps);
     right->setResolution(monoRes);
-    right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    right->setCamera("right");
     right->setFps(fps);
 
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);
     // LR-check is required for depth alignment
     stereo->setLeftRightCheck(true);
-    stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+    stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
 
     // Linking
     camRgb->isp.link(rgbOut->input);

--- a/examples/StereoDepth/stereo_depth_video.cpp
+++ b/examples/StereoDepth/stereo_depth_video.cpp
@@ -41,9 +41,9 @@ int main() {
 
     // Properties
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     if(withDepth) {
         // StereoDepth

--- a/examples/VideoEncoder/disparity_encoding.cpp
+++ b/examples/VideoEncoder/disparity_encoding.cpp
@@ -19,11 +19,11 @@ int main() {
     // Define sources and outputs
     auto monoLeft = pipeline.create<dai::node::MonoCamera>();
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
 
     auto monoRight = pipeline.create<dai::node::MonoCamera>();
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
 
     auto stereo = pipeline.create<dai::node::StereoDepth>();
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);

--- a/examples/VideoEncoder/encoding_max_limit.cpp
+++ b/examples/VideoEncoder/encoding_max_limit.cpp
@@ -35,10 +35,10 @@ int main() {
     ve3Out->setStreamName("ve3Out");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_4_K);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoLeft->setCamera("left");
+    monoRight->setCamera("right");
 
     // Setting to 26fps will trigger error
     ve1->setDefaultProfilePreset(25, dai::VideoEncoderProperties::Profile::H264_MAIN);

--- a/examples/VideoEncoder/rgb_encoding.cpp
+++ b/examples/VideoEncoder/rgb_encoding.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
     xout->setStreamName("h265");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_4_K);
     videoEnc->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);
 

--- a/examples/VideoEncoder/rgb_full_resolution_saver.cpp
+++ b/examples/VideoEncoder/rgb_full_resolution_saver.cpp
@@ -21,7 +21,7 @@ int main() {
     xoutRgb->setStreamName("rgb");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_4_K);
     videoEnc->setDefaultProfilePreset(camRgb->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
 

--- a/examples/VideoEncoder/rgb_mono_encoding.cpp
+++ b/examples/VideoEncoder/rgb_mono_encoding.cpp
@@ -34,9 +34,9 @@ int main() {
     ve3Out->setStreamName("ve3Out");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
+    monoLeft->setCamera("left");
+    monoRight->setCamera("right");
     // Create encoders, one for each camera, consuming the frames and encoding them using H.264 / H.265 encoding
     ve1->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H264_MAIN);
     ve2->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);

--- a/examples/calibration/calibration_load.cpp
+++ b/examples/calibration/calibration_load.cpp
@@ -27,10 +27,10 @@ int main(int argc, char** argv) {
 
     // MonoCamera
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     // monoLeft->setFps(5.0);
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
     // monoRight->setFps(5.0);
 
     // Linking

--- a/examples/calibration/calibration_reader.cpp
+++ b/examples/calibration/calibration_reader.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
     int width, height;
 
     cout << "Intrinsics from defaultIntrinsics function:" << endl;
-    std::tie(intrinsics, width, height) = calibData.getDefaultIntrinsics(dai::CameraBoardSocket::RIGHT);
+    std::tie(intrinsics, width, height) = calibData.getDefaultIntrinsics(dai::CameraBoardSocket::CAM_C);
     printMatrix(intrinsics);
 
     cout << "Width: " << width << endl;
@@ -39,45 +39,45 @@ int main(int argc, char** argv) {
 
     cout << "Stereo baseline distance: " << calibData.getBaselineDistance() << " cm" << endl;
 
-    cout << "Mono FOV from camera specs: " << calibData.getFov(dai::CameraBoardSocket::LEFT)
-         << ", calculated FOV: " << calibData.getFov(dai::CameraBoardSocket::LEFT, false) << endl;
+    cout << "Mono FOV from camera specs: " << calibData.getFov(dai::CameraBoardSocket::CAM_B)
+         << ", calculated FOV: " << calibData.getFov(dai::CameraBoardSocket::CAM_B, false) << endl;
 
     cout << "Intrinsics from getCameraIntrinsics function full resolution:" << endl;
-    intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT);
+    intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::CAM_C);
     printMatrix(intrinsics);
 
     cout << "Intrinsics from getCameraIntrinsics function 1280 x 720:" << endl;
-    intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT, 1280, 720);
+    intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::CAM_C, 1280, 720);
     printMatrix(intrinsics);
 
     cout << "Intrinsics from getCameraIntrinsics function 720 x 450:" << endl;
-    intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT, 720);
+    intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::CAM_C, 720);
     printMatrix(intrinsics);
 
     cout << "Intrinsics from getCameraIntrinsics function 600 x 1280:" << endl;
-    intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::RIGHT, 600, 1280);
+    intrinsics = calibData.getCameraIntrinsics(dai::CameraBoardSocket::CAM_C, 600, 1280);
     printMatrix(intrinsics);
 
     std::vector<std::vector<float>> extrinsics;
 
     cout << "Extrinsics from left->right test:" << endl;
-    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::LEFT, dai::CameraBoardSocket::RIGHT);
+    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::CAM_B, dai::CameraBoardSocket::CAM_C);
     printMatrix(extrinsics);
 
     cout << "Extrinsics from right->left test:" << endl;
-    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::RIGHT, dai::CameraBoardSocket::LEFT);
+    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::CAM_C, dai::CameraBoardSocket::CAM_B);
     printMatrix(extrinsics);
 
     cout << "Extrinsics from right->rgb test:" << endl;
-    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::RIGHT, dai::CameraBoardSocket::RGB);
+    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::CAM_C, dai::CameraBoardSocket::CAM_A);
     printMatrix(extrinsics);
 
     cout << "Extrinsics from rgb->right test:" << endl;
-    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::RGB, dai::CameraBoardSocket::RIGHT);
+    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::CAM_A, dai::CameraBoardSocket::CAM_C);
     printMatrix(extrinsics);
 
     cout << "Extrinsics from left->rgb test:" << endl;
-    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::LEFT, dai::CameraBoardSocket::RGB);
+    extrinsics = calibData.getCameraExtrinsics(dai::CameraBoardSocket::CAM_B, dai::CameraBoardSocket::CAM_A);
     printMatrix(extrinsics);
 
     return 0;

--- a/examples/host_side/opencv_support.cpp
+++ b/examples/host_side/opencv_support.cpp
@@ -20,7 +20,7 @@ int main() {
 
     // Properties
     camRgb->setPreviewSize(300, 300);
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setInterleaved(true);
     camRgb->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);

--- a/examples/host_side/queue_add_callback.cpp
+++ b/examples/host_side/queue_add_callback.cpp
@@ -24,9 +24,9 @@ int main() {
 
     // Properties
     camRgb->setPreviewSize(300, 300);
-    left->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    left->setCamera("left");
     left->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    right->setCamera("right");
     right->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
 
     // Stream all the camera streams through the same XLink node

--- a/examples/mixed/frame_sync.cpp
+++ b/examples/mixed/frame_sync.cpp
@@ -19,12 +19,12 @@ int main() {
 
     auto left = pipeline.create<dai::node::MonoCamera>();
     left->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    left->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    left->setCamera("left");
     left->setFps(FPS);
 
     auto right = pipeline.create<dai::node::MonoCamera>();
     right->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    right->setCamera("right");
     right->setFps(FPS);
 
     auto stereo = pipeline.create<dai::node::StereoDepth>();
@@ -32,7 +32,7 @@ int main() {
     stereo->setLeftRightCheck(true);
     stereo->setExtendedDisparity(false);
     stereo->setSubpixel(false);
-    stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+    stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
     left->out.link(stereo->left);
     right->out.link(stereo->right);
 

--- a/examples/mixed/mono_depth_mobilenetssd.cpp
+++ b/examples/mixed/mono_depth_mobilenetssd.cpp
@@ -41,9 +41,9 @@ int main(int argc, char** argv) {
     nnOut->setStreamName("nn");
 
     // Properties
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
     // Produce the depth map (using disparity output as it's easier to visualize depth this way)
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);

--- a/examples/mixed/multiple_devices.cpp
+++ b/examples/mixed/multiple_devices.cpp
@@ -11,7 +11,7 @@ std::shared_ptr<dai::Pipeline> createPipeline() {
     auto camRgb = pipeline->create<dai::node::ColorCamera>();
 
     camRgb->setPreviewSize(300, 300);
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setInterleaved(false);
 

--- a/examples/mixed/rgb_encoding_mobilenet.cpp
+++ b/examples/mixed/rgb_encoding_mobilenet.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
     nnOut->setStreamName("nn");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setPreviewSize(300, 300);
     camRgb->setInterleaved(false);

--- a/examples/mixed/rgb_encoding_mono_mobilenet.cpp
+++ b/examples/mixed/rgb_encoding_mono_mobilenet.cpp
@@ -43,9 +43,9 @@ int main(int argc, char** argv) {
     nnOut->setStreamName("nn");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
     videoEncoder->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);
 

--- a/examples/mixed/rgb_encoding_mono_mobilenet_depth.cpp
+++ b/examples/mixed/rgb_encoding_mono_mobilenet_depth.cpp
@@ -48,11 +48,11 @@ int main(int argc, char** argv) {
     nnOut->setStreamName("nn");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
     videoEncoder->setDefaultProfilePreset(30, dai::VideoEncoderProperties::Profile::H265_MAIN);
 

--- a/include/depthai/common/CameraBoardSocket.hpp
+++ b/include/depthai/common/CameraBoardSocket.hpp
@@ -34,6 +34,12 @@ inline std::ostream& operator<<(std::ostream& out, const dai::CameraBoardSocket&
         case dai::CameraBoardSocket::CAM_H:
             out << "CAM_H";
             break;
+        case dai::CameraBoardSocket::CAM_I:
+            out << "CAM_I";
+            break;
+        case dai::CameraBoardSocket::CAM_J:
+            out << "CAM_J";
+            break;
     }
     return out;
 }

--- a/include/depthai/common/CameraBoardSocket.hpp
+++ b/include/depthai/common/CameraBoardSocket.hpp
@@ -10,14 +10,14 @@ inline std::ostream& operator<<(std::ostream& out, const dai::CameraBoardSocket&
         case dai::CameraBoardSocket::AUTO:
             out << "AUTO";
             break;
-        case dai::CameraBoardSocket::RGB:
-            out << "RGB/CENTER/CAM_A";
+        case dai::CameraBoardSocket::CAM_A:
+            out << "CAM_A";
             break;
-        case dai::CameraBoardSocket::LEFT:
-            out << "LEFT/CAM_B";
+        case dai::CameraBoardSocket::CAM_B:
+            out << "CAM_B";
             break;
-        case dai::CameraBoardSocket::RIGHT:
-            out << "RIGHT/CAM_C";
+        case dai::CameraBoardSocket::CAM_C:
+            out << "CAM_C";
             break;
         case dai::CameraBoardSocket::CAM_D:
             out << "CAM_D";

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -226,16 +226,16 @@ class CalibrationHandler {
     std::vector<float> getCameraTranslationVector(CameraBoardSocket srcCamera, CameraBoardSocket dstCamera, bool useSpecTranslation = true) const;
 
     /**
-     * Get the baseline distance between two specified cameras. By default it will get the baseline between CameraBoardSocket.RIGHT
-     * and CameraBoardSocket.LEFT.
+     * Get the baseline distance between two specified cameras. By default it will get the baseline between CameraBoardSocket.CAM_C
+     * and CameraBoardSocket.CAM_B.
      *
      * @param cam1 First camera
      * @param cam2 Second camera
      * @param useSpecTranslation Enabling this bool uses the translation information from the board design data (not the calibration data)
      * @return baseline distance in centimeters
      */
-    float getBaselineDistance(CameraBoardSocket cam1 = CameraBoardSocket::RIGHT,
-                              CameraBoardSocket cam2 = CameraBoardSocket::LEFT,
+    float getBaselineDistance(CameraBoardSocket cam1 = CameraBoardSocket::CAM_C,
+                              CameraBoardSocket cam2 = CameraBoardSocket::CAM_B,
                               bool useSpecTranslation = true) const;
 
     /**

--- a/include/depthai/device/Device.hpp
+++ b/include/depthai/device/Device.hpp
@@ -34,7 +34,7 @@ class Device : public DeviceBase {
      * @param usb2Mode (bool) Boot device using USB2 mode firmware
      */
     template <typename T, std::enable_if_t<std::is_same<T, bool>::value, bool> = true>
-    Device(const Pipeline& pipeline, T usb2Mode);
+    [[deprecated("Use constructor taking 'UsbSpeed' instead")]] Device(const Pipeline& pipeline, T usb2Mode);
 
     /**
      * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
@@ -64,7 +64,7 @@ class Device : public DeviceBase {
      * @param usb2Mode (bool) Boot device using USB2 mode firmware
      */
     template <typename T, std::enable_if_t<std::is_same<T, bool>::value, bool> = true>
-    Device(const Pipeline& pipeline, const DeviceInfo& devInfo, T usb2Mode);
+    [[deprecated("Use constructor taking 'UsbSpeed' instead")]] Device(const Pipeline& pipeline, const DeviceInfo& devInfo, T usb2Mode);
 
     /**
      * Connects to device specified by devInfo.

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -802,7 +802,7 @@ class DeviceBase {
     // protected functions
     void init(OpenVINO::Version version);
     void init(OpenVINO::Version version, const dai::Path& pathToCmd);
-    void init(OpenVINO::Version version, UsbSpeed maxUsbSpeed);;
+    void init(OpenVINO::Version version, UsbSpeed maxUsbSpeed);
     void init(OpenVINO::Version version, bool usb2Mode, const dai::Path& pathToMvcmd);
     void init(OpenVINO::Version version, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd);
     void init(const Pipeline& pipeline);

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -322,6 +322,53 @@ class DeviceBase {
     DeviceBase(std::string nameOrDeviceId, UsbSpeed maxUsbSpeed);
 
     /**
+     * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
+     * @param config Config with which the device will be booted with
+     * @param usb2Mode Boot device using USB2 mode firmware
+     */
+    template <typename T, std::enable_if_t<std::is_same<T, bool>::value, bool> = true>
+    DeviceBase(Config config, T usb2Mode) : DeviceBase(config, usb2Mode ? UsbSpeed::HIGH : DeviceBase::DEFAULT_USB_SPEED) {}
+
+    /**
+     * Connects to device specified by devInfo.
+     * @param config Config with which the device will be booted with
+     * @param maxUsbSpeed Maximum allowed USB speed
+     */
+    DeviceBase(Config config, UsbSpeed maxUsbSpeed);
+
+    /**
+     * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
+     * @param config Config with which the device will be booted with
+     * @param pathToCmd Path to custom device firmware
+     */
+    DeviceBase(Config config, const dai::Path& pathToCmd);
+
+    /**
+     * Connects to device specified by devInfo.
+     * @param config Config with which the device will be booted with
+     * @param devInfo DeviceInfo which specifies which device to connect to
+     * @param usb2Mode Boot device using USB2 mode firmware
+     */
+    template <typename T, std::enable_if_t<std::is_same<T, bool>::value, bool> = true>
+    DeviceBase(Config config, const DeviceInfo& devInfo, T usb2Mode) : DeviceBase(config, devInfo, usb2Mode ? UsbSpeed::HIGH : DeviceBase::DEFAULT_USB_SPEED) {}
+
+    /**
+     * Connects to device specified by devInfo.
+     * @param version OpenVINO version which the device will be booted with
+     * @param config Config with which specifies which device to connect to
+     * @param maxUsbSpeed Maximum allowed USB speed
+     */
+    DeviceBase(Config config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed);
+
+    /**
+     * Connects to device specified by devInfo.
+     * @param config Config with which the device will be booted with
+     * @param devInfo DeviceInfo which specifies which device to connect to
+     * @param pathToCmd Path to custom device firmware
+     */
+    DeviceBase(Config config, const DeviceInfo& devInfo, const dai::Path& pathToCmd);
+
+    /**
      * Device destructor
      * @note In the destructor of the derived class, remember to call close()
      */
@@ -814,6 +861,12 @@ class DeviceBase {
     void init(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd);
     void init(const Pipeline& pipeline, bool usb2Mode, const dai::Path& pathToMvcmd);
     void init(const Pipeline& pipeline, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd);
+    void init(Config config, bool usb2Mode, const dai::Path& pathToMvcmd);
+    void init(Config config, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd);
+    void init(Config config, UsbSpeed maxUsbSpeed);
+    void init(Config config, const dai::Path& pathToCmd);
+    void init(Config config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed);
+    void init(Config config, const DeviceInfo& devInfo, const dai::Path& pathToCmd);
 
    private:
     // private functions

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -798,12 +798,25 @@ class DeviceBase {
      */
     virtual void closeImpl();
 
+   protected:
+    // protected functions
+    void init(OpenVINO::Version version);
+    void init(OpenVINO::Version version, const dai::Path& pathToCmd);
+    void init(OpenVINO::Version version, UsbSpeed maxUsbSpeed);;
+    void init(OpenVINO::Version version, bool usb2Mode, const dai::Path& pathToMvcmd);
+    void init(OpenVINO::Version version, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd);
+    void init(const Pipeline& pipeline);
+    void init(const Pipeline& pipeline, UsbSpeed maxUsbSpeed);
+    void init(const Pipeline& pipeline, const dai::Path& pathToCmd);
+    void init(const Pipeline& pipeline, const DeviceInfo& devInfo);
+    void init(const Pipeline& pipeline, const DeviceInfo& devInfo, bool usb2Mode);
+    void init(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed);
+    void init(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd);
+    void init(const Pipeline& pipeline, bool usb2Mode, const dai::Path& pathToMvcmd);
+    void init(const Pipeline& pipeline, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd);
+
    private:
     // private functions
-    void init(OpenVINO::Version version, bool usb2Mode, const dai::Path& pathToMvcmd);
-    void init(const Pipeline& pipeline, bool usb2Mode, const dai::Path& pathToMvcmd);
-    void init(OpenVINO::Version version, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd);
-    void init(const Pipeline& pipeline, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd);
     void init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<const Pipeline&> pipeline);
     void tryGetDevice();
 

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -94,8 +94,8 @@ CalibrationHandler::CalibrationHandler(dai::Path calibrationDataPath, dai::Path 
     }
 
     nlohmann::json boardConfigData = nlohmann::json::parse(boardConfigStream);
-    CameraBoardSocket left = CameraBoardSocket::LEFT;
-    CameraBoardSocket right = CameraBoardSocket::RIGHT;
+    CameraBoardSocket left = CameraBoardSocket::CAM_B;
+    CameraBoardSocket right = CameraBoardSocket::CAM_C;
 
     if(boardConfigData.contains("board_config")) {
         eepromData.boardName = boardConfigData.at("board_config").at("name").get<std::string>();
@@ -104,13 +104,13 @@ CalibrationHandler::CalibrationHandler(dai::Path calibrationDataPath, dai::Path 
         eepromData.version = 6;
 
         if(!swapLeftRightCam) {
-            right = CameraBoardSocket::LEFT;
-            left = CameraBoardSocket::RIGHT;
+            right = CameraBoardSocket::CAM_B;
+            left = CameraBoardSocket::CAM_C;
         }
 
         eepromData.cameraData[right].specHfovDeg = boardConfigData.at("board_config").at("left_fov_deg").get<float>();
         eepromData.cameraData[left].specHfovDeg = boardConfigData.at("board_config").at("left_fov_deg").get<float>();
-        eepromData.cameraData[CameraBoardSocket::RGB].specHfovDeg = boardConfigData.at("board_config").at("rgb_fov_deg").get<float>();
+        eepromData.cameraData[CameraBoardSocket::CAM_A].specHfovDeg = boardConfigData.at("board_config").at("rgb_fov_deg").get<float>();
 
         eepromData.cameraData[left].extrinsics.specTranslation.x = -boardConfigData.at("board_config").at("left_to_right_distance_cm").get<float>();
         eepromData.cameraData[left].extrinsics.specTranslation.y = 0;
@@ -143,11 +143,11 @@ CalibrationHandler::CalibrationHandler(dai::Path calibrationDataPath, dai::Path 
 
     eepromData.cameraData[left].intrinsicMatrix = matrixConv(calibrationBuff, 18);
     eepromData.cameraData[right].intrinsicMatrix = matrixConv(calibrationBuff, 27);
-    eepromData.cameraData[CameraBoardSocket::RGB].intrinsicMatrix = matrixConv(calibrationBuff, 48);  // 9*5 + 3
+    eepromData.cameraData[CameraBoardSocket::CAM_A].intrinsicMatrix = matrixConv(calibrationBuff, 48);  // 9*5 + 3
 
     eepromData.cameraData[left].cameraType = CameraModel::Perspective;
     eepromData.cameraData[right].cameraType = CameraModel::Perspective;
-    eepromData.cameraData[CameraBoardSocket::RGB].cameraType = CameraModel::Perspective;  // 9*5 + 3
+    eepromData.cameraData[CameraBoardSocket::CAM_A].cameraType = CameraModel::Perspective;  // 9*5 + 3
 
     eepromData.cameraData[left].width = 1280;
     eepromData.cameraData[left].height = 800;
@@ -155,12 +155,12 @@ CalibrationHandler::CalibrationHandler(dai::Path calibrationDataPath, dai::Path 
     eepromData.cameraData[right].width = 1280;
     eepromData.cameraData[right].height = 800;
 
-    eepromData.cameraData[CameraBoardSocket::RGB].width = 1920;
-    eepromData.cameraData[CameraBoardSocket::RGB].height = 1080;
+    eepromData.cameraData[CameraBoardSocket::CAM_A].width = 1920;
+    eepromData.cameraData[CameraBoardSocket::CAM_A].height = 1080;
 
     eepromData.cameraData[left].distortionCoeff = std::vector<float>(calibrationBuff.begin() + 69, calibrationBuff.begin() + 83);  // 69 + 14
     eepromData.cameraData[right].distortionCoeff = std::vector<float>(calibrationBuff.begin() + 83, calibrationBuff.begin() + 69 + (2 * 14));
-    eepromData.cameraData[CameraBoardSocket::RGB].distortionCoeff =
+    eepromData.cameraData[CameraBoardSocket::CAM_A].distortionCoeff =
         std::vector<float>(calibrationBuff.begin() + 69 + (2 * 14), calibrationBuff.begin() + 69 + (3 * 14));
 
     eepromData.cameraData[left].extrinsics.rotationMatrix = matrixConv(calibrationBuff, 36);
@@ -171,7 +171,7 @@ CalibrationHandler::CalibrationHandler(dai::Path calibrationDataPath, dai::Path 
     eepromData.cameraData[left].extrinsics.translation.z = calibrationBuff[47];
 
     eepromData.cameraData[right].extrinsics.rotationMatrix = matrixConv(calibrationBuff, 57);
-    eepromData.cameraData[right].extrinsics.toCameraSocket = CameraBoardSocket::RGB;
+    eepromData.cameraData[right].extrinsics.toCameraSocket = CameraBoardSocket::CAM_A;
 
     eepromData.cameraData[right].extrinsics.translation.x = -calibrationBuff[66];
     eepromData.cameraData[right].extrinsics.translation.y = -calibrationBuff[67];
@@ -741,8 +741,8 @@ void CalibrationHandler::setStereoRight(CameraBoardSocket cameraId, std::vector<
 
 bool CalibrationHandler::validateCameraArray() const {
     if(eepromData.cameraData.size() > 1) {
-        if(eepromData.cameraData.find(dai::CameraBoardSocket::LEFT) != eepromData.cameraData.end()) {
-            return checkSrcLinks(dai::CameraBoardSocket::LEFT) || checkSrcLinks(dai::CameraBoardSocket::RIGHT);
+        if(eepromData.cameraData.find(dai::CameraBoardSocket::CAM_B) != eepromData.cameraData.end()) {
+            return checkSrcLinks(dai::CameraBoardSocket::CAM_B) || checkSrcLinks(dai::CameraBoardSocket::CAM_C);
         } else {
             spdlog::debug(
                 "make sure the head of the Extrinsics is your left camera. Please cross check the data by creating a json file using "

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -23,47 +23,39 @@ namespace dai {
 // Common explicit instantiation, to remove the need to define in header
 constexpr std::size_t Device::EVENT_QUEUE_MAXIMUM_SIZE;
 
-Device::Device(const Pipeline& pipeline) {
-    init(pipeline);
+Device::Device(const Pipeline& pipeline) : DeviceBase(pipeline.getOpenVINOVersion()) {
     tryStartPipeline(pipeline);
 }
 
 template <typename T, std::enable_if_t<std::is_same<T, bool>::value, bool>>
-Device::Device(const Pipeline& pipeline, T usb2Mode) {
-    init(pipeline, usb2Mode ? UsbSpeed::HIGH : DEFAULT_USB_SPEED);
+Device::Device(const Pipeline& pipeline, T usb2Mode) : DeviceBase(pipeline.getDeviceConfig(), usb2Mode) {
     tryStartPipeline(pipeline);
 }
 template Device::Device(const Pipeline&, bool);
 
-Device::Device(const Pipeline& pipeline, UsbSpeed maxUsbSpeed) {
-    init(pipeline, maxUsbSpeed);
+Device::Device(const Pipeline& pipeline, UsbSpeed maxUsbSpeed) : DeviceBase(pipeline.getDeviceConfig(), maxUsbSpeed) {
     tryStartPipeline(pipeline);
 }
 
-Device::Device(const Pipeline& pipeline, const dai::Path& pathToCmd) {
-    init(pipeline, pathToCmd);
+Device::Device(const Pipeline& pipeline, const dai::Path& pathToCmd) : DeviceBase(pipeline.getDeviceConfig(), pathToCmd) {
     tryStartPipeline(pipeline);
 }
 
-Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo) {
-    init(pipeline, devInfo);
+Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo) : DeviceBase(pipeline.getDeviceConfig(), devInfo, false) {
     tryStartPipeline(pipeline);
 }
 
-Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd) {
-    init(pipeline, devInfo, pathToCmd);
+Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd) : DeviceBase(pipeline.getDeviceConfig(), devInfo, pathToCmd) {
     tryStartPipeline(pipeline);
 }
 
 template <typename T, std::enable_if_t<std::is_same<T, bool>::value, bool>>
-Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, T usb2Mode) {
-    init(pipeline, devInfo, usb2Mode ? UsbSpeed::HIGH : DEFAULT_USB_SPEED);
+Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, T usb2Mode) : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, usb2Mode) {
     tryStartPipeline(pipeline);
 }
 template Device::Device(const Pipeline&, const DeviceInfo&, bool);
 
-Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) : DeviceBase(pipeline, devInfo, maxUsbSpeed) {
-    init(pipeline, devInfo, maxUsbSpeed);
+Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, maxUsbSpeed) {
     tryStartPipeline(pipeline);
 }
 

--- a/src/device/Device.cpp
+++ b/src/device/Device.cpp
@@ -23,40 +23,47 @@ namespace dai {
 // Common explicit instantiation, to remove the need to define in header
 constexpr std::size_t Device::EVENT_QUEUE_MAXIMUM_SIZE;
 
-Device::Device(const Pipeline& pipeline) : DeviceBase(pipeline.getOpenVINOVersion()) {
+Device::Device(const Pipeline& pipeline) {
+    init(pipeline);
     tryStartPipeline(pipeline);
 }
 
 template <typename T, std::enable_if_t<std::is_same<T, bool>::value, bool>>
-Device::Device(const Pipeline& pipeline, T usb2Mode) : DeviceBase(pipeline.getOpenVINOVersion(), usb2Mode) {
+Device::Device(const Pipeline& pipeline, T usb2Mode) {
+    init(pipeline, usb2Mode ? UsbSpeed::HIGH : DEFAULT_USB_SPEED);
     tryStartPipeline(pipeline);
 }
 template Device::Device(const Pipeline&, bool);
 
-Device::Device(const Pipeline& pipeline, UsbSpeed maxUsbSpeed) : DeviceBase(pipeline.getOpenVINOVersion(), maxUsbSpeed) {
+Device::Device(const Pipeline& pipeline, UsbSpeed maxUsbSpeed) {
+    init(pipeline, maxUsbSpeed);
     tryStartPipeline(pipeline);
 }
 
-Device::Device(const Pipeline& pipeline, const dai::Path& pathToCmd) : DeviceBase(pipeline.getOpenVINOVersion(), pathToCmd) {
+Device::Device(const Pipeline& pipeline, const dai::Path& pathToCmd) {
+    init(pipeline, pathToCmd);
     tryStartPipeline(pipeline);
 }
 
-Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo) : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, false) {
+Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo) {
+    init(pipeline, devInfo);
     tryStartPipeline(pipeline);
 }
 
-Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd)
-    : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, pathToCmd) {
+Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd) {
+    init(pipeline, devInfo, pathToCmd);
     tryStartPipeline(pipeline);
 }
 
 template <typename T, std::enable_if_t<std::is_same<T, bool>::value, bool>>
-Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, T usb2Mode) : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, usb2Mode) {
+Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, T usb2Mode) {
+    init(pipeline, devInfo, usb2Mode ? UsbSpeed::HIGH : DEFAULT_USB_SPEED);
     tryStartPipeline(pipeline);
 }
 template Device::Device(const Pipeline&, const DeviceInfo&, bool);
 
-Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, maxUsbSpeed) {
+Device::Device(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) : DeviceBase(pipeline, devInfo, maxUsbSpeed) {
+    init(pipeline, devInfo, maxUsbSpeed);
     tryStartPipeline(pipeline);
 }
 

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -384,6 +384,22 @@ DeviceBase::DeviceBase(const Pipeline& pipeline, const DeviceInfo& devInfo, cons
     tryStartPipeline(pipeline);
 }
 
+DeviceBase::DeviceBase(Config config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) : deviceInfo(devInfo) {
+    init(config, maxUsbSpeed, "");
+}
+
+DeviceBase::DeviceBase(Config config, const DeviceInfo& devInfo, const dai::Path& pathToCmd) : deviceInfo(devInfo) {
+    init(config, false, pathToCmd);
+}
+
+DeviceBase::DeviceBase(Config config, const dai::Path& pathToCmd) {
+    init(config, pathToCmd);
+}
+
+DeviceBase::DeviceBase(Config config, UsbSpeed maxUsbSpeed) {
+    init(config, maxUsbSpeed);
+}
+
 void DeviceBase::init(OpenVINO::Version version) {
     tryGetDevice();
     init(version, false, "");
@@ -427,6 +443,26 @@ void DeviceBase::init(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSp
 void DeviceBase::init(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd) {
     deviceInfo = devInfo;
     init(pipeline, false, pathToCmd);
+}
+
+void DeviceBase::init(Config config, UsbSpeed maxUsbSpeed) {
+    tryGetDevice();
+    init(config, maxUsbSpeed, "");
+}
+
+void DeviceBase::init(Config config, const dai::Path& pathToCmd) {
+    tryGetDevice();
+    init(config, false, pathToCmd);
+}
+
+void DeviceBase::init(Config config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) {
+    deviceInfo = devInfo;
+    init(config, maxUsbSpeed, "");
+}
+
+void DeviceBase::init(Config config, const DeviceInfo& devInfo, const dai::Path& pathToCmd) {
+    deviceInfo = devInfo;
+    init(config, false, pathToCmd);
 }
 
 DeviceBase::DeviceBase(Config config) {
@@ -518,6 +554,12 @@ void DeviceBase::init(const Pipeline& pipeline, bool usb2Mode, const dai::Path& 
     cfg.board.usb.maxSpeed = usb2Mode ? UsbSpeed::HIGH : DeviceBase::DEFAULT_USB_SPEED;
     init2(cfg, pathToMvcmd, pipeline);
 }
+void DeviceBase::init(Config config, bool usb2Mode, const dai::Path& pathToMvcmd) {
+    Config cfg = config;
+    // Modify usb speed
+    cfg.board.usb.maxSpeed = usb2Mode ? UsbSpeed::HIGH : DeviceBase::DEFAULT_USB_SPEED;
+    init2(cfg, pathToMvcmd, {});
+}
 void DeviceBase::init(OpenVINO::Version version, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd) {
     Config cfg;
     // Specify usb speed
@@ -531,6 +573,12 @@ void DeviceBase::init(const Pipeline& pipeline, UsbSpeed maxUsbSpeed, const dai:
     // Modify usb speed
     cfg.board.usb.maxSpeed = maxUsbSpeed;
     init2(cfg, pathToMvcmd, pipeline);
+}
+void DeviceBase::init(Config config, UsbSpeed maxUsbSpeed, const dai::Path& pathToMvcmd) {
+    Config cfg = config;
+    // Modify usb speed
+    cfg.board.usb.maxSpeed = maxUsbSpeed;
+    init2(cfg, pathToMvcmd, {});
 }
 
 void DeviceBase::init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<const Pipeline&> pipeline) {

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -343,43 +343,90 @@ DeviceBase::DeviceBase(std::string nameOrDeviceId, UsbSpeed maxUsbSpeed)
     : DeviceBase(OpenVINO::VERSION_UNIVERSAL, dai::DeviceInfo(std::move(nameOrDeviceId)), maxUsbSpeed) {}
 
 DeviceBase::DeviceBase(OpenVINO::Version version) {
+    init(version);
+}
+
+DeviceBase::DeviceBase(OpenVINO::Version version, const dai::Path& pathToCmd) {
+    init(version, pathToCmd);
+}
+
+DeviceBase::DeviceBase(OpenVINO::Version version, UsbSpeed maxUsbSpeed) {
+    init(version, maxUsbSpeed);
+}
+
+DeviceBase::DeviceBase(const Pipeline& pipeline) {
+    init(pipeline);
+    tryStartPipeline(pipeline);
+}
+
+DeviceBase::DeviceBase(const Pipeline& pipeline, UsbSpeed maxUsbSpeed) {
+    init(pipeline, maxUsbSpeed);
+    tryStartPipeline(pipeline);
+}
+
+DeviceBase::DeviceBase(const Pipeline& pipeline, const dai::Path& pathToCmd) {
+    init(pipeline, pathToCmd);
+    tryStartPipeline(pipeline);
+}
+
+DeviceBase::DeviceBase(const Pipeline& pipeline, const DeviceInfo& devInfo) : deviceInfo(devInfo) {
+    init(pipeline, devInfo);
+    tryStartPipeline(pipeline);
+}
+
+DeviceBase::DeviceBase(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) : deviceInfo(devInfo) {
+    init(pipeline, devInfo, maxUsbSpeed);
+    tryStartPipeline(pipeline);
+}
+
+DeviceBase::DeviceBase(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd) : deviceInfo(devInfo) {
+    init(pipeline, devInfo, pathToCmd);
+    tryStartPipeline(pipeline);
+}
+
+void DeviceBase::init(OpenVINO::Version version) {
     tryGetDevice();
     init(version, false, "");
 }
 
-DeviceBase::DeviceBase(OpenVINO::Version version, const dai::Path& pathToCmd) {
+void DeviceBase::init(OpenVINO::Version version, const dai::Path& pathToCmd) {
     tryGetDevice();
     init(version, false, pathToCmd);
 }
 
-DeviceBase::DeviceBase(OpenVINO::Version version, UsbSpeed maxUsbSpeed) {
+void DeviceBase::init(OpenVINO::Version version, UsbSpeed maxUsbSpeed) {
     tryGetDevice();
     init(version, maxUsbSpeed, "");
 }
 
-DeviceBase::DeviceBase(const Pipeline& pipeline) : DeviceBase(pipeline.getOpenVINOVersion()) {
-    tryStartPipeline(pipeline);
+void DeviceBase::init(const Pipeline& pipeline) {
+    tryGetDevice();
+    init(pipeline, false, "");
 }
 
-DeviceBase::DeviceBase(const Pipeline& pipeline, UsbSpeed maxUsbSpeed) : DeviceBase(pipeline.getOpenVINOVersion(), maxUsbSpeed) {
-    tryStartPipeline(pipeline);
+void DeviceBase::init(const Pipeline& pipeline, UsbSpeed maxUsbSpeed) {
+    tryGetDevice();
+    init(pipeline, maxUsbSpeed, "");
 }
 
-DeviceBase::DeviceBase(const Pipeline& pipeline, const dai::Path& pathToCmd) : DeviceBase(pipeline.getOpenVINOVersion(), pathToCmd) {
-    tryStartPipeline(pipeline);
+void DeviceBase::init(const Pipeline& pipeline, const dai::Path& pathToCmd) {
+    tryGetDevice();
+    init(pipeline, false, pathToCmd);
 }
 
-DeviceBase::DeviceBase(const Pipeline& pipeline, const DeviceInfo& devInfo)
-    : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, DeviceBase::DEFAULT_USB_SPEED) {}
-
-DeviceBase::DeviceBase(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed)
-    : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, maxUsbSpeed) {
-    tryStartPipeline(pipeline);
+void DeviceBase::init(const Pipeline& pipeline, const DeviceInfo& devInfo) {
+    deviceInfo = devInfo;
+    init(pipeline, false, "");
 }
 
-DeviceBase::DeviceBase(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd)
-    : DeviceBase(pipeline.getOpenVINOVersion(), devInfo, pathToCmd) {
-    tryStartPipeline(pipeline);
+void DeviceBase::init(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) {
+    deviceInfo = devInfo;
+    init(pipeline, maxUsbSpeed, "");
+}
+
+void DeviceBase::init(const Pipeline& pipeline, const DeviceInfo& devInfo, const dai::Path& pathToCmd) {
+    deviceInfo = devInfo;
+    init(pipeline, false, pathToCmd);
 }
 
 DeviceBase::DeviceBase(Config config) {

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -54,13 +54,13 @@ void ColorCamera::setCamId(int64_t camId) {
     // cast to board socket
     switch(camId) {
         case 0:
-            properties.boardSocket = CameraBoardSocket::RGB;
+            properties.boardSocket = CameraBoardSocket::CAM_A;
             break;
         case 1:
-            properties.boardSocket = CameraBoardSocket::LEFT;
+            properties.boardSocket = CameraBoardSocket::CAM_B;
             break;
         case 2:
-            properties.boardSocket = CameraBoardSocket::RIGHT;
+            properties.boardSocket = CameraBoardSocket::CAM_C;
             break;
         case 3:
             properties.boardSocket = CameraBoardSocket::CAM_D;

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -46,13 +46,13 @@ void MonoCamera::setCamId(int64_t camId) {
     // cast to board socket
     switch(camId) {
         case 0:
-            properties.boardSocket = CameraBoardSocket::RGB;
+            properties.boardSocket = CameraBoardSocket::CAM_A;
             break;
         case 1:
-            properties.boardSocket = CameraBoardSocket::LEFT;
+            properties.boardSocket = CameraBoardSocket::CAM_B;
             break;
         case 2:
-            properties.boardSocket = CameraBoardSocket::RIGHT;
+            properties.boardSocket = CameraBoardSocket::CAM_C;
             break;
         case 3:
             properties.boardSocket = CameraBoardSocket::CAM_D;

--- a/tests/src/multiple_devices_test.cpp
+++ b/tests/src/multiple_devices_test.cpp
@@ -41,7 +41,7 @@ int main() {
 
             // Properties
             camRgb->setPreviewSize(300, 300);
-            camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+            camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
             camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
             camRgb->setInterleaved(false);
             camRgb->setColorOrder(dai::ColorCameraProperties::ColorOrder::RGB);

--- a/tests/src/stability_stress_test.cpp
+++ b/tests/src/stability_stress_test.cpp
@@ -133,18 +133,18 @@ int main(int argc, char** argv) {
     // xoutTrackedFeaturesRight->setStreamName("trackedFeaturesRight");
 
     // Properties
-    camRgb->setBoardSocket(dai::CameraBoardSocket::RGB);
+    camRgb->setBoardSocket(dai::CameraBoardSocket::CAM_A);
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_4_K);
     camRgb->setPreviewSize(416, 416);
     camRgb->setInterleaved(false);
     camRgb->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
     camRgb->setFps(RGB_FPS);
 
-    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoLeft->setCamera("left");
     monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
     monoLeft->setFps(MONO_FPS);
 
-    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+    monoRight->setCamera("right");
     monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
     monoRight->setFps(MONO_FPS);
 
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
 
     stereo->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::HIGH_DENSITY);
     // Align depth map to the perspective of RGB camera, on which inference is done
-    stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+    stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
     stereo->setOutputSize(monoLeft->getResolutionWidth(), monoLeft->getResolutionHeight());
 
     spatialDetectionNetwork->setBlobPath(nnPath);


### PR DESCRIPTION
This PR deprecates (slated to be removed) the named camera board socket enums as those are misleading and in certain contexts or devices outright wrong.
 - RGB, CENTER
 - LEFT, RIGHT

The alternative is to rely on camera names - using API such as:
 - `ColorCamera.setCamera([name])`
 - `MonoCamera.setCamera([name])`
 - `Camera.setCamera([name])`
 - `device.getConnectedCameraFeatures()` - to discover connected cameras, their sockets and names

Or explicit board sockets (depends a lot more on specific device in question)

This is also a preparation for potential name aliasing, where a device will be able to be 180 degree rotated without having to modify which camera is now "left / right / ..." 