### PR TITLE
BMI270: Enable interrupt mode

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "115765d4d9f70a9f983a7824b3b38f06c6464267")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "8e9d4424a97060cb4383896b76e131400d03893e")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "8e9d4424a97060cb4383896b76e131400d03893e")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a69259a0e38deca9d77ea246b0c33251cdf0b6cc")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
Related: 
https://github.com/boschsensortec/BMI270-Sensor-API/pull/16
https://github.com/luxonis/depthai-core/issues/684