### PR TITLE
Timesync optimization

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "ef924fe490d6608fd624e89a7bf3f47e6fcb0b89")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "16bb073ae70ad6d79e8e0e319587155a2a75be53")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -54,8 +54,8 @@ class XLinkStream {
     void write(const void* data, std::size_t size);
     void write(const std::uint8_t* data, std::size_t size);
     void write(const std::vector<std::uint8_t>& data);
-    std::vector<std::uint8_t> read();
-    void read(std::vector<std::uint8_t>& data);
+    std::vector<std::uint8_t> read(struct timespec* out_time = NULL);
+    void read(std::vector<std::uint8_t>& data, struct timespec* out_time = NULL);
     // split write helper
     void writeSplit(const void* data, std::size_t size, std::size_t split);
     void writeSplit(const std::vector<uint8_t>& data, std::size_t split);

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -54,8 +54,8 @@ class XLinkStream {
     void write(const void* data, std::size_t size);
     void write(const std::uint8_t* data, std::size_t size);
     void write(const std::vector<std::uint8_t>& data);
-    std::vector<std::uint8_t> read();
-    void read(std::vector<std::uint8_t>& data);
+    std::vector<std::uint8_t> read(struct timespec* out_time=NULL);
+    void read(std::vector<std::uint8_t>& data, struct timespec* out_time=NULL);
     // split write helper
     void writeSplit(const void* data, std::size_t size, std::size_t split);
     void writeSplit(const std::vector<uint8_t>& data, std::size_t split);

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -25,7 +25,7 @@ namespace dai {
 
 class StreamPacketDesc : public streamPacketDesc_t {
    public:
-    StreamPacketDesc() noexcept : streamPacketDesc_t{nullptr, 0} {};
+    StreamPacketDesc() noexcept : streamPacketDesc_t{nullptr, 0, {}, {}} {};
     StreamPacketDesc(const StreamPacketDesc&) = delete;
     StreamPacketDesc(StreamPacketDesc&& other) noexcept;
     StreamPacketDesc& operator=(const StreamPacketDesc&) = delete;
@@ -54,8 +54,8 @@ class XLinkStream {
     void write(const void* data, std::size_t size);
     void write(const std::uint8_t* data, std::size_t size);
     void write(const std::vector<std::uint8_t>& data);
-    std::vector<std::uint8_t> read(struct timespec* out_time = NULL);
-    void read(std::vector<std::uint8_t>& data, struct timespec* out_time = NULL);
+    std::vector<std::uint8_t> read();
+    void read(std::vector<std::uint8_t>& data);
     // split write helper
     void writeSplit(const void* data, std::size_t size, std::size_t split);
     void writeSplit(const std::vector<uint8_t>& data, std::size_t split);

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -54,8 +54,10 @@ class XLinkStream {
     void write(const void* data, std::size_t size);
     void write(const std::uint8_t* data, std::size_t size);
     void write(const std::vector<std::uint8_t>& data);
-    std::vector<std::uint8_t> read(struct timespec* out_time=NULL);
-    void read(std::vector<std::uint8_t>& data, struct timespec* out_time=NULL);
+    std::vector<std::uint8_t> read();
+    std::vector<std::uint8_t> read(struct timespec& timestampReceived);
+    void read(std::vector<std::uint8_t>& data);
+    void read(std::vector<std::uint8_t>& data, struct timespec& timestampReceived);
     // split write helper
     void writeSplit(const void* data, std::size_t size, std::size_t split);
     void writeSplit(const std::vector<uint8_t>& data, std::size_t split);

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -17,6 +17,7 @@
 
 // libraries
 #include <XLink/XLinkPublicDefines.h>
+#include <XLink/XLinkTime.h>
 
 // project
 #include "depthai/xlink/XLinkConnection.hpp"
@@ -55,9 +56,9 @@ class XLinkStream {
     void write(const std::uint8_t* data, std::size_t size);
     void write(const std::vector<std::uint8_t>& data);
     std::vector<std::uint8_t> read();
-    std::vector<std::uint8_t> read(struct timespec& timestampReceived);
+    std::vector<std::uint8_t> read(XLinkTimespec& timestampReceived);
     void read(std::vector<std::uint8_t>& data);
-    void read(std::vector<std::uint8_t>& data, struct timespec& timestampReceived);
+    void read(std::vector<std::uint8_t>& data, XLinkTimespec& timestampReceived);
     // split write helper
     void writeSplit(const void* data, std::size_t size, std::size_t split);
     void writeSplit(const std::vector<uint8_t>& data, std::size_t split);

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -846,7 +846,7 @@ void DeviceBase::init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<co
             while(timesyncRunning) {
                 // Block
                 struct timespec timestamp;
-                stream.read(timestamp);              
+                stream.read(timestamp);
 
                 // Write timestamp back
                 stream.write(&timestamp, sizeof(timestamp));

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -28,6 +28,7 @@
 
 // libraries
 #include "XLink/XLink.h"
+#include "XLink/XLinkTime.h"
 #include "nanorpc/core/client.h"
 #include "nanorpc/packer/nlohmann_msgpack.h"
 #include "spdlog/details/os.h"
@@ -845,8 +846,7 @@ void DeviceBase::init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<co
             XLinkStream stream(connection, device::XLINK_CHANNEL_TIMESYNC, 128);
             while(timesyncRunning) {
                 // Block
-                // FIXME: RPI has timespec size of 8 bytes - mismatch on device
-                struct timespec timestamp;
+                XLinkTimespec timestamp;
                 stream.read(timestamp);
 
                 // Write timestamp back

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -846,11 +846,15 @@ void DeviceBase::init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<co
             Timestamp timestamp = {};
             while(timesyncRunning) {
                 // Block
-                struct timespec treceive;
-                stream.read(&treceive);
+                stream.read();
+                
+                // Timestamp
+                auto d = std::chrono::steady_clock::now().time_since_epoch();
+                timestamp.sec = duration_cast<seconds>(d).count();
+                timestamp.nsec = duration_cast<nanoseconds>(d).count() % 1000000000;                
 
                 // Write timestamp back
-                stream.write(&treceive, sizeof(timestamp));
+                stream.write(&timestamp, sizeof(timestamp));
             }
         } catch(const std::exception& ex) {
             // ignore

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -845,6 +845,7 @@ void DeviceBase::init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<co
             XLinkStream stream(connection, device::XLINK_CHANNEL_TIMESYNC, 128);
             while(timesyncRunning) {
                 // Block
+                // FIXME: RPI has timespec size of 8 bytes - mismatch on device
                 struct timespec timestamp;
                 stream.read(timestamp);
 

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -843,15 +843,10 @@ void DeviceBase::init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<co
 
         try {
             XLinkStream stream(connection, device::XLINK_CHANNEL_TIMESYNC, 128);
-            Timestamp timestamp = {};
             while(timesyncRunning) {
                 // Block
-                stream.read();
-                
-                // Timestamp
-                auto d = std::chrono::steady_clock::now().time_since_epoch();
-                timestamp.sec = duration_cast<seconds>(d).count();
-                timestamp.nsec = duration_cast<nanoseconds>(d).count() % 1000000000;                
+                struct timespec timestamp;
+                stream.read(&timestamp);              
 
                 // Write timestamp back
                 stream.write(&timestamp, sizeof(timestamp));

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -846,7 +846,7 @@ void DeviceBase::init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<co
             while(timesyncRunning) {
                 // Block
                 struct timespec timestamp;
-                stream.read(&timestamp);              
+                stream.read(timestamp);              
 
                 // Write timestamp back
                 stream.write(&timestamp, sizeof(timestamp));

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -846,15 +846,11 @@ void DeviceBase::init2(Config cfg, const dai::Path& pathToMvcmd, tl::optional<co
             Timestamp timestamp = {};
             while(timesyncRunning) {
                 // Block
-                stream.read();
-
-                // Timestamp
-                auto d = std::chrono::steady_clock::now().time_since_epoch();
-                timestamp.sec = duration_cast<seconds>(d).count();
-                timestamp.nsec = duration_cast<nanoseconds>(d).count() % 1000000000;
+                struct timespec treceive;
+                stream.read(&treceive);
 
                 // Write timestamp back
-                stream.write(&timestamp, sizeof(timestamp));
+                stream.write(&treceive, sizeof(timestamp));
             }
         } catch(const std::exception& ex) {
             // ignore

--- a/src/openvino/BlobReader.cpp
+++ b/src/openvino/BlobReader.cpp
@@ -18,7 +18,7 @@
 #include "BlobFormat.hpp"
 
 // TODO(themarpe)
-//#include <vpu/model/data.hpp>
+// #include <vpu/model/data.hpp>
 
 namespace dai {
 

--- a/src/utility/Path.cpp
+++ b/src/utility/Path.cpp
@@ -10,13 +10,13 @@
 
 namespace dai {
 std::wstring Path::convert_utf8_to_wide(const std::string& utf8string) {
-    //#pragma warning(suppress : 4996)
+    // #pragma warning(suppress : 4996)
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
     return converter.from_bytes(utf8string);
 }
 
 std::string Path::u8string() const {
-    //#pragma warning(suppress : 4996)
+    // #pragma warning(suppress : 4996)
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
     return converter.to_bytes(_nativePath);
 }

--- a/src/xlink/XLinkStream.cpp
+++ b/src/xlink/XLinkStream.cpp
@@ -100,7 +100,7 @@ void XLinkStream::read(std::vector<std::uint8_t>& data) {
     data = std::vector<std::uint8_t>(packet.data, packet.data + packet.length);
 }
 
-void XLinkStream::read(std::vector<std::uint8_t>& data, struct timespec& timestampReceived) {
+void XLinkStream::read(std::vector<std::uint8_t>& data, XLinkTimespec& timestampReceived) {
     StreamPacketDesc packet;
     const auto status = XLinkReadMoveData(streamId, &packet);
     if(status != X_LINK_SUCCESS) {
@@ -116,7 +116,7 @@ std::vector<std::uint8_t> XLinkStream::read() {
     return data;
 }
 
-std::vector<std::uint8_t> XLinkStream::read(struct timespec& timestampReceived) {
+std::vector<std::uint8_t> XLinkStream::read(XLinkTimespec& timestampReceived) {
     std::vector<std::uint8_t> data;
     read(data, timestampReceived);
     return data;

--- a/src/xlink/XLinkStream.cpp
+++ b/src/xlink/XLinkStream.cpp
@@ -54,7 +54,7 @@ XLinkStream::~XLinkStream() {
     }
 }
 
-StreamPacketDesc::StreamPacketDesc(StreamPacketDesc&& other) noexcept : streamPacketDesc_t{other.data, other.length} {
+StreamPacketDesc::StreamPacketDesc(StreamPacketDesc&& other) noexcept : streamPacketDesc_t{other.data, other.length, {}, {}} {
     other.data = nullptr;
     other.length = 0;
 }
@@ -89,18 +89,18 @@ void XLinkStream::write(const std::vector<std::uint8_t>& data) {
     write(data.data(), data.size());
 }
 
-void XLinkStream::read(std::vector<std::uint8_t>& data, struct timespec* out_time) {
+void XLinkStream::read(std::vector<std::uint8_t>& data) {
     StreamPacketDesc packet;
-    const auto status = XLinkReadMoveDataWithTime(streamId, &packet, out_time);
+    const auto status = XLinkReadMoveData(streamId, &packet);
     if(status != X_LINK_SUCCESS) {
         throw XLinkReadError(status, streamName);
     }
     data = std::vector<std::uint8_t>(packet.data, packet.data + packet.length);
 }
 
-std::vector<std::uint8_t> XLinkStream::read(struct timespec* out_time) {
+std::vector<std::uint8_t> XLinkStream::read() {
     std::vector<std::uint8_t> data;
-    read(data, out_time);
+    read(data);
     return data;
 }
 

--- a/src/xlink/XLinkStream.cpp
+++ b/src/xlink/XLinkStream.cpp
@@ -89,18 +89,18 @@ void XLinkStream::write(const std::vector<std::uint8_t>& data) {
     write(data.data(), data.size());
 }
 
-void XLinkStream::read(std::vector<std::uint8_t>& data) {
+void XLinkStream::read(std::vector<std::uint8_t>& data, struct timespec* out_time) {
     StreamPacketDesc packet;
-    const auto status = XLinkReadMoveData(streamId, &packet);
+    const auto status = XLinkReadMoveDataWithTime(streamId, &packet, out_time);
     if(status != X_LINK_SUCCESS) {
         throw XLinkReadError(status, streamName);
     }
     data = std::vector<std::uint8_t>(packet.data, packet.data + packet.length);
 }
 
-std::vector<std::uint8_t> XLinkStream::read() {
+std::vector<std::uint8_t> XLinkStream::read(struct timespec* out_time) {
     std::vector<std::uint8_t> data;
-    read(data);
+    read(data, out_time);
     return data;
 }
 

--- a/src/xlink/XLinkStream.cpp
+++ b/src/xlink/XLinkStream.cpp
@@ -54,7 +54,7 @@ XLinkStream::~XLinkStream() {
     }
 }
 
-StreamPacketDesc::StreamPacketDesc(StreamPacketDesc&& other) noexcept : streamPacketDesc_t{other.data, other.length, other.trsend, other.treceive} {
+StreamPacketDesc::StreamPacketDesc(StreamPacketDesc&& other) noexcept : streamPacketDesc_t{other.data, other.length, other.tRemoteSent, other.tReceived} {
     other.data = nullptr;
     other.length = 0;
 }
@@ -63,8 +63,8 @@ StreamPacketDesc& StreamPacketDesc::operator=(StreamPacketDesc&& other) noexcept
     if(this != &other) {
         data = std::exchange(other.data, nullptr);
         length = std::exchange(other.length, 0);
-        trsend = std::exchange(other.trsend, {});
-        treceive = std::exchange(other.treceive, {});
+        tRemoteSent = std::exchange(other.tRemoteSent, {});
+        tReceived = std::exchange(other.tReceived, {});
     }
     return *this;
 }
@@ -91,20 +91,34 @@ void XLinkStream::write(const std::vector<std::uint8_t>& data) {
     write(data.data(), data.size());
 }
 
-void XLinkStream::read(std::vector<std::uint8_t>& data, struct timespec* out_time) {
+void XLinkStream::read(std::vector<std::uint8_t>& data) {
     StreamPacketDesc packet;
     const auto status = XLinkReadMoveData(streamId, &packet);
     if(status != X_LINK_SUCCESS) {
         throw XLinkReadError(status, streamName);
     }
     data = std::vector<std::uint8_t>(packet.data, packet.data + packet.length);
-    if(out_time != NULL)
-        *out_time = packet.treceive;
 }
 
-std::vector<std::uint8_t> XLinkStream::read(struct timespec* out_time) {
+void XLinkStream::read(std::vector<std::uint8_t>& data, struct timespec& timestampReceived) {
+    StreamPacketDesc packet;
+    const auto status = XLinkReadMoveData(streamId, &packet);
+    if(status != X_LINK_SUCCESS) {
+        throw XLinkReadError(status, streamName);
+    }
+    data = std::vector<std::uint8_t>(packet.data, packet.data + packet.length);
+    timestampReceived = packet.tReceived;
+}
+
+std::vector<std::uint8_t> XLinkStream::read() {
     std::vector<std::uint8_t> data;
-    read(data, out_time);
+    read(data);
+    return data;
+}
+
+std::vector<std::uint8_t> XLinkStream::read(struct timespec& timestampReceived) {
+    std::vector<std::uint8_t> data;
+    read(data, timestampReceived);
     return data;
 }
 


### PR DESCRIPTION
Changed timesync to only take into account the time between send and remote receive + remote send and receive as the RTT.
Moved the receive timestamp to XLink - get data to write back through the stream packet.