### PR TITLE
Moved timestamps and sequence number from descendants to RawBuffer

### DIFF
--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -364,7 +364,7 @@ class DeviceBase {
 
     /**
      * Connects to device specified by devInfo.
-     * @param config Config with which the device will be booted with 
+     * @param config Config with which the device will be booted with
      * @param devInfo DeviceInfo which specifies which device to connect to
      * @param maxUsbSpeed Maximum allowed USB speed
      */

--- a/include/depthai/pipeline/datatype/AprilTags.hpp
+++ b/include/depthai/pipeline/datatype/AprilTags.hpp
@@ -26,22 +26,6 @@ class AprilTags : public Buffer {
     std::vector<AprilTag>& aprilTags;
 
     /**
-     * Retrieves image timestamp related to dai::Clock::now()
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
-
-    /**
-     * Retrieves image timestamp directly captured from device's monotonic clock,
-     * not synchronized to host time. Used mostly for debugging
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
-
-    /**
-     * Retrieves image sequence number
-     */
-    int64_t getSequenceNum() const;
-
-    /**
      * Sets image timestamp related to dai::Clock::now()
      */
     AprilTags& setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> timestamp);

--- a/include/depthai/pipeline/datatype/Buffer.hpp
+++ b/include/depthai/pipeline/datatype/Buffer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <unordered_map>
 #include <vector>
 
@@ -34,6 +35,37 @@ class Buffer : public ADatatype {
      * @param data Moves data to internal buffer
      */
     void setData(std::vector<std::uint8_t>&& data);
+
+    /**
+     * Retrieves timestamp related to dai::Clock::now()
+     */
+    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
+
+    /**
+     * Retrieves timestamp directly captured from device's monotonic clock,
+     * not synchronized to host time. Used mostly for debugging
+     */
+    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
+
+    /**
+     * Retrieves sequence number
+     */
+    int64_t getSequenceNum() const;
+
+    /**
+     * Sets timestamp related to dai::Clock::now()
+     */
+    Buffer& setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> timestamp);
+
+    /**
+     * Sets timestamp related to dai::Clock::now()
+     */
+    Buffer& setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> timestamp);
+
+    /**
+     * Retrieves sequence number
+     */
+    Buffer& setSequenceNum(int64_t sequenceNum);
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/datatype/ImgDetections.hpp
+++ b/include/depthai/pipeline/datatype/ImgDetections.hpp
@@ -38,22 +38,6 @@ class ImgDetections : public Buffer {
      * Retrieves image sequence number
      */
     ImgDetections& setSequenceNum(int64_t sequenceNum);
-
-    /**
-     * Retrieves image timestamp related to dai::Clock::now()
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
-
-    /**
-     * Retrieves image timestamp directly captured from device's monotonic clock,
-     * not synchronized to host time. Used mostly for debugging
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
-
-    /**
-     * Retrieves image sequence number
-     */
-    int64_t getSequenceNum() const;
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -31,6 +31,8 @@ class ImgFrame : public Buffer {
     using Type = RawImgFrame::Type;
     using Specs = RawImgFrame::Specs;
     using CameraSettings = RawImgFrame::CameraSettings;
+    using Buffer::getTimestamp;
+    using Buffer::getTimestampDevice;
 
     /**
      * Construct ImgFrame message.
@@ -39,18 +41,6 @@ class ImgFrame : public Buffer {
     ImgFrame();
     explicit ImgFrame(std::shared_ptr<RawImgFrame> ptr);
     virtual ~ImgFrame() = default;
-
-    // getters
-    /**
-     * Retrieves image timestamp (end of exposure) related to dai::Clock::now()
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
-
-    /**
-     * Retrieves image timestamp (end of exposure) directly captured from device's monotonic clock,
-     * not synchronized to host time. Used when monotonicity is required.
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
 
     // getters
     /**
@@ -73,11 +63,6 @@ class ImgFrame : public Buffer {
      * Retrieves image category
      */
     unsigned int getCategory() const;
-
-    /**
-     * Retrieves image sequence number
-     */
-    int64_t getSequenceNum() const;
 
     /**
      * Retrieves image width in pixels

--- a/include/depthai/pipeline/datatype/NNData.hpp
+++ b/include/depthai/pipeline/datatype/NNData.hpp
@@ -141,22 +141,6 @@ class NNData : public Buffer {
     std::vector<std::int32_t> getFirstLayerInt32() const;
 
     /**
-     * Retrieves image timestamp related to dai::Clock::now()
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
-
-    /**
-     * Retrieves image timestamp directly captured from device's monotonic clock,
-     * not synchronized to host time. Used mostly for debugging
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
-
-    /**
-     * Retrieves image sequence number
-     */
-    int64_t getSequenceNum() const;
-
-    /**
      * Sets image timestamp related to dai::Clock::now()
      */
     NNData& setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> timestamp);

--- a/include/depthai/pipeline/datatype/SpatialImgDetections.hpp
+++ b/include/depthai/pipeline/datatype/SpatialImgDetections.hpp
@@ -43,22 +43,6 @@ class SpatialImgDetections : public Buffer {
      * Retrieves image sequence number
      */
     SpatialImgDetections& setSequenceNum(int64_t sequenceNum);
-
-    /**
-     * Retrieves image timestamp related to dai::Clock::now()
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
-
-    /**
-     * Retrieves image timestamp directly captured from device's monotonic clock,
-     * not synchronized to host time. Used mostly for debugging
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
-
-    /**
-     * Retrieves image sequence number
-     */
-    int64_t getSequenceNum() const;
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/datatype/SpatialLocationCalculatorData.hpp
+++ b/include/depthai/pipeline/datatype/SpatialLocationCalculatorData.hpp
@@ -32,22 +32,6 @@ class SpatialLocationCalculatorData : public Buffer {
     std::vector<SpatialLocations>& spatialLocations;
 
     /**
-     * Retrieves image timestamp related to dai::Clock::now()
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
-
-    /**
-     * Retrieves image timestamp directly captured from device's monotonic clock,
-     * not synchronized to host time. Used mostly for debugging
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
-
-    /**
-     * Retrieves image sequence number
-     */
-    int64_t getSequenceNum() const;
-
-    /**
      * Sets image timestamp related to dai::Clock::now()
      */
     SpatialLocationCalculatorData& setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> timestamp);

--- a/include/depthai/pipeline/datatype/TrackedFeatures.hpp
+++ b/include/depthai/pipeline/datatype/TrackedFeatures.hpp
@@ -26,22 +26,6 @@ class TrackedFeatures : public Buffer {
     std::vector<TrackedFeature>& trackedFeatures;
 
     /**
-     * Retrieves image timestamp related to dai::Clock::now()
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
-
-    /**
-     * Retrieves image timestamp directly captured from device's monotonic clock,
-     * not synchronized to host time. Used mostly for debugging
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
-
-    /**
-     * Retrieves image sequence number
-     */
-    int64_t getSequenceNum() const;
-
-    /**
      * Sets image timestamp related to dai::Clock::now()
      */
     TrackedFeatures& setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> timestamp);

--- a/include/depthai/pipeline/datatype/Tracklets.hpp
+++ b/include/depthai/pipeline/datatype/Tracklets.hpp
@@ -31,22 +31,6 @@ class Tracklets : public Buffer {
     std::vector<Tracklet>& tracklets;
 
     /**
-     * Retrieves image timestamp related to dai::Clock::now()
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestamp() const;
-
-    /**
-     * Retrieves image timestamp directly captured from device's monotonic clock,
-     * not synchronized to host time. Used mostly for debugging
-     */
-    std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> getTimestampDevice() const;
-
-    /**
-     * Retrieves image sequence number
-     */
-    int64_t getSequenceNum() const;
-
-    /**
      * Sets image timestamp related to dai::Clock::now()
      */
     Tracklets& setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> timestamp);

--- a/src/pipeline/datatype/AprilTags.cpp
+++ b/src/pipeline/datatype/AprilTags.cpp
@@ -10,39 +10,17 @@ AprilTags::AprilTags() : Buffer(std::make_shared<RawAprilTags>()), rawdata(*dyna
 AprilTags::AprilTags(std::shared_ptr<RawAprilTags> ptr)
     : Buffer(std::move(ptr)), rawdata(*dynamic_cast<RawAprilTags*>(raw.get())), aprilTags(rawdata.aprilTags) {}
 
-// getters
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> AprilTags::getTimestamp() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawdata.ts.sec) + nanoseconds(rawdata.ts.nsec)};
-}
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> AprilTags::getTimestampDevice() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawdata.tsDevice.sec) + nanoseconds(rawdata.tsDevice.nsec)};
-}
-int64_t AprilTags::getSequenceNum() const {
-    return rawdata.sequenceNum;
-}
-
 // setters
 AprilTags& AprilTags::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawdata.ts.sec = duration_cast<seconds>(ts).count();
