### PR TITLE
Fix a bug where watchdog is created and destroyed more than once

### DIFF
--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -277,7 +277,7 @@ void DeviceBootloader::createWatchdog() {
     if(monitorThread.joinable() || watchdogThread.joinable()) {
         throw std::runtime_error("Watchdog already created. Destroy it first.");
     }
-
+    watchdogRunning = true;
     // Specify "last" ping time (5s in the future, for some grace time)
     {
         std::unique_lock<std::mutex> lock(lastWatchdogPingTimeMtx);


### PR DESCRIPTION
Fix a bug, where the bootloader watchdog did not run successfully on the second run.

Solves https://github.com/luxonis/depthai-python/issues/953 