### PR TITLE
Add 3A skipping option to reduce CSS CPU usage

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "1b9a2401edd53bf26e8af00b71dc0941c1217b31")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "8f6a30a17a5c7076c6b05260f9c07ab80f54ab12")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "8f6a30a17a5c7076c6b05260f9c07ab80f54ab12")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "85a6a52c1dcb8000c03dbd7af00758ed06d1a38e")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "85a6a52c1dcb8000c03dbd7af00758ed06d1a38e")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "1545a3a9e3eac4d2a5a66b9643cbeebc32e6e58f")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/node/Camera.hpp
+++ b/include/depthai/pipeline/node/Camera.hpp
@@ -199,6 +199,13 @@ class Camera : public NodeCRTP<Node, Camera, CameraProperties> {
     void setFps(float fps);
 
     /**
+     * Image tuning, 3A rate.
+     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     */
+    void set3AFpsDenominator(int denominator);
+
+    /**
      * Get rate at which camera should produce frames
      * @returns Rate in frames per second
      */

--- a/include/depthai/pipeline/node/Camera.hpp
+++ b/include/depthai/pipeline/node/Camera.hpp
@@ -199,11 +199,13 @@ class Camera : public NodeCRTP<Node, Camera, CameraProperties> {
     void setFps(float fps);
 
     /**
-     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Isp 3A rate (auto focus, auto exposure, auto white balance, camera controls etc.).
      * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
      * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
+     * Note that camera controls will be processed at this rate. E.g. if camera is running at 30 fps, and camera control is sent at every frame,
+     * but 3A fps is set to 15, the camera control messages will be processed at 15 fps rate, which will lead to queueing.
      */
     void setIsp3aFps(int isp3aFps);
 

--- a/include/depthai/pipeline/node/Camera.hpp
+++ b/include/depthai/pipeline/node/Camera.hpp
@@ -199,11 +199,13 @@ class Camera : public NodeCRTP<Node, Camera, CameraProperties> {
     void setFps(float fps);
 
     /**
-     * Image tuning, 3A rate.
-     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
-     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Can be overriden by setting explicitly.
+     * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    void set3AFpsDenominator(int denominator);
+    void setIsp3aFps(int isp3aFps);
 
     /**
      * Get rate at which camera should produce frames

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -223,11 +223,13 @@ class ColorCamera : public NodeCRTP<Node, ColorCamera, ColorCameraProperties> {
     void setFps(float fps);
 
     /**
-     * Image tuning, 3A rate.
-     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
-     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Can be overriden by setting explicitly.
+     * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    void set3AFpsDenominator(int denominator);
+    void setIsp3aFps(int isp3aFps);
 
     // Set events on which frames will be received
     void setFrameEventFilter(const std::vector<dai::FrameEvent>& events);

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -223,11 +223,14 @@ class ColorCamera : public NodeCRTP<Node, ColorCamera, ColorCameraProperties> {
     void setFps(float fps);
 
     /**
-     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Isp 3A rate (auto focus, auto exposure, auto white balance, camera controls etc.).
      * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
      * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
+     * Note that camera controls will be processed at this rate. E.g. if camera is running at 30 fps, and camera control is sent at every frame,
+     * but 3A fps is set to 15, the camera control messages will be processed at 15 fps rate, which will lead to queueing.
+
      */
     void setIsp3aFps(int isp3aFps);
 

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -222,6 +222,13 @@ class ColorCamera : public NodeCRTP<Node, ColorCamera, ColorCameraProperties> {
      */
     void setFps(float fps);
 
+    /**
+     * Image tuning, 3A rate.
+     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     */
+    void set3AFpsDenominator(int denominator);
+
     // Set events on which frames will be received
     void setFrameEventFilter(const std::vector<dai::FrameEvent>& events);
 

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -118,11 +118,14 @@ class MonoCamera : public NodeCRTP<Node, MonoCamera, MonoCameraProperties> {
     void setFps(float fps);
 
     /**
-     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Isp 3A rate (auto focus, auto exposure, auto white balance, camera controls etc.).
      * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
      * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
+     * Note that camera controls will be processed at this rate. E.g. if camera is running at 30 fps, and camera control is sent at every frame,
+     * but 3A fps is set to 15, the camera control messages will be processed at 15 fps rate, which will lead to queueing.
+
      */
     void setIsp3aFps(int isp3aFps);
 

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -118,6 +118,13 @@ class MonoCamera : public NodeCRTP<Node, MonoCamera, MonoCameraProperties> {
     void setFps(float fps);
 
     /**
+     * Image tuning, 3A rate.
+     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     */
+    void set3AFpsDenominator(int denominator);
+
+    /**
      * Get rate at which camera should produce frames
      * @returns Rate in frames per second
      */

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -118,11 +118,13 @@ class MonoCamera : public NodeCRTP<Node, MonoCamera, MonoCameraProperties> {
     void setFps(float fps);
 
     /**
-     * Image tuning, 3A rate.
-     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
-     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Can be overriden by setting explicitly.
+     * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    void set3AFpsDenominator(int denominator);
+    void setIsp3aFps(int isp3aFps);
 
     /**
      * Get rate at which camera should produce frames

--- a/src/pipeline/node/Camera.cpp
+++ b/src/pipeline/node/Camera.cpp
@@ -130,6 +130,10 @@ void Camera::setFps(float fps) {
     properties.fps = fps;
 }
 
+void Camera::set3AFpsDenominator(int denominator) {
+    properties.imageTuningFpsDenominator = denominator;
+}
+
 float Camera::getFps() const {
     // if AUTO
     if(properties.fps == CameraProperties::AUTO || properties.fps == 0) {

--- a/src/pipeline/node/Camera.cpp
+++ b/src/pipeline/node/Camera.cpp
@@ -130,8 +130,8 @@ void Camera::setFps(float fps) {
     properties.fps = fps;
 }
 
-void Camera::set3AFpsDenominator(int denominator) {
-    properties.imageTuningFpsDenominator = denominator;
+void Camera::setIsp3aFps(int isp3aFps) {
+    properties.isp3aFps = isp3aFps;
 }
 
 float Camera::getFps() const {

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -177,8 +177,8 @@ void ColorCamera::setFps(float fps) {
     properties.fps = fps;
 }
 
-void ColorCamera::set3AFpsDenominator(int denominator) {
-    properties.imageTuningFpsDenominator = denominator;
+void ColorCamera::setIsp3aFps(int isp3aFps) {
+    properties.isp3aFps = isp3aFps;
 }
 
 void ColorCamera::setFrameEventFilter(const std::vector<dai::FrameEvent>& events) {

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -177,6 +177,10 @@ void ColorCamera::setFps(float fps) {
     properties.fps = fps;
 }
 
+void ColorCamera::set3AFpsDenominator(int denominator) {
+    properties.imageTuningFpsDenominator = denominator;
+}
+
 void ColorCamera::setFrameEventFilter(const std::vector<dai::FrameEvent>& events) {
     properties.eventFilter = events;
 }

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -99,8 +99,8 @@ void MonoCamera::setFps(float fps) {
     properties.fps = fps;
 }
 
-void MonoCamera::set3AFpsDenominator(int denominator) {
-    properties.imageTuningFpsDenominator = denominator;
+void MonoCamera::setIsp3aFps(int isp3aFps) {
+    properties.isp3aFps = isp3aFps;
 }
 
 float MonoCamera::getFps() const {

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -99,6 +99,10 @@ void MonoCamera::setFps(float fps) {
     properties.fps = fps;
 }
 
+void MonoCamera::set3AFpsDenominator(int denominator) {
+    properties.imageTuningFpsDenominator = denominator;
+}
+
 float MonoCamera::getFps() const {
     // if AUTO
     if(properties.fps == -1 || properties.fps == 0) {


### PR DESCRIPTION
For example setting:
```
monoLeft.setIsp3aFps(5)
monoRight.setIsp3aFps(5)
```
While cameras are set to 30 fps, this will reduce the CSS CPU usage by half. Useful for POE cameras where CPU usage is high.
It is achieved by running the 3A algos every 4-th frame.
It also enables higher FPS, for example with `setIsp3aFps(5)` OV9282 cameras are capable of running at 100 fps at 800P.

```
    /**
     * Isp 3A rate (auto focus, auto exposure, auto white balance).
     * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
     * Can be overriden by setting explicitly.
     * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
     * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
     */
    void setIsp3aFps(int isp3aFps);
```