-    rawdata.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<AprilTags&>(Buffer::setTimestamp(tp));
 }
 AprilTags& AprilTags::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawdata.tsDevice.sec = duration_cast<seconds>(ts).count();
-    rawdata.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<AprilTags&>(Buffer::setTimestampDevice(tp));
 }
 AprilTags& AprilTags::setSequenceNum(int64_t sequenceNum) {
-    rawdata.sequenceNum = sequenceNum;
-    return *this;
+    return static_cast<AprilTags&>(Buffer::setSequenceNum(sequenceNum));
 }
 
 }  // namespace dai

--- a/src/pipeline/datatype/Buffer.cpp
+++ b/src/pipeline/datatype/Buffer.cpp
@@ -49,7 +49,7 @@ Buffer& Buffer::setTimestampDevice(std::chrono::time_point<std::chrono::steady_c
     using namespace std::chrono;
     auto ts = tp.time_since_epoch();
     raw->tsDevice.sec = duration_cast<seconds>(ts).count();
-    raw->ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
+    raw->tsDevice.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
     return *this;
 }
 Buffer& Buffer::setSequenceNum(int64_t sequenceNum) {

--- a/src/pipeline/datatype/Buffer.cpp
+++ b/src/pipeline/datatype/Buffer.cpp
@@ -22,4 +22,39 @@ void Buffer::setData(std::vector<std::uint8_t>&& data) {
     raw->data = std::move(data);
 }
 
+// getters
+std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> Buffer::getTimestamp() const {
+    using namespace std::chrono;
+    return time_point<steady_clock, steady_clock::duration>{seconds(raw->ts.sec) + nanoseconds(raw->ts.nsec)};
+}
+std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> Buffer::getTimestampDevice() const {
+    using namespace std::chrono;
+    return time_point<steady_clock, steady_clock::duration>{seconds(raw->tsDevice.sec) + nanoseconds(raw->tsDevice.nsec)};
+}
+int64_t Buffer::getSequenceNum() const {
+    return raw->sequenceNum;
+}
+
+// setters
+Buffer& Buffer::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
+    // Set timestamp from timepoint
+    using namespace std::chrono;
+    auto ts = tp.time_since_epoch();
+    raw->ts.sec = duration_cast<seconds>(ts).count();
+    raw->ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
+    return *this;
+}
+Buffer& Buffer::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
+    // Set timestamp from timepoint
+    using namespace std::chrono;
+    auto ts = tp.time_since_epoch();
+    raw->tsDevice.sec = duration_cast<seconds>(ts).count();
+    raw->ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
+    return *this;
+}
+Buffer& Buffer::setSequenceNum(int64_t sequenceNum) {
+    raw->sequenceNum = sequenceNum;
+    return *this;
+}
+
 }  // namespace dai

