### PR TITLE
Fix build with gcc 13.2 toolchain

### DIFF
--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -325,7 +325,7 @@ void DataInputQueue::send(const std::shared_ptr<RawBuffer>& rawMsg) {
 
     // Check if stream receiver has enough space for this message
     if(rawMsg->data.size() > maxDataSize) {
-        throw std::runtime_error(fmt::format("Trying to send larger ({}B) message than XLinkIn maxDataSize ({}B)", rawMsg->data.size(), maxDataSize));
+        throw std::runtime_error(fmt::format("Trying to send larger ({}B) message than XLinkIn maxDataSize ({}B)", rawMsg->data.size(), maxDataSize.load()));
     }
 
     if(!queue.push(rawMsg)) {
@@ -347,7 +347,7 @@ bool DataInputQueue::send(const std::shared_ptr<RawBuffer>& rawMsg, std::chrono:
 
     // Check if stream receiver has enough space for this message
     if(rawMsg->data.size() > maxDataSize) {
-        throw std::runtime_error(fmt::format("Trying to send larger ({}B) message than XLinkIn maxDataSize ({}B)", rawMsg->data.size(), maxDataSize));
+        throw std::runtime_error(fmt::format("Trying to send larger ({}B) message than XLinkIn maxDataSize ({}B)", rawMsg->data.size(), maxDataSize.load()));
     }
 
     return queue.tryWaitAndPush(rawMsg, timeout);


### PR DESCRIPTION
To fix a couple compile errors along these lines,

/usr/include/fmt/core.h: In instantiation of 'constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) -- snip some typical C++ compiler noise --
src/device/DataQueue.cpp:296:45:   required from here
/usr/include/fmt/core.h:1580:7: error: static assertion failed: Cannot format an argument.

avoid trying to format atomic_t directly, and instead pass in the simple type being protected by that atomic_t (which in this case, is size_t).