### PR TITLE
[RVC2] getStereoPairs

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "5e397fa51910f1f5c282463643b6fc86bbec227d")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "6060b3504a75ded6806b14342ec94d31fd0fe6c1")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "8e44ce193c4c8d1666e1a0a08409c0015c2fc4c1")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "f089593893c1b1ccb29c99ccdc9a0e723db57a3b")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "a95f582a61ec9bdbd0f72dec84822455872ffaf7")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "6f4c58056952605eaed9e18bbaa3c939712cea2d")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "6f4c58056952605eaed9e18bbaa3c939712cea2d")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "5e397fa51910f1f5c282463643b6fc86bbec227d")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "6060b3504a75ded6806b14342ec94d31fd0fe6c1")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "8e44ce193c4c8d1666e1a0a08409c0015c2fc4c1")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/common/StereoPair.hpp
+++ b/include/depthai/common/StereoPair.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "depthai-shared/common/StereoPair.hpp"
+
+// Global namespace
+inline std::ostream& operator<<(std::ostream& out, const dai::StereoPair& pair) {
+    out << "{left: " << pair.left << ", ";
+    out << "right: " << pair.right << ", ";
+    out << "baseline: " << pair.baseline << ", ";
+    out << "isVertical: " << pair.isVertical << "}";
+    return out;
+}
+
+inline std::ostream& operator<<(std::ostream& out, const std::vector<dai::StereoPair>& pairs) {
+    out << "[";
+    for(size_t i = 0; i < pairs.size(); i++) {
+        if(i != 0) {
+            out << ", ";
+        }
+        out << pairs.at(i);
+    }
+    out << "]";
+
+    return out;
+}

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -31,6 +31,7 @@
 #include "depthai-shared/common/ConnectionInterface.hpp"
 #include "depthai-shared/common/CpuUsage.hpp"
 #include "depthai-shared/common/MemoryInfo.hpp"
+#include "depthai-shared/common/StereoPair.hpp"
 #include "depthai-shared/datatype/RawIMUData.hpp"
 #include "depthai-shared/device/BoardConfig.hpp"
 #include "depthai-shared/device/CrashDump.hpp"