--- a/src/pipeline/datatype/ImgDetections.cpp
+++ b/src/pipeline/datatype/ImgDetections.cpp
@@ -13,36 +13,14 @@ ImgDetections::ImgDetections(std::shared_ptr<RawImgDetections> ptr)
 // setters
 ImgDetections& ImgDetections::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    dets.ts.sec = duration_cast<seconds>(ts).count();
-    dets.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<ImgDetections&>(Buffer::setTimestamp(tp));
 }
 ImgDetections& ImgDetections::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    dets.tsDevice.sec = duration_cast<seconds>(ts).count();
-    dets.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<ImgDetections&>(Buffer::setTimestampDevice(tp));
 }
 ImgDetections& ImgDetections::setSequenceNum(int64_t sequenceNum) {
-    dets.sequenceNum = sequenceNum;
-    return *this;
-}
-
-// getters
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgDetections::getTimestamp() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(dets.ts.sec) + nanoseconds(dets.ts.nsec)};
-}
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgDetections::getTimestampDevice() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(dets.tsDevice.sec) + nanoseconds(dets.tsDevice.nsec)};
-}
-int64_t ImgDetections::getSequenceNum() const {
-    return dets.sequenceNum;
+    return static_cast<ImgDetections&>(Buffer::setSequenceNum(sequenceNum));
 }
 
 }  // namespace dai

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -31,7 +31,7 @@ std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::du
     }
 }
 std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestampDevice(CameraExposureOffset offset) const {
-    auto ts = getTimestamp();
+    auto ts = getTimestampDevice();
     auto expTime = getExposureTime();
     switch(offset) {
         case CameraExposureOffset::START:

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -17,14 +17,6 @@ ImgFrame::ImgFrame(std::shared_ptr<RawImgFrame> ptr) : Buffer(std::move(ptr)), i
 // helpers
 
 // getters
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestamp() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(img.ts.sec) + nanoseconds(img.ts.nsec)};
-}
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestampDevice() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(img.tsDevice.sec) + nanoseconds(img.tsDevice.nsec)};
-}
 std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestamp(CameraExposureOffset offset) const {
     auto ts = getTimestamp();
     auto expTime = getExposureTime();
@@ -39,7 +31,7 @@ std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::du
     }
 }
 std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> ImgFrame::getTimestampDevice(CameraExposureOffset offset) const {
-    auto ts = getTimestampDevice();
+    auto ts = getTimestamp();
     auto expTime = getExposureTime();
     switch(offset) {
         case CameraExposureOffset::START:
@@ -57,9 +49,6 @@ unsigned int ImgFrame::getInstanceNum() const {
 }
 unsigned int ImgFrame::getCategory() const {
     return img.category;
-}
-int64_t ImgFrame::getSequenceNum() const {
-    return img.sequenceNum;
 }
 unsigned int ImgFrame::getWidth() const {
     return img.fb.width;
@@ -86,19 +75,11 @@ int ImgFrame::getLensPosition() const {
 // setters
 ImgFrame& ImgFrame::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    img.ts.sec = duration_cast<seconds>(ts).count();
-    img.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<ImgFrame&>(Buffer::setTimestamp(tp));
 }
 ImgFrame& ImgFrame::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    img.tsDevice.sec = duration_cast<seconds>(ts).count();
-    img.tsDevice.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<ImgFrame&>(Buffer::setTimestampDevice(tp));
 }
 ImgFrame& ImgFrame::setInstanceNum(unsigned int instanceNum) {
     img.instanceNum = instanceNum;
@@ -109,8 +90,7 @@ ImgFrame& ImgFrame::setCategory(unsigned int category) {
     return *this;
 }
 ImgFrame& ImgFrame::setSequenceNum(int64_t sequenceNum) {
-    img.sequenceNum = sequenceNum;
-    return *this;
+    return static_cast<ImgFrame&>(Buffer::setSequenceNum(sequenceNum));
 }
 ImgFrame& ImgFrame::setWidth(unsigned int width) {
     img.fb.width = width;

--- a/src/pipeline/datatype/NNData.cpp
+++ b/src/pipeline/datatype/NNData.cpp
@@ -269,39 +269,17 @@ std::vector<std::int32_t> NNData::getFirstLayerInt32() const {
     return {};
 }
 
-// getters
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> NNData::getTimestamp() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawNn.ts.sec) + nanoseconds(rawNn.ts.nsec)};
-}
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> NNData::getTimestampDevice() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawNn.tsDevice.sec) + nanoseconds(rawNn.tsDevice.nsec)};
-}
-int64_t NNData::getSequenceNum() const {
-    return rawNn.sequenceNum;
-}
-
 // setters
 NNData& NNData::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawNn.ts.sec = duration_cast<seconds>(ts).count();
