### PR TITLE
Fixed setWarpTransformFourPoints() unexpected behaviour #882

### DIFF
--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -48,6 +48,7 @@ ImageManipConfig& ImageManipConfig::setCropRotatedRect(RotatedRect rr, bool norm
 ImageManipConfig& ImageManipConfig::setWarpTransformFourPoints(std::vector<Point2f> pt, bool normalizedCoords) {
     // Enable resize stage and extended flags
     cfg.enableResize = true;
+    cfg.resizeConfig.keepAspectRatio = false;
     cfg.resizeConfig.enableWarp4pt = true;
     cfg.resizeConfig.warpFourPoints = pt;
     cfg.resizeConfig.normalizedCoords = normalizedCoords;


### PR DESCRIPTION
Using setWarpTransformFourPoints() left `keepAspectRatio` on `true` which caused unexpected behaviour in some cases.