### PR TITLE
V3 develop build encoder

### DIFF
--- a/bindings/python/examples/v3/RecordReplay/record_video.py
+++ b/bindings/python/examples/v3/RecordReplay/record_video.py
@@ -16,7 +16,7 @@ with dai.Pipeline() as pipeline:
     signal.signal(signal.SIGINT, signal_handler)
 
     cam = pipeline.create(dai.node.ColorCamera)
-    cam.setBoardSocket(dai.CameraBoardSocket.RGB)
+    cam.setBoardSocket(dai.CameraBoardSocket.CAM_A)
     cam.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
     cam.setVideoSize(320, 320)
 

--- a/bindings/python/examples/v3/RecordReplay/record_video.py
+++ b/bindings/python/examples/v3/RecordReplay/record_video.py
@@ -20,13 +20,12 @@ with dai.Pipeline() as pipeline:
     cam.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
     cam.setVideoSize(320, 320)
 
-    videoEncoder = pipeline.create(dai.node.VideoEncoder)
+    videoEncoder = pipeline.create(dai.node.VideoEncoder).build(cam.video)
     videoEncoder.setProfile(dai.VideoEncoderProperties.Profile.H264_MAIN)
 
     record = pipeline.create(dai.node.Record)
     record.setRecordFile(args.output)
 
-    cam.video.link(videoEncoder.input)
     videoEncoder.out.link(record.input)
 
     pipeline.start()


### PR DESCRIPTION
- build video encoder instead of linking in record_video.py
- replaced the deprecated RGB board socket with CAM_A