### PR TITLE
Camera: move alpha parameter as optional to be consistent with stereo

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "91fd63cb4e50b716bbd22e667d86fcc904bee92c")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "78f6ce2dff2aa2edb9c8ea06106c46d268da8160")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "900949c33d6b683d78ad8084828b6ba9c2979d93")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "91fd63cb4e50b716bbd22e667d86fcc904bee92c")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/node/Camera.hpp
+++ b/include/depthai/pipeline/node/Camera.hpp
@@ -333,7 +333,7 @@ class Camera : public NodeCRTP<Node, Camera, CameraProperties> {
     /// Set calibration alpha parameter that determines FOV of undistorted frames
     void setCalibrationAlpha(float alpha);
     /// Get calibration alpha parameter that determines FOV of undistorted frames
-    float getCalibrationAlpha() const;
+    tl::optional<float> getCalibrationAlpha() const;
 
     /**
      * Configures whether the camera `raw` frames are saved as MIPI-packed to memory.

--- a/src/pipeline/node/Camera.cpp
+++ b/src/pipeline/node/Camera.cpp
@@ -271,7 +271,7 @@ void Camera::setCalibrationAlpha(float alpha) {
     properties.calibAlpha = alpha;
 }
 
-float Camera::getCalibrationAlpha() const {
+tl::optional<float> Camera::getCalibrationAlpha() const {
     return properties.calibAlpha;
 }
 


### PR DESCRIPTION
Important to mention that alpha=0 doesn't mean that intrinsics don't change at all, thus to use intrinsics from calibration, alpha shouldn't be set.