-    rawNn.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<NNData&>(Buffer::setTimestamp(tp));
 }
 NNData& NNData::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawNn.tsDevice.sec = duration_cast<seconds>(ts).count();
-    rawNn.tsDevice.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<NNData&>(Buffer::setTimestampDevice(tp));
 }
 NNData& NNData::setSequenceNum(int64_t sequenceNum) {
-    rawNn.sequenceNum = sequenceNum;
-    return *this;
+    return static_cast<NNData&>(Buffer::setSequenceNum(sequenceNum));
 }
 
 }  // namespace dai

--- a/src/pipeline/datatype/NNData.cpp
+++ b/src/pipeline/datatype/NNData.cpp
@@ -296,7 +296,7 @@ NNData& NNData::setTimestampDevice(std::chrono::time_point<std::chrono::steady_c
     using namespace std::chrono;
     auto ts = tp.time_since_epoch();
     rawNn.tsDevice.sec = duration_cast<seconds>(ts).count();
-    rawNn.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
+    rawNn.tsDevice.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
     return *this;
 }
 NNData& NNData::setSequenceNum(int64_t sequenceNum) {

--- a/src/pipeline/datatype/SpatialImgDetections.cpp
+++ b/src/pipeline/datatype/SpatialImgDetections.cpp
@@ -14,36 +14,14 @@ SpatialImgDetections::SpatialImgDetections(std::shared_ptr<RawSpatialImgDetectio
 // setters
 SpatialImgDetections& SpatialImgDetections::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    dets.ts.sec = duration_cast<seconds>(ts).count();
-    dets.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<SpatialImgDetections&>(Buffer::setTimestamp(tp));
 }
 SpatialImgDetections& SpatialImgDetections::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    dets.tsDevice.sec = duration_cast<seconds>(ts).count();
-    dets.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<SpatialImgDetections&>(Buffer::setTimestampDevice(tp));
 }
 SpatialImgDetections& SpatialImgDetections::setSequenceNum(int64_t sequenceNum) {
-    dets.sequenceNum = sequenceNum;
-    return *this;
-}
-
-// getters
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> SpatialImgDetections::getTimestamp() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(dets.ts.sec) + nanoseconds(dets.ts.nsec)};
-}
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> SpatialImgDetections::getTimestampDevice() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(dets.tsDevice.sec) + nanoseconds(dets.tsDevice.nsec)};
-}
-int64_t SpatialImgDetections::getSequenceNum() const {
-    return dets.sequenceNum;
+    return static_cast<SpatialImgDetections&>(Buffer::setSequenceNum(sequenceNum));
 }
 
 }  // namespace dai

