### PR TITLE
Crash dump support for debugging

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "da7739bf402427b2d2d38316beedb0e1a1cf7304")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "143e162f9adb251d0875d91ed6835ce52663ef54")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "785dc95b2f870126e3cab939199bbe7e05a9646c")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "da7739bf402427b2d2d38316beedb0e1a1cf7304")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "78ba554b106d7eb2baca2f7a2770ed1f312811aa")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "1ec2c463fef44d4bf30062e160b8e283db62a0ee")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "1ec2c463fef44d4bf30062e160b8e283db62a0ee")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "d5195cfdbe8e0c024d6763c227a2e3dc3c38248d")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "d5195cfdbe8e0c024d6763c227a2e3dc3c38248d")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "785dc95b2f870126e3cab939199bbe7e05a9646c")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -359,3 +359,6 @@ dai_add_example(apriltag_rgb AprilTag/apriltag_rgb.cpp ON)
 # DetectionParser
 dai_add_example(detection_parser NeuralNetwork/detection_parser.cpp ON)
 target_compile_definitions(detection_parser PRIVATE BLOB_PATH="${mobilenet_blob}")
+
+# DetectionParser
+dai_add_example(crash_report CrashReport/crash_report.cpp OFF)

--- a/examples/CrashReport/crash_report.cpp
+++ b/examples/CrashReport/crash_report.cpp
@@ -8,16 +8,17 @@ int main() {
 
     // Connect to device and start pipeline
     dai::Device device;
-    auto crashDump = device.getCrashDump();
-    if(crashDump.crashReports.empty()) {
-        std::cout << "There was no crash dump found on your device!" << std::endl;
-    } else {
+    if(device.hasCrashDump()) {
+        auto crashDump = device.getCrashDump();
+
         auto json = crashDump.serializeToJson();
         std::cout << json << std::endl;
 
-        dai::Path destPath = "crashDump.json"; 
+        dai::Path destPath = "crashDump.json";
         std::ofstream ob(destPath);
         ob << std::setw(4) << json << std::endl;
+    } else {
+        std::cout << "There was no crash dump found on your device!" << std::endl;
     }
 
     return 0;

--- a/examples/CrashReport/crash_report.cpp
+++ b/examples/CrashReport/crash_report.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+
+// Includes common necessary includes for development using depthai library
+#include "depthai/depthai.hpp"
+
+int main() {
+    using namespace std;
+
+    // Connect to device and start pipeline
+    dai::Device device;
+    auto crashDump = device.getCrashDump();
+    if(crashDump.crashReports.empty()) {
+        std::cout << "There was no crash dump found on your device!" << std::endl;
+    } else {
+        auto json = crashDump.serializeToJson();
+        std::cout << json << std::endl;
+
+        dai::Path destPath = "crashDump.json"; 
+        std::ofstream ob(destPath);
+        ob << std::setw(4) << json << std::endl;
+    }
+
+    return 0;
+}

--- a/examples/CrashReport/crash_report.cpp
+++ b/examples/CrashReport/crash_report.cpp
@@ -1,7 +1,13 @@
+#include <fstream>
 #include <iostream>
 
 // Includes common necessary includes for development using depthai library
 #include "depthai/depthai.hpp"
+
+static bool fileExists(dai::Path path) {
+    std::ifstream file(path);
+    return file.is_open();
+}
 
 int main() {
     using namespace std;
@@ -10,13 +16,23 @@ int main() {
     dai::Device device;
     if(device.hasCrashDump()) {
         auto crashDump = device.getCrashDump();
+        std::string commitHash = crashDump.depthaiCommitHash;
+        std::string deviceId = crashDump.deviceId;
 
         auto json = crashDump.serializeToJson();
-        std::cout << json << std::endl;
 
-        dai::Path destPath = "crashDump.json";
-        std::ofstream ob(destPath);
-        ob << std::setw(4) << json << std::endl;
+        for(int i = 0;; i++) {
+            dai::Path destPath = "crashDump_" + to_string(i) + "_" + deviceId + "_" + commitHash + ".json";
+            if(fileExists(destPath)) continue;
+
+            std::ofstream ob(destPath);
+            ob << std::setw(4) << json << std::endl;
+
+            std::cout << "Crash dump found on your device!" << std::endl;
+            std::cout << "Saved to " << std::string(destPath) << std::endl;
+            std::cout << "Please report to developers!" << std::endl;
+            break;
+        }
     } else {
         std::cout << "There was no crash dump found on your device!" << std::endl;
     }

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -457,6 +457,11 @@ class DeviceBase {
     dai::CrashDump getCrashDump();
 
     /**
+     * Retrieves whether the is crash dump stored on device or not.
+     */
+    bool hasCrashDump();
+
+    /**
      * Add a callback for device logging. The callback will be called from a separate thread with the LogMessage being passed.
      *
      * @param callback Callback to call whenever a log message arrives

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -30,6 +30,7 @@
 #include "depthai-shared/common/CpuUsage.hpp"
 #include "depthai-shared/common/MemoryInfo.hpp"
 #include "depthai-shared/device/BoardConfig.hpp"
+#include "depthai-shared/device/CrashDump.hpp"
 #include "depthai-shared/log/LogLevel.hpp"
 #include "depthai-shared/log/LogMessage.hpp"
 
@@ -449,6 +450,11 @@ class DeviceBase {
      * For OAK-D-Pro it should be `[{"LM3644", 2, 0x63}]`
      */
     std::vector<std::tuple<std::string, int, int>> getIrDrivers();
+
+    /**
+     * Retrieves crash dump for debugging.
+     */
+    std::vector<dai::CrashDump> getCrashDump();
 
     /**
      * Add a callback for device logging. The callback will be called from a separate thread with the LogMessage being passed.

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -454,7 +454,7 @@ class DeviceBase {
     /**
      * Retrieves crash dump for debugging.
      */
-    std::vector<dai::CrashDump> getCrashDump();
+    dai::CrashDump getCrashDump();
 
     /**
      * Add a callback for device logging. The callback will be called from a separate thread with the LogMessage being passed.

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -7,6 +7,7 @@
 #include "depthai-bootloader-shared/Bootloader.hpp"
 #include "depthai-bootloader-shared/XLinkConstants.hpp"
 #include "depthai-shared/datatype/RawImgFrame.hpp"
+#include "depthai-shared/device/CrashDump.hpp"
 #include "depthai-shared/log/LogConstants.hpp"
 #include "depthai-shared/log/LogLevel.hpp"
 #include "depthai-shared/log/LogMessage.hpp"
@@ -963,6 +964,12 @@ std::vector<std::tuple<std::string, int, int>> DeviceBase::getIrDrivers() {
     checkClosed();
 
     return pimpl->rpcClient->call("getIrDrivers");
+}
+
+std::vector<dai::CrashDump> DeviceBase::getCrashDump() {
+    checkClosed();
+
+    return pimpl->rpcClient->call("getCrashDump").as<std::vector<dai::CrashDump>>();
 }
 
 int DeviceBase::addLogCallback(std::function<void(LogMessage)> callback) {

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -966,10 +966,10 @@ std::vector<std::tuple<std::string, int, int>> DeviceBase::getIrDrivers() {
     return pimpl->rpcClient->call("getIrDrivers");
 }
 
-std::vector<dai::CrashDump> DeviceBase::getCrashDump() {
+dai::CrashDump DeviceBase::getCrashDump() {
     checkClosed();
 
-    return pimpl->rpcClient->call("getCrashDump").as<std::vector<dai::CrashDump>>();
+    return pimpl->rpcClient->call("getCrashDump").as<dai::CrashDump>();
 }
 
 int DeviceBase::addLogCallback(std::function<void(LogMessage)> callback) {

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -972,6 +972,11 @@ dai::CrashDump DeviceBase::getCrashDump() {
     return pimpl->rpcClient->call("getCrashDump").as<dai::CrashDump>();
 }
 
+bool DeviceBase::hasCrashDump() {
+    dai::CrashDump crashDump = getCrashDump();
+    return !crashDump.crashReports.empty();
+}
+
 int DeviceBase::addLogCallback(std::function<void(LogMessage)> callback) {
     checkClosed();
 


### PR DESCRIPTION
Outputs stack trace of threads from the device in case of a crash in json format, parsable by `addr2line`.
TODO: tool