@@ -609,6 +610,13 @@ class DeviceBase {
      * @returns Vector of connected camera features
      */
     std::vector<CameraFeatures> getConnectedCameraFeatures();
+
+    /**
+     * Get stereo pairs based on the device type.
+     * 
+     * @returns Vector of stereo pairs
+     */
+    std::vector<StereoPair> getStereoPairs();
 
     /**
      * Get sensor names for cameras that are connected to the device

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -613,7 +613,7 @@ class DeviceBase {
 
     /**
      * Get stereo pairs based on the device type.
-     * 
+     *
      * @returns Vector of stereo pairs
      */
     std::vector<StereoPair> getStereoPairs();

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -619,6 +619,15 @@ class DeviceBase {
     std::vector<StereoPair> getStereoPairs();
 
     /**
+     * Get stereo pairs taking into account the calibration and connected cameras.
+     * 
+     * @note This method will always return a subset of `getStereoPairs`.
+     *
+     * @returns Vector of stereo pairs
+     */
+    std::vector<StereoPair> getAvailableStereoPairs();
+
+    /**
      * Get sensor names for cameras that are connected to the device
      *
      * @returns Map/dictionary with camera sensor names, indexed by socket

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -620,7 +620,7 @@ class DeviceBase {
 
     /**
      * Get stereo pairs taking into account the calibration and connected cameras.
-     * 
+     *
      * @note This method will always return a subset of `getStereoPairs`.
      *
      * @returns Vector of stereo pairs

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1051,88 +1051,63 @@ std::vector<CameraBoardSocket> DeviceBase::getConnectedCameras() {
 
 std::vector<StereoPair> DeviceBase::getAvailableStereoPairs() {
     std::vector<dai::StereoPair> stereoPairs;
-    std::function<std::vector<dai::CameraBoardSocket>(dai::CameraBoardSocket, const std::unordered_map<dai::CameraBoardSocket, dai::CameraInfo>&, std::vector<dai::CameraBoardSocket>&)> visitLinks;
-    visitLinks = [&visitLinks](dai::CameraBoardSocket camId, const std::unordered_map<dai::CameraBoardSocket, dai::CameraInfo>& camData, std::vector<dai::CameraBoardSocket>& visited) -> std::vector<dai::CameraBoardSocket> {
-        if (camId == dai::CameraBoardSocket::AUTO) {
-            return visited;
-        }
-        visited.push_back(camId);
-        auto extrinsics = camData.at(camId).extrinsics;
-        auto toSocket = extrinsics.toCameraSocket;
-        return visitLinks(toSocket, camData, visited);
-    };
-
-    dai::EepromData eepromData;
+    dai::CalibrationHandler calibHandler;
     try {
-        auto calib = readCalibration2();
-        eepromData = calib.getEepromData();
-        if (eepromData.cameraData.empty()) {
+        calibHandler = readCalibration2();
+        if(calibHandler.getEepromData().cameraData.empty()) {
             throw std::runtime_error("No camera data found.");
         }
     } catch(const std::exception&) {
         try {
-            auto calib = readFactoryCalibration();
-            eepromData = calib.getEepromData();
+            calibHandler = readFactoryCalibration();
         } catch(const std::exception&) {
             pimpl->logger.info("No calibration found.");
             return stereoPairs;
         }
     }
-    // Step 1: Find the linked cameras
-    std::unordered_map<dai::CameraBoardSocket, std::vector<dai::CameraBoardSocket>> linkedCameras;
-    for (auto const& [cam, camInfo] : eepromData.cameraData) {
-        auto camId = cam;
-        auto extrinsics = camInfo.extrinsics;
-        auto toSocket = extrinsics.toCameraSocket;
-        std::vector<dai::CameraBoardSocket> visited;
-        linkedCameras[camId] = visitLinks(toSocket, eepromData.cameraData, visited);
-    }
-
-    // Step 2: Find stereo pairs, check if vertical or horizontal, and get baseline
-    for (auto const& [camId, linkedSockets] : linkedCameras) {
-        auto fromSocket = camId;
-        auto toSocket = eepromData.cameraData[fromSocket].extrinsics.toCameraSocket;
-        auto accBaselineX = 0.0f;
-        auto accBaselineY = 0.0f;
-        while (toSocket != dai::CameraBoardSocket::AUTO) {
-            auto extrinsics = eepromData.cameraData[fromSocket].extrinsics;
-            accBaselineX += extrinsics.translation.x;
-            accBaselineY = extrinsics.translation.y;
-            auto baseline = accBaselineX;
-            if (std::abs(accBaselineY) > std::abs(accBaselineX)) {
-                baseline = accBaselineY;
+    // Find links between cameras.
+    for(auto const& [camId1, _camInfo1] : calibHandler.getEepromData().cameraData) {
+        for(auto const& [camId2, _camInfo2] : calibHandler.getEepromData().cameraData) {
+            try {
+                auto translationVector = calibHandler.getCameraTranslationVector(camId1, camId2, false);
+                auto baseline = std::abs(translationVector[0]) > std::abs(translationVector[1]) ? translationVector[0] : translationVector[1];  // X or Y
+                auto leftSocket = baseline < 0 ? camId1 : camId2;
+                auto rightSocket = leftSocket == camId1 ? camId2 : camId1;
+                int baselineDiff = std::abs(static_cast<int>(translationVector[0]) - static_cast<int>(translationVector[1]));
+                if(baselineDiff == static_cast<int>(std::abs(baseline))) {
+                    if(std::find_if(stereoPairs.begin(),
+                                    stereoPairs.end(),
+                                    [leftSocket, rightSocket](auto const& pair) { return pair.left == leftSocket && pair.right == rightSocket; })
+                       == stereoPairs.end()) {
+                        stereoPairs.push_back(dai::StereoPair{leftSocket, rightSocket, std::abs(baseline), static_cast<int>(translationVector[0]) == 0});
+                    }
+                } else {
+                    pimpl->logger.debug("Skipping diagonal pair, left: {}, right: {}.", leftSocket, rightSocket);
+                }
+            } catch(const std::exception&) {
+                continue;
             }
-            auto leftSocket = baseline < 0 ? camId : toSocket;
-            auto rightSocket = leftSocket == camId ? toSocket : camId;
-            // Make sure the pair isn't diagonal, else skip
-            int baselineDiff = std::abs(static_cast<int>(accBaselineX) - static_cast<int>(accBaselineY));
-            if (baselineDiff == static_cast<int>(std::abs(baseline))) {
-                stereoPairs.push_back(dai::StereoPair{leftSocket, rightSocket, std::abs(baseline), baseline == accBaselineY});
-            } else {
-                pimpl->logger.debug("Skipping diagonal pair, left: {}, right: {}.", leftSocket, rightSocket);
-            }
-            auto nextSocket = eepromData.cameraData[toSocket].extrinsics.toCameraSocket;
-            fromSocket = toSocket;
-            toSocket = nextSocket;
         }
     }
-    // Step 3: Filter out undetected cameras and socket pairs which are not present in getStereoPairs 
+    // Filter out undetected cameras and socket pairs which are not present in getStereoPairs
     auto deviceStereoPairs = getStereoPairs();
     auto connectedCameras = getConnectedCameras();
     std::vector<dai::StereoPair> filteredStereoPairs;
-    std::copy_if(stereoPairs.begin(), stereoPairs.end(), std::back_inserter(filteredStereoPairs), [this, connectedCameras, deviceStereoPairs](dai::StereoPair pair) {
-        if (std::find(connectedCameras.begin(), connectedCameras.end(), pair.left) == connectedCameras.end()) {
-            pimpl->logger.debug("Skipping calibrated stereo pair because, camera {} was not detected.", pair.left);
-            return false;
-        } else if (std::find(connectedCameras.begin(), connectedCameras.end(), pair.right) == connectedCameras.end()) {
-            pimpl->logger.debug("Skipping calibrated stereo pair because, camera {} was not detected.", pair.right);
-            return false;
-        }
-        return std::find_if(deviceStereoPairs.begin(), deviceStereoPairs.end(), [pair](dai::StereoPair devicePair) {
-            return devicePair.left == pair.left && devicePair.right == pair.right;
-        }) != deviceStereoPairs.end();
-    });
-    
+    std::copy_if(
+        stereoPairs.begin(), stereoPairs.end(), std::back_inserter(filteredStereoPairs), [this, connectedCameras, deviceStereoPairs](dai::StereoPair pair) {
+            if(std::find(connectedCameras.begin(), connectedCameras.end(), pair.left) == connectedCameras.end()) {
+                pimpl->logger.debug("Skipping calibrated stereo pair because, camera {} was not detected.", pair.left);
+                return false;
+            } else if(std::find(connectedCameras.begin(), connectedCameras.end(), pair.right) == connectedCameras.end()) {
+                pimpl->logger.debug("Skipping calibrated stereo pair because, camera {} was not detected.", pair.right);
+                return false;
+            }
+            return std::find_if(deviceStereoPairs.begin(),
+                                deviceStereoPairs.end(),
+                                [pair](dai::StereoPair devicePair) { return devicePair.left == pair.left && devicePair.right == pair.right; })
+                   != deviceStereoPairs.end();
+        });
+
     std::sort(filteredStereoPairs.begin(), filteredStereoPairs.end(), [](dai::StereoPair a, dai::StereoPair b) { return a.baseline < b.baseline; });
     return filteredStereoPairs;
 }

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1057,6 +1057,10 @@ std::vector<CameraFeatures> DeviceBase::getConnectedCameraFeatures() {
     return pimpl->rpcClient->call("getConnectedCameraFeatures").as<std::vector<CameraFeatures>>();
 }
 
+std::vector<StereoPair> DeviceBase::getStereoPairs() {
+    return pimpl->rpcClient->call("getStereoPairs").as<std::vector<StereoPair>>();
+}
+
 std::unordered_map<CameraBoardSocket, std::string> DeviceBase::getCameraSensorNames() {
     return pimpl->rpcClient->call("getCameraSensorNames").as<std::unordered_map<CameraBoardSocket, std::string>>();
 }

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1066,8 +1066,10 @@ std::vector<StereoPair> DeviceBase::getAvailableStereoPairs() {
         }
     }
     // Find links between cameras.
-    for(auto const& [camId1, _camInfo1] : calibHandler.getEepromData().cameraData) {
-        for(auto const& [camId2, _camInfo2] : calibHandler.getEepromData().cameraData) {
+    for(auto const& camIdAndInfo1 : calibHandler.getEepromData().cameraData) {
+        auto camId1 = camIdAndInfo1.first;
+        for(auto const& camIdAndInfo2 : calibHandler.getEepromData().cameraData) {
+            auto camId2 = camIdAndInfo2.first;
             try {
                 auto translationVector = calibHandler.getCameraTranslationVector(camId1, camId2, false);
                 auto baseline = std::abs(translationVector[0]) > std::abs(translationVector[1]) ? translationVector[0] : translationVector[1];  // X or Y
@@ -1077,7 +1079,7 @@ std::vector<StereoPair> DeviceBase::getAvailableStereoPairs() {
                 if(baselineDiff == static_cast<int>(std::abs(baseline))) {
                     if(std::find_if(stereoPairs.begin(),
                                     stereoPairs.end(),
-                                    [leftSocket, rightSocket](auto const& pair) { return pair.left == leftSocket && pair.right == rightSocket; })
+                                    [&leftSocket, &rightSocket](const dai::StereoPair& pair) { return pair.left == leftSocket && pair.right == rightSocket; })
                        == stereoPairs.end()) {
                         stereoPairs.push_back(dai::StereoPair{leftSocket, rightSocket, std::abs(baseline), static_cast<int>(translationVector[0]) == 0});
                     }


### PR DESCRIPTION
Returns stereo pairs on known devices. Empty on FFC, because the stereo pairs could be anything. Skip getAvailableStereoPairs for now.