--- a/src/pipeline/datatype/SpatialLocationCalculatorData.cpp
+++ b/src/pipeline/datatype/SpatialLocationCalculatorData.cpp
@@ -15,41 +15,19 @@ std::vector<SpatialLocations>& SpatialLocationCalculatorData::getSpatialLocation
     return rawdata.spatialLocations;
 }
 
-// getters
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> SpatialLocationCalculatorData::getTimestamp() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawdata.ts.sec) + nanoseconds(rawdata.ts.nsec)};
-}
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> SpatialLocationCalculatorData::getTimestampDevice() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawdata.tsDevice.sec) + nanoseconds(rawdata.tsDevice.nsec)};
-}
-int64_t SpatialLocationCalculatorData::getSequenceNum() const {
-    return rawdata.sequenceNum;
-}
-
 // setters
 SpatialLocationCalculatorData& SpatialLocationCalculatorData::setTimestamp(
     std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawdata.ts.sec = duration_cast<seconds>(ts).count();
-    rawdata.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<SpatialLocationCalculatorData&>(Buffer::setTimestamp(tp));
 }
 SpatialLocationCalculatorData& SpatialLocationCalculatorData::setTimestampDevice(
     std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawdata.tsDevice.sec = duration_cast<seconds>(ts).count();
-    rawdata.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<SpatialLocationCalculatorData&>(Buffer::setTimestampDevice(tp));
 }
 SpatialLocationCalculatorData& SpatialLocationCalculatorData::setSequenceNum(int64_t sequenceNum) {
-    rawdata.sequenceNum = sequenceNum;
-    return *this;
+    return static_cast<SpatialLocationCalculatorData&>(Buffer::setSequenceNum(sequenceNum));
 }
 
 }  // namespace dai

