### PR TITLE
Introduced `DeviceBootloader::getFlashedVersion` to retrieve the bootloader version flashed on the device. Fixed `isUserBootloaderSupported` - thereby fixed user bootloader flashing.

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "7a11ef8a21cfd73ed890a146c44c6ab8206cca47")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "c58546bf837efe2ffc1befb3dffc7d2c0a69fdec")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/device/DeviceBootloader.hpp
+++ b/include/depthai/device/DeviceBootloader.hpp
@@ -442,6 +442,12 @@ class DeviceBootloader {
     Version getVersion() const;
 
     /**
+     * @return Version of the bootloader that is flashed on the device.
+     * Nullopt when the version could not be retrieved because the device was in X_LINK_UNBOOTED state before booting the bootloader.
+     */
+    tl::optional<Version> getFlashedVersion() const;
+
+    /**
      * @returns True when bootloader was booted using latest bootloader integrated in the library.
      * False when bootloader is already running on the device and just connected to.
      */
@@ -504,6 +510,8 @@ class DeviceBootloader {
 
     bool isEmbedded = false;
     Type bootloaderType;
+    tl::optional<Version> flashedVersion;
+    const Version VERSION_USER_BL_UNSUPPORTED = Version("0.0.20");
 
     // closed
     std::atomic<bool> closed{false};

--- a/include/depthai/device/DeviceBootloader.hpp
+++ b/include/depthai/device/DeviceBootloader.hpp
@@ -511,7 +511,6 @@ class DeviceBootloader {
     bool isEmbedded = false;
     Type bootloaderType;
     tl::optional<Version> flashedVersion;
-    const Version VERSION_USER_BL_UNSUPPORTED = Version("0.0.20");
 
     // closed
     std::atomic<bool> closed{false};

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -701,8 +701,12 @@ bool DeviceBootloader::isUserBootloaderSupported() {
         return false;
     }
 
+    if(!getFlashedVersion()) {
+        return false;
+    }
+
     // Check if bootloader version is adequate
-    if(getFlashedVersion().value_or(DeviceBootloader::VERSION_USER_BL_UNSUPPORTED).getSemver() < Version(Request::IsUserBootloader::VERSION)) {
+    if(getFlashedVersion().value().getSemver() < Version(Request::IsUserBootloader::VERSION)) {
         return false;
     }
 
@@ -933,8 +937,14 @@ std::tuple<bool, std::string> DeviceBootloader::flashUserBootloader(std::functio
     // }
 
     // Check if bootloader version is adequate
-    if(getFlashedVersion().value_or(DeviceBootloader::VERSION_USER_BL_UNSUPPORTED).getSemver() < Version(Request::IsUserBootloader::VERSION)) {
-        throw std::runtime_error("Current bootloader version doesn't support User Bootloader");
+    if(!getFlashedVersion()) {
+        throw std::runtime_error(
+            "Couldn't retrieve version of the flashed bootloader. Make sure you have a factory bootloader flashed and the device is booted to bootloader.");
+    }
+    if(getFlashedVersion().value().getSemver() < Version(Request::IsUserBootloader::VERSION)) {
+        throw std::runtime_error(fmt::format("Current bootloader version doesn't support User Bootloader. Current version: {}, minimum required version: {}",
+                                             getFlashedVersion().value().toStringSemver(),
+                                             Version(Request::IsUserBootloader::VERSION).toStringSemver()));
     }
 
     // Retrieve bootloader


### PR DESCRIPTION
@diablodale reported in https://github.com/luxonis/depthai-core/issues/988 that `DeviceBootloader::getVersion()` returns the incorrect version when constructed with `allowFlashingBootloader=true`.

As you noticed - underneath depthai boots the latest embedded bootloader. As `getVersion()` returns the current running version of the bootloader - the reported version was unexpected (e.g. device with 0.0.17 bl flashed, would report bl version 0.0.26).. 

This version reporting also messes with `flashUserBootloader`, due to reliance on `getVersion()` to check if the "flashed" bootloader supports user bootloader (as reported in https://github.com/luxonis/depthai-core/issues/995).

To resolve this issue - this PR introduces a `DeviceBootloader::getFlashedVersion()` api to get the flashed bl version, `isUserBootloaderSupported()` now relies on `getFlashedVersion` to decide whether flashing a user bootloader is supported. `getVersion` is left unchanged and still reports the version of the booted bootloader.

@jakaskerl could we enhance the docs in this regard. We could include some comments about which version `getVersion` reports etc.

Thanks @diablodale for the thorough bug reports.