### PR TITLE
Spatial calculator accuracy improvements + RGB align fix when custom depth output size is specified

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "78ba554b106d7eb2baca2f7a2770ed1f312811aa")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "81701b1fe003b50e9bd17862a7f9c0b1ffdaf53a")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Uses camera intrinsic data instead design FOV to calculate spatial locations.