--- a/src/pipeline/datatype/StreamMessageParser.cpp
+++ b/src/pipeline/datatype/StreamMessageParser.cpp
@@ -114,13 +114,9 @@ std::shared_ptr<RawBuffer> StreamMessageParser::parseMessage(streamPacketDesc_t*
 
     // Create corresponding object
     switch(objectType) {
-        // RawBuffer is special case, no metadata is actually serialized
-        case DatatypeEnum::Buffer: {
-            // RawBuffer is special case, no metadata is actually serialized
-            auto pBuf = std::make_shared<RawBuffer>();
-            pBuf->data = std::move(data);
-            return pBuf;
-        } break;
+        case DatatypeEnum::Buffer:
+            return parseDatatype<RawBuffer>(metadataStart, serializedObjectSize, data);
+            break;
 
         case DatatypeEnum::ImgFrame:
             return parseDatatype<RawImgFrame>(metadataStart, serializedObjectSize, data);

--- a/src/pipeline/datatype/StreamMessageParser.cpp
+++ b/src/pipeline/datatype/StreamMessageParser.cpp
@@ -206,10 +206,7 @@ std::shared_ptr<ADatatype> StreamMessageParser::parseMessageToADatatype(streamPa
 
     switch(objectType) {
         case DatatypeEnum::Buffer: {
-            // RawBuffer is special case, no metadata is actually serialized
-            auto pBuf = std::make_shared<RawBuffer>();
-            pBuf->data = std::move(data);
-            return std::make_shared<Buffer>(pBuf);
+            return std::make_shared<Buffer>(parseDatatype<RawBuffer>(metadataStart, serializedObjectSize, data));
         } break;
 
         case DatatypeEnum::ImgFrame:

--- a/src/pipeline/datatype/TrackedFeatures.cpp
+++ b/src/pipeline/datatype/TrackedFeatures.cpp
@@ -11,39 +11,17 @@ TrackedFeatures::TrackedFeatures()
 TrackedFeatures::TrackedFeatures(std::shared_ptr<RawTrackedFeatures> ptr)
     : Buffer(std::move(ptr)), rawdata(*dynamic_cast<RawTrackedFeatures*>(raw.get())), trackedFeatures(rawdata.trackedFeatures) {}
 
-// getters
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> TrackedFeatures::getTimestamp() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawdata.ts.sec) + nanoseconds(rawdata.ts.nsec)};
-}
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> TrackedFeatures::getTimestampDevice() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawdata.tsDevice.sec) + nanoseconds(rawdata.tsDevice.nsec)};
-}
-int64_t TrackedFeatures::getSequenceNum() const {
-    return rawdata.sequenceNum;
-}
-
 // setters
 TrackedFeatures& TrackedFeatures::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawdata.ts.sec = duration_cast<seconds>(ts).count();
-    rawdata.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<TrackedFeatures&>(Buffer::setTimestamp(tp));
 }
 TrackedFeatures& TrackedFeatures::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawdata.tsDevice.sec = duration_cast<seconds>(ts).count();
-    rawdata.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<TrackedFeatures&>(Buffer::setTimestampDevice(tp));
 }
 TrackedFeatures& TrackedFeatures::setSequenceNum(int64_t sequenceNum) {
-    rawdata.sequenceNum = sequenceNum;
-    return *this;
+    return static_cast<TrackedFeatures&>(Buffer::setSequenceNum(sequenceNum));
 }
 
 }  // namespace dai

--- a/src/pipeline/datatype/Tracklets.cpp
+++ b/src/pipeline/datatype/Tracklets.cpp
@@ -10,39 +10,17 @@ Tracklets::Tracklets() : Buffer(std::make_shared<RawTracklets>()), rawdata(*dyna
 Tracklets::Tracklets(std::shared_ptr<RawTracklets> ptr)
     : Buffer(std::move(ptr)), rawdata(*dynamic_cast<RawTracklets*>(raw.get())), tracklets(rawdata.tracklets) {}
 
-// getters
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> Tracklets::getTimestamp() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawdata.ts.sec) + nanoseconds(rawdata.ts.nsec)};
-}
-std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> Tracklets::getTimestampDevice() const {
-    using namespace std::chrono;
-    return time_point<steady_clock, steady_clock::duration>{seconds(rawdata.tsDevice.sec) + nanoseconds(rawdata.tsDevice.nsec)};
-}
-int64_t Tracklets::getSequenceNum() const {
-    return rawdata.sequenceNum;
-}
-
 // setters
 Tracklets& Tracklets::setTimestamp(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawdata.ts.sec = duration_cast<seconds>(ts).count();
-    rawdata.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<Tracklets&>(Buffer::setTimestamp(tp));
 }
 Tracklets& Tracklets::setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> tp) {
     // Set timestamp from timepoint
-    using namespace std::chrono;
-    auto ts = tp.time_since_epoch();
-    rawdata.tsDevice.sec = duration_cast<seconds>(ts).count();
-    rawdata.ts.nsec = duration_cast<nanoseconds>(ts).count() % 1000000000;
-    return *this;
+    return static_cast<Tracklets&>(Buffer::setTimestampDevice(tp));
 }
 Tracklets& Tracklets::setSequenceNum(int64_t sequenceNum) {
-    rawdata.sequenceNum = sequenceNum;
-    return *this;
+    return static_cast<Tracklets&>(Buffer::setSequenceNum(sequenceNum));
 }
 
 }  // namespace dai


### PR DESCRIPTION
Getters and setters for moved parameters in depthai-shared and changed (de)serialization. Depends on [depthai-shared](https://github.com/luxonis/depthai-shared/pull/147) MR.