### PR TITLE
IR Intensity API

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "1cf15832ab1f408d8e4dab72e901ce050bf8850b")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "3bba9ec3238bfb254174402253c0ecbe7dd9a71a")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "e22e0a628020d5e90c50751d51f2a27c36ecf1ef")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a240c28eb1001654f6c9413c268bf0bfd560efbb")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "76ff45773ebf994abbdb42e78ab1cfe08ac73d58")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "e22e0a628020d5e90c50751d51f2a27c36ecf1ef")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "3bba9ec3238bfb254174402253c0ecbe7dd9a71a")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "76ff45773ebf994abbdb42e78ab1cfe08ac73d58")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a240c28eb1001654f6c9413c268bf0bfd560efbb")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "9f8bc9fe677b7a1fce27f78448fe348ce6e122e0")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/examples/SpatialDetection/spatial_calculator_multi_roi.cpp
+++ b/examples/SpatialDetection/spatial_calculator_multi_roi.cpp
@@ -61,7 +61,7 @@ int main() {
 
     // Connect to device and start pipeline
     dai::Device device(pipeline);
-    device.setIrLaserDotProjectorBrightness(0.7f);
+    device.setIrLaserDotProjectorIntensity(0.7f);
 
     // Output queue will be used to get the depth frames from the outputs defined above
     auto depthQueue = device.getOutputQueue("depth", 4, false);

--- a/examples/SpatialDetection/spatial_calculator_multi_roi.cpp
+++ b/examples/SpatialDetection/spatial_calculator_multi_roi.cpp
@@ -61,7 +61,7 @@ int main() {
 
     // Connect to device and start pipeline
     dai::Device device(pipeline);
-    device.setIrLaserDotProjectorBrightness(1000);
+    device.setIrLaserDotProjectorBrightness(0.7f);
 
     // Output queue will be used to get the depth frames from the outputs defined above
     auto depthQueue = device.getOutputQueue("depth", 4, false);

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -508,8 +508,8 @@ class DeviceBase {
     bool setIrFloodLightBrightness(float mA, int mask = -1);
 
     /**
-     * Sets the brightness of the IR Laser Dot Projector. Limits: up to 765mA at 30% frame time duty cycle when exposure time is longer than 30% frame time.
-     * Otherwise, duty cycle is 100% of exposure time, with increased current 765mA + linearly interpolated based on difference between 30% frame time and exposure time. 
+     * Sets the intensity of the IR Laser Dot Projector. Limits: up to 765mA at 30% frame time duty cycle when exposure time is longer than 30% frame time.
+     * Otherwise, duty cycle is 100% of exposure time, with current increased up to max 1200mA to make up for shorter duty cycle.
      * The duty cycle is controlled by `left` camera STROBE, aligned to start of exposure.
      * The emitter is turned off by default
      *
@@ -520,7 +520,7 @@ class DeviceBase {
     bool setIrLaserDotProjectorIntensity(float intensity, int mask = -1);
 
     /**
-     * Sets the brightness of the IR Flood Light. Limits: Intensity is directly normalized to 0 - 1500mA current.
+     * Sets the intensity of the IR Flood Light. Limits: Intensity is directly normalized to 0 - 1500mA current.
      * The duty cycle is 30% when exposure time is longer than 30% frame time. Otherwise, duty cycle is 100% of exposure time.
      * The duty cycle is controlled by the `left` camera STROBE, aligned to start of exposure.
      * The emitter is turned off by default

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -485,27 +485,28 @@ class DeviceBase {
     LogLevel getLogOutputLevel();
 
     /**
-     * Sets the brightness of the IR Laser Dot Projector. Limits: up to 765mA at 30% duty cycle, up to 1200mA at 6% duty cycle.
+     * Sets the brightness of the IR Laser Dot Projector. Limits: up to 765mA at 30% frame time duty cycle when exposure time is longer than 30% frame time.
+     * Otherwise, duty cycle is 100% of exposure time, with increased current 765mA + linearly interpolated based on difference between 30% frame time and exposure time. 
      * The duty cycle is controlled by `left` camera STROBE, aligned to start of exposure.
      * The emitter is turned off by default
      *
-     * @param mA Current in mA that will determine brightness, 0 or negative to turn off
+     * @param intensity Intensity on range 0 to 1, that will determine brightness. 0 or negative to turn off
      * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV
      * @returns True on success, false if not found or other failure
      */
-    bool setIrLaserDotProjectorBrightness(float mA, int mask = -1);
+    bool setIrLaserDotProjectorBrightness(float intensity, int mask = -1);
 
     /**
-     * Sets the brightness of the IR Flood Light. Limits: up to 1500mA at 30% duty cycle.
+     * Sets the brightness of the IR Flood Light. Limits: Intensity is directly normalized to 0 - 1500mA current.
+     * The duty cycle is 30% when exposure time is longer than 30% frame time. Otherwise, duty cycle is 100% of exposure time.
      * The duty cycle is controlled by the `left` camera STROBE, aligned to start of exposure.
-     * If the dot projector is also enabled, its lower duty cycle limits take precedence.
      * The emitter is turned off by default
      *
-     * @param mA Current in mA that will determine brightness, 0 or negative to turn off
+     * @param intensity Intensity on range 0 to 1, that will determine brightness, 0 or negative to turn off
      * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV
      * @returns True on success, false if not found or other failure
      */
-    bool setIrFloodLightBrightness(float mA, int mask = -1);
+    bool setIrFloodLightBrightness(float intensity, int mask = -1);
 
     /**
      * Retrieves detected IR laser/LED drivers.

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -485,6 +485,29 @@ class DeviceBase {
     LogLevel getLogOutputLevel();
 
     /**
+     * Sets the brightness of the IR Laser Dot Projector. Limits: up to 765mA at 30% duty cycle, up to 1200mA at 6% duty cycle.
+     * The duty cycle is controlled by `left` camera STROBE, aligned to start of exposure.
+     * The emitter is turned off by default
+     *
+     * @param mA Current in mA that will determine brightness, 0 or negative to turn off
+     * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV
+     * @returns True on success, false if not found or other failure
+     */
+    bool setIrLaserDotProjectorBrightness(float mA, int mask = -1);
+
+    /**
+     * Sets the brightness of the IR Flood Light. Limits: up to 1500mA at 30% duty cycle.
+     * The duty cycle is controlled by the `left` camera STROBE, aligned to start of exposure.
+     * If the dot projector is also enabled, its lower duty cycle limits take precedence.
+     * The emitter is turned off by default
+     *
+     * @param mA Current in mA that will determine brightness, 0 or negative to turn off
+     * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV
+     * @returns True on success, false if not found or other failure
+     */
+    bool setIrFloodLightBrightness(float mA, int mask = -1);
+
+    /**
      * Sets the brightness of the IR Laser Dot Projector. Limits: up to 765mA at 30% frame time duty cycle when exposure time is longer than 30% frame time.
      * Otherwise, duty cycle is 100% of exposure time, with increased current 765mA + linearly interpolated based on difference between 30% frame time and exposure time. 
      * The duty cycle is controlled by `left` camera STROBE, aligned to start of exposure.
@@ -494,7 +517,7 @@ class DeviceBase {
      * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV
      * @returns True on success, false if not found or other failure
      */
-    bool setIrLaserDotProjectorBrightness(float intensity, int mask = -1);
+    bool setIrLaserDotProjectorIntensity(float intensity, int mask = -1);
 
     /**
      * Sets the brightness of the IR Flood Light. Limits: Intensity is directly normalized to 0 - 1500mA current.
@@ -506,7 +529,7 @@ class DeviceBase {
      * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV
      * @returns True on success, false if not found or other failure
      */
-    bool setIrFloodLightBrightness(float intensity, int mask = -1);
+    bool setIrFloodLightIntensity(float intensity, int mask = -1);
 
     /**
      * Retrieves detected IR laser/LED drivers.

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -493,7 +493,7 @@ class DeviceBase {
      * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV
      * @returns True on success, false if not found or other failure
      */
-    bool setIrLaserDotProjectorBrightness(float mA, int mask = -1);
+    [[deprecated("Use setIrLaserDotProjectorIntensity(float intensity) instead.")]] bool setIrLaserDotProjectorBrightness(float mA, int mask = -1);
 
     /**
      * Sets the brightness of the IR Flood Light. Limits: up to 1500mA at 30% duty cycle.
@@ -505,7 +505,7 @@ class DeviceBase {
      * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV
      * @returns True on success, false if not found or other failure
      */
-    bool setIrFloodLightBrightness(float mA, int mask = -1);
+    [[deprecated("Use setIrFloodLightIntensity(float intensity) instead.")]] bool setIrFloodLightBrightness(float mA, int mask = -1);
 
     /**
      * Sets the intensity of the IR Laser Dot Projector. Limits: up to 765mA at 30% frame time duty cycle when exposure time is longer than 30% frame time.

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1084,12 +1084,20 @@ LogLevel DeviceBase::getLogOutputLevel() {
     return pimpl->getLogLevel();
 }
 
-bool DeviceBase::setIrLaserDotProjectorBrightness(float intensity, int mask) {
-    return pimpl->rpcClient->call("setIrLaserDotProjectorBrightness", intensity, mask);
+bool DeviceBase::setIrLaserDotProjectorBrightness(float mA, int mask) {
+    return pimpl->rpcClient->call("setIrLaserDotProjectorBrightness", mA, mask, false);
 }
 
-bool DeviceBase::setIrFloodLightBrightness(float intensity, int mask) {
-    return pimpl->rpcClient->call("setIrFloodLightBrightness", intensity, mask);
+bool DeviceBase::setIrLaserDotProjectorIntensity(float intensity, int mask) {
+    return pimpl->rpcClient->call("setIrLaserDotProjectorBrightness", intensity, mask, true);
+}
+
+bool DeviceBase::setIrFloodLightBrightness(float mA, int mask) {
+    return pimpl->rpcClient->call("setIrFloodLightBrightness", mA, mask, false);
+}
+
+bool DeviceBase::setIrFloodLightIntensity(float intensity, int mask) {
+    return pimpl->rpcClient->call("setIrFloodLightBrightness", intensity, mask, true);
 }
 
 std::vector<std::tuple<std::string, int, int>> DeviceBase::getIrDrivers() {

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1084,12 +1084,12 @@ LogLevel DeviceBase::getLogOutputLevel() {
     return pimpl->getLogLevel();
 }
 
-bool DeviceBase::setIrLaserDotProjectorBrightness(float mA, int mask) {
-    return pimpl->rpcClient->call("setIrLaserDotProjectorBrightness", mA, mask);
+bool DeviceBase::setIrLaserDotProjectorBrightness(float intensity, int mask) {
+    return pimpl->rpcClient->call("setIrLaserDotProjectorBrightness", intensity, mask);
 }
 
-bool DeviceBase::setIrFloodLightBrightness(float mA, int mask) {
-    return pimpl->rpcClient->call("setIrFloodLightBrightness", mA, mask);
+bool DeviceBase::setIrFloodLightBrightness(float intensity, int mask) {
+    return pimpl->rpcClient->call("setIrFloodLightBrightness", intensity, mask);
 }
 
 std::vector<std::tuple<std::string, int, int>> DeviceBase::getIrDrivers() {


### PR DESCRIPTION
## Added ability to control IR brightness based on a normalized intensity instead of specifying the current.

Previous implementation of setting ir brightness was based on specifying the current in mA. After 765mA, the duty cycle was linearly interpolated from 30% to 6%, resulting in 765mA @ 30% duty cycle being the peak brightness, altho you could go up to 1200mA (for dot projector).
The new API takes a float on range [0, 1] as the ir (dot or flood) brightness and computes the dot proj. and flood light current, aswell as the duty cycle.

### Duty cycle and current calculations:
- Duty cycle = 30% when exposure time is longer than 30% of frame time.
  - In this case the dot current is computed as dotIntensity * 765 [mA]
- Duty cycle is 100% of exposure time, when exposure time is shorter than 30% of frame time.
  - In this case the dot current is dotIntensity * 765 [mA] + linear upto 1200mA in respect to the difference in (30%frame time - exposure time), to accommodate for the shorter duty cycle.
- Flood current is always computed as floodIntensity * 1500 [mA]

```
30 FPS, 30% duty cycle --> max 10ms from 33.3ms frame-time

frame-time |---------33.3ms---------|---------33.3ms---------|---------33.3ms---------|
exposure          <------20ms------>                <--10ms->                  <-8ms->
          _        _________                         ________                   ______
STROBE     |______|   10ms  |_______________________|  10ms  |_________________| 8ms  |
                                                                                 ^ Compensate with higher current
```
