### PR TITLE
Add input queues to the new API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ add_library(${TARGET_CORE_NAME}
     src/pipeline/AssetManager.cpp
     src/pipeline/MessageQueue.cpp
     src/pipeline/Node.cpp
+    src/pipeline/InputQueue.cpp
     src/pipeline/ThreadedNode.cpp
     src/pipeline/DeviceNode.cpp
     src/pipeline/node/XLinkIn.cpp

--- a/bindings/python/examples/ColorCamera/rgb_video.py
+++ b/bindings/python/examples/ColorCamera/rgb_video.py
@@ -13,7 +13,7 @@ with dai.Pipeline(True) as pipeline:
     camRgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
     camRgb.setVideoSize(1920, 1080)
 
-    videoQueue = camRgb.video.createQueue()
+    videoQueue = camRgb.video.createOutputQueue()
 
     # Connect to device and start pipeline
     pipeline.start()

--- a/bindings/python/examples/NNArchive/nn_archive.py
+++ b/bindings/python/examples/NNArchive/nn_archive.py
@@ -43,8 +43,8 @@ with dai.Pipeline() as pipeline:
 
     # Linking
     camRgb.preview.link(detectionNetwork.input)
-    qRgb = detectionNetwork.passthrough.createQueue()
-    qDet = detectionNetwork.out.createQueue()
+    qRgb = detectionNetwork.passthrough.createOutputQueue()
+    qDet = detectionNetwork.out.createOutputQueue()
 
     pipeline.start()
 

--- a/bindings/python/examples/SpatialDetection/spatial_tiny_yolo.py
+++ b/bindings/python/examples/SpatialDetection/spatial_tiny_yolo.py
@@ -101,7 +101,7 @@ spatialDetectionNetwork.passthroughDepth.link(sync.inputs["depth"])
 spatialDetectionNetwork.outNetwork.link(sync.inputs["nn"])
 spatialDetectionNetwork.out.link(sync.inputs["detections"])
 
-syncedQueue = sync.out.createQueue()
+syncedQueue = sync.out.createOutputQueue()
 
 # Connect to device and start pipeline
 with pipeline:

--- a/bindings/python/examples/v3/Camera/camera_multiple_outputs.py
+++ b/bindings/python/examples/v3/Camera/camera_multiple_outputs.py
@@ -45,7 +45,7 @@ with dai.Device(info) as device:
                 cap.resizeMode = dai.ImgResizeMode.LETTERBOX
             else:
                 exit_usage()
-            queues.append(cam.requestOutput(cap, True).createQueue())
+            queues.append(cam.requestOutput(cap, True).createOutputQueue())
 
         # Connect to device and start pipeline
         pipeline.start()

--- a/bindings/python/examples/v3/Camera/camera_output.py
+++ b/bindings/python/examples/v3/Camera/camera_output.py
@@ -19,7 +19,7 @@ with dai.Device(info) as device:
 
         cap = dai.ImgFrameCapability()
         cap.size.fixed([640, 480])
-        videoQueue = cam.requestOutput(cap, True).createQueue()
+        videoQueue = cam.requestOutput(cap, True).createOutputQueue()
 
         # Connect to device and start pipeline
         pipeline.start()

--- a/bindings/python/examples/v3/ColorCamera/rgb_video.py
+++ b/bindings/python/examples/v3/ColorCamera/rgb_video.py
@@ -13,7 +13,7 @@ with dai.Pipeline(True) as pipeline:
     camRgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
     camRgb.setVideoSize(1920, 1080)
 
-    videoQueue = camRgb.video.createQueue()
+    videoQueue = camRgb.video.createOutputQueue()
 
     # Connect to device and start pipeline
     pipeline.start()

--- a/bindings/python/examples/v3/HostNodes/host_camera.py
+++ b/bindings/python/examples/v3/HostNodes/host_camera.py
@@ -31,7 +31,7 @@ class HostCamera(dai.node.ThreadedHostNode):
 
 with dai.Pipeline(createImplicitDevice=False) as p:
     hostCamera = p.create(HostCamera)
-    camQueue = hostCamera.output.createQueue()
+    camQueue = hostCamera.output.createOutputQueue()
 
     p.start()
     while p.isRunning():

--- a/bindings/python/examples/v3/NNArchive/nn_archive.py
+++ b/bindings/python/examples/v3/NNArchive/nn_archive.py
@@ -38,8 +38,8 @@ with dai.Pipeline() as pipeline:
     detectionNetwork.setNumInferenceThreads(2)
 
 
-    qRgb = detectionNetwork.passthrough.createQueue()
-    qDet = detectionNetwork.out.createQueue()
+    qRgb = detectionNetwork.passthrough.createOutputQueue()
+    qDet = detectionNetwork.out.createOutputQueue()
 
     labelMap = detectionNetwork.getClasses()
 

--- a/bindings/python/examples/v3/RecordReplay/replay_video.py
+++ b/bindings/python/examples/v3/RecordReplay/replay_video.py
@@ -23,7 +23,7 @@ with dai.Pipeline() as pipeline:
     imageManip.initialConfig.setResize(300, 300)
     imageManip.initialConfig.setFrameType(dai.ImgFrame.Type.BGR888p)
     replay.out.link(imageManip.inputImage)
-    manipOutQueue = imageManip.out.createQueue()
+    manipOutQueue = imageManip.out.createOutputQueue()
 
     pipeline.start()
     while pipeline.isRunning() and replay.isRunning():

--- a/bindings/python/examples/v3/SpatialDetection/spatial_tiny_yolo.py
+++ b/bindings/python/examples/v3/SpatialDetection/spatial_tiny_yolo.py
@@ -73,7 +73,7 @@ with dai.Pipeline() as p:
     spatialDetectionNetwork.outNetwork.link(sync.inputs["nn"])
     spatialDetectionNetwork.out.link(sync.inputs["detections"])
 
-    syncedQueue = sync.out.createQueue()
+    syncedQueue = sync.out.createOutputQueue()
 
     p.start()
     labelMap = spatialDetectionNetwork.getClasses()

--- a/bindings/python/examples/v3/StereoDepth/stereo.py
+++ b/bindings/python/examples/v3/StereoDepth/stereo.py
@@ -33,7 +33,7 @@ with dai.Pipeline() as pipeline:
     # Linking
     monoLeft.out.link(depth.left)
     monoRight.out.link(depth.right)
-    depthQueue = depth.disparity.createQueue()
+    depthQueue = depth.disparity.createOutputQueue()
 
     pipeline.start()
     while pipeline.isRunning():

--- a/bindings/python/src/pipeline/node/NodeBindings.cpp
+++ b/bindings/python/src/pipeline/node/NodeBindings.cpp
@@ -5,6 +5,7 @@
 #include "Common.hpp"
 #include "depthai/pipeline/DeviceNode.hpp"
 #include "depthai/pipeline/Node.hpp"
+#include "depthai/pipeline/InputQueue.hpp"
 #include "depthai/pipeline/NodeGroup.hpp"
 #include "depthai/pipeline/Pipeline.hpp"
 #include "depthai/pipeline/ThreadedNode.hpp"

--- a/bindings/python/src/pipeline/node/NodeBindings.cpp
+++ b/bindings/python/src/pipeline/node/NodeBindings.cpp
@@ -292,7 +292,11 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("getWaitForMessage", &Node::Input::getWaitForMessage, DOC(dai, Node, Input, getWaitForMessage))
         .def("setReusePreviousMessage", &Node::Input::setReusePreviousMessage, py::arg("reusePreviousMessage"), DOC(dai, Node, Input, setReusePreviousMessage))
         .def("getReusePreviousMessage", &Node::Input::getReusePreviousMessage, DOC(dai, Node, Input, getReusePreviousMessage))
-        .def("createInputQueue", &Node::Input::createInputQueue, py::arg("maxSize") = 16, py::arg("blocking") = true, DOC(dai, Node, Input, createInputQueue));
+        .def("createInputQueue",
+             &Node::Input::createInputQueue,
+             py::arg("maxSize") = Node::Input::INPUT_QUEUE_DEFAULT_MAX_SIZE,
+             py::arg("blocking") = Node::Input::INPUT_QUEUE_DEFAULT_BLOCKING,
+             DOC(dai, Node, Input, createInputQueue));
 
     // Node::Output bindings
     nodeOutputType.value("MSender", Node::Output::Type::MSender).value("SSender", Node::Output::Type::SSender);
@@ -316,8 +320,11 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack) {
              DOC(dai, Node, Output, getParent))
         .def("isSamePipeline", &Node::Output::isSamePipeline, py::arg("input"), DOC(dai, Node, Output, isSamePipeline))
         .def("canConnect", &Node::Output::canConnect, py::arg("input"), DOC(dai, Node, Output, canConnect))
-        .def("createQueue", &Node::Output::createQueue, py::arg("maxSize") = 16, py::arg("blocking") = true, DOC(dai, Node, Output, createQueue))
-        .def("createOutputQueue", &Node::Output::createOutputQueue, py::arg("maxSize") = 16, py::arg("blocking") = true, DOC(dai, Node, Output, createOutputQueue))
+        .def("createOutputQueue",
+             &Node::Output::createOutputQueue,
+             py::arg("maxSize") = Node::Output::OUTPUT_QUEUE_DEFAULT_MAX_SIZE,
+             py::arg("blocking") = Node::Output::OUTPUT_QUEUE_DEFAULT_BLOCKING,
+             DOC(dai, Node, Output, createOutputQueue))
         .def("link", static_cast<void (Node::Output::*)(Node::Input&)>(&Node::Output::link), py::arg("input"), DOC(dai, Node, Output, link))
         .def("unlink", static_cast<void (Node::Output::*)(Node::Input&)>(&Node::Output::unlink), py::arg("input"), DOC(dai, Node, Output, unlink))
         .def("send", &Node::Output::send, py::arg("msg"), DOC(dai, Node, Output, send), py::call_guard<py::gil_scoped_release>())

--- a/bindings/python/src/pipeline/node/NodeBindings.cpp
+++ b/bindings/python/src/pipeline/node/NodeBindings.cpp
@@ -209,6 +209,10 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack) {
     py::enum_<Node::Output::Type> nodeOutputType(pyOutput, "Type");
     py::class_<Properties, std::shared_ptr<Properties>> pyProperties(m, "Properties", DOC(dai, Properties));
     py::class_<Node::DatatypeHierarchy> nodeDatatypeHierarchy(pyNode, "DatatypeHierarchy", DOC(dai, Node, DatatypeHierarchy));
+    
+    
+    py::class_<InputQueue, std::shared_ptr<InputQueue>> pyInputQueue(m, "InputQueue", DOC(dai, InputQueue));
+    pyInputQueue.def("send", &InputQueue::send, py::arg("msg"), DOC(dai, InputQueue, send));
 
     // Node::Id bindings
     py::class_<Node::Id>(pyNode, "Id", "Node identificator. Unique for every node on a single Pipeline");
@@ -287,7 +291,8 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("setWaitForMessage", &Node::Input::setWaitForMessage, py::arg("waitForMessage"), DOC(dai, Node, Input, setWaitForMessage))
         .def("getWaitForMessage", &Node::Input::getWaitForMessage, DOC(dai, Node, Input, getWaitForMessage))
         .def("setReusePreviousMessage", &Node::Input::setReusePreviousMessage, py::arg("reusePreviousMessage"), DOC(dai, Node, Input, setReusePreviousMessage))
-        .def("getReusePreviousMessage", &Node::Input::getReusePreviousMessage, DOC(dai, Node, Input, getReusePreviousMessage));
+        .def("getReusePreviousMessage", &Node::Input::getReusePreviousMessage, DOC(dai, Node, Input, getReusePreviousMessage))
+        .def("createInputQueue", &Node::Input::createInputQueue, py::arg("maxSize") = 16, py::arg("blocking") = true, DOC(dai, Node, Input, createInputQueue));
 
     // Node::Output bindings
     nodeOutputType.value("MSender", Node::Output::Type::MSender).value("SSender", Node::Output::Type::SSender);
@@ -312,6 +317,7 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("isSamePipeline", &Node::Output::isSamePipeline, py::arg("input"), DOC(dai, Node, Output, isSamePipeline))
         .def("canConnect", &Node::Output::canConnect, py::arg("input"), DOC(dai, Node, Output, canConnect))
         .def("createQueue", &Node::Output::createQueue, py::arg("maxSize") = 16, py::arg("blocking") = true, DOC(dai, Node, Output, createQueue))
+        .def("createOutputQueue", &Node::Output::createOutputQueue, py::arg("maxSize") = 16, py::arg("blocking") = true, DOC(dai, Node, Output, createOutputQueue))
         .def("link", static_cast<void (Node::Output::*)(Node::Input&)>(&Node::Output::link), py::arg("input"), DOC(dai, Node, Output, link))
         .def("unlink", static_cast<void (Node::Output::*)(Node::Input&)>(&Node::Output::unlink), py::arg("input"), DOC(dai, Node, Output, unlink))
         .def("send", &Node::Output::send, py::arg("msg"), DOC(dai, Node, Output, send), py::call_guard<py::gil_scoped_release>())

--- a/examples/Camera/camera_multiple_outputs.cpp
+++ b/examples/Camera/camera_multiple_outputs.cpp
@@ -50,19 +50,19 @@ int main(int argc, char** argv) {
                 throw std::runtime_error("Resize mode argument (every 3rd) must be 0, 1 or 2");
         }
         auto* output = camRgb->requestOutput(cap, true);
-        videos.push_back(output->createQueue());
+        videos.push_back(output->createOutputQueue());
     }
 
     /*
     camRgb->setSize(1920, 1080);
-    auto video = camRgb->video.createQueue();
+    auto video = camRgb->video.createOutputQueue();
     */
 
     /*
     dai::ImgFrameCapability cap;
     cap.size.value = std::pair(1920, 1080);
     auto* output = camRgb->requestOutput(cap);
-    auto video = output->createQueue();
+    auto video = output->createOutputQueue();
     */
 
     pipeline.start();

--- a/examples/ColorCamera/rgb_video.cpp
+++ b/examples/ColorCamera/rgb_video.cpp
@@ -13,7 +13,7 @@ int main() {
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setVideoSize(1920, 1080);
 
-    auto outputQueue = camRgb->video.createQueue();
+    auto outputQueue = camRgb->video.createOutputQueue();
 
     pipeline.start();
     while(pipeline.isRunning()) {

--- a/examples/ImageManip/image_manip_many_instances.cpp
+++ b/examples/ImageManip/image_manip_many_instances.cpp
@@ -67,10 +67,10 @@ int main() {
     imageManip->out.link(imageManipCrop->inputImage);
     */
 
-    auto video = camRgb->video.createQueue();
+    auto video = camRgb->video.createOutputQueue();
     std::vector<std::shared_ptr<dai::MessageQueue>> resizedOutputs;
     for(auto imageManip : resizeNodes) {
-        resizedOutputs.push_back(imageManip->out.createQueue());
+        resizedOutputs.push_back(imageManip->out.createOutputQueue());
     }
 
     pipeline.start();

--- a/examples/Script/script_get_ip.cpp
+++ b/examples/Script/script_get_ip.cpp
@@ -31,7 +31,7 @@ int main() {
     )");
 
     // XLinkOut
-    auto queue = script->outputs["end"].createQueue();
+    auto queue = script->outputs["end"].createOutputQueue();
 
     // Connect to device with pipeline
     dai::Device device(pipeline);

--- a/examples/host_side/host_only_camera.cpp
+++ b/examples/host_side/host_only_camera.cpp
@@ -7,7 +7,7 @@ int main() {
     auto displayDevice = pipeline.create<dai::node::Display>(std::string{"Device Display"});
 
     camRgb->out.link(displayDevice->input);
-    auto queue = camRgb->out.createQueue();
+    auto queue = camRgb->out.createOutputQueue();
     pipeline.start();
     while(pipeline.isRunning()) {
         auto img = queue->get<dai::ImgFrame>();

--- a/examples/host_side/host_pipeline_opencv.cpp
+++ b/examples/host_side/host_pipeline_opencv.cpp
@@ -18,7 +18,7 @@ int main() {
     // camRgb->video.link(displayDevice->input);
 
     // Option 2:
-    auto queue = camRgb->video.createQueue();
+    auto queue = camRgb->video.createOutputQueue();
 
     pipeline.start();
 

--- a/examples/v3/ColorCamera/rgb_video.cpp
+++ b/examples/v3/ColorCamera/rgb_video.cpp
@@ -13,7 +13,7 @@ int main() {
     camRgb->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     camRgb->setVideoSize(1920, 1080);
 
-    auto outputQueue = camRgb->video.createQueue();
+    auto outputQueue = camRgb->video.createOutputQueue();
 
     pipeline.start();
     while(pipeline.isRunning()) {

--- a/include/depthai/pipeline/InputQueue.hpp
+++ b/include/depthai/pipeline/InputQueue.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "depthai/pipeline/Node.hpp"
+#include "depthai/pipeline/ThreadedHostNode.hpp"
+
+namespace dai {
+
+class InputQueue : public node::ThreadedHostNode {
+    friend class Node::Input;
+
+   public:
+    /**
+     * @brief Send a message to the connected input
+     *
+     * @param msg Message to send
+     */
+    void send(const std::shared_ptr<ADatatype>& msg);
+
+   private:
+    /**
+     * @brief Construct a new Input Queue object
+     *
+     * @param maxSize: Maximum size of the input queue
+     * @param blocking: Whether the input queue should block when full
+     */
+    InputQueue(unsigned int maxSize = 16, bool blocking = false);
+
+    /**
+     * @brief InputQueue's main thread function that takes care of sending messages from onhost to the connected ondevice input
+     */
+    void run() override;
+
+    const char *getName() const override;
+
+    Node::Input input{*this, {.name = "input", .types = {{DatatypeEnum::Buffer, true}}}};
+    Node::Output output{*this, {.name = "output", .types = {{DatatypeEnum::Buffer, true}}}};
+
+};
+
+}  // namespace dai

--- a/include/depthai/pipeline/InputQueue.hpp
+++ b/include/depthai/pipeline/InputQueue.hpp
@@ -5,36 +5,50 @@
 
 namespace dai {
 
-class InputQueue : public node::ThreadedHostNode {
+class InputQueue {
     friend class Node::Input;
 
    public:
     /**
      * @brief Send a message to the connected input
      *
-     * @param msg Message to send
+     * @param msg: Message to send
      */
     void send(const std::shared_ptr<ADatatype>& msg);
 
    private:
     /**
-     * @brief Construct a new Input Queue object
+     * @brief Construct a new Input Queue object. The constructor is private as we only want to expose the relevant methods - only send for now
      *
      * @param maxSize: Maximum size of the input queue
      * @param blocking: Whether the input queue should block when full
      */
     InputQueue(unsigned int maxSize = 16, bool blocking = false);
 
-    /**
-     * @brief InputQueue's main thread function that takes care of sending messages from onhost to the connected ondevice input
-     */
-    void run() override;
+    class InputQueueNode : public node::ThreadedHostNode {
+       public:
+        /** Constructor*/
+        InputQueueNode(unsigned int maxSize, bool blocking);
 
-    const char *getName() const override;
+        /** Send message from host*/
+        void send(const std::shared_ptr<ADatatype>& msg);
 
-    Node::Input input{*this, {.name = "input", .types = {{DatatypeEnum::Buffer, true}}}};
-    Node::Output output{*this, {.name = "output", .types = {{DatatypeEnum::Buffer, true}}}};
+        void run() override;
+        const char* getName() const override;
 
+        Node::Input input{*this, {.name = "input", .types = {{DatatypeEnum::Buffer, true}}}};
+        Node::Output output{*this, {.name = "output", .types = {{DatatypeEnum::Buffer, true}}}};
+    };
+
+    // Helper access functions
+    inline Node::Output& getNodeOutput() {
+        return inputQueueNode->output;
+    }
+    inline std::shared_ptr<Node> getNode() {
+        return inputQueueNode;
+    }
+
+    /** Pointer to InputQueueNode that does the actual communication between host and device */
+    std::shared_ptr<InputQueueNode> inputQueueNode;
 };
-
 }  // namespace dai

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -682,13 +682,13 @@ class InputQueue : public Node {
      */
     void run();
 
-    JoiningThread inputQueueThread_;
-    std::unique_ptr<MessageQueue> queuePtr_;
-    std::atomic_bool stopThreadFlag_;
+    JoiningThread inputQueueThread;
+    std::unique_ptr<MessageQueue> queuePtr;
+    std::atomic_bool stopThreadFlag;
 
-    mutable std::mutex guard_;
-    std::condition_variable sendThreadCv_;
-    std::condition_variable inputQueueEmptiedCv_;
+    mutable std::mutex guard;
+    std::condition_variable sendThreadCv;
+    std::condition_variable inputQueueEmptiedCv;
 };
 
 // Node CRTP class

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -651,48 +651,6 @@ class Node : public std::enable_shared_from_this<Node> {
     }
 };
 
-class InputQueue : public Node {
-    friend class Input;
-
-   public:
-    /**
-     * @brief Send a message to the connected input
-     *
-     * @param msg Message to send
-     */
-    void send(const std::shared_ptr<ADatatype>& msg);
-
-   private:
-    /**
-     * @brief Construct a new Input Queue object
-     *
-     * @param maxSize: Maximum size of the input queue
-     * @param blocking: Whether the input queue should block when full
-     */
-    InputQueue(unsigned int maxSize = 16, bool blocking = false);
-
-    /**
-     * @brief InputQueue's main thread function that takes care of sending messages from onhost to the connected ondevice input
-     */
-    void run();
-
-    void start() override;
-    void stop() override;
-    void wait() override;
-    bool runOnHost() const override;
-    const char* getName() const override;
-
-    Output output{*this, {.name = "output", .types = {{DatatypeEnum::Buffer, true}}}};
-
-    JoiningThread inputQueueThread;
-    std::unique_ptr<MessageQueue> queuePtr;
-    std::atomic_bool stopThreadFlag;
-
-    mutable std::mutex guard;
-    std::condition_variable sendThreadCv;
-    std::condition_variable inputQueueEmptiedCv;
-};
-
 // Node CRTP class
 template <typename Base, typename Derived>
 class NodeCRTP : public Base {

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <set>
@@ -14,7 +13,6 @@
 #include "depthai/openvino/OpenVINO.hpp"
 #include "depthai/pipeline/AssetManager.hpp"
 #include "depthai/pipeline/MessageQueue.hpp"
-#include "depthai/utility/JoiningThread.hpp"
 #include "depthai/utility/RecordReplay.hpp"
 #include "depthai/utility/copyable_unique_ptr.hpp"
 
@@ -343,7 +341,6 @@ class Node : public std::enable_shared_from_this<Node> {
         bool waitForMessage{false};
         std::string group;
         Type type = Type::SReceiver;
-        std::vector<std::shared_ptr<InputQueue>> connectedQueues;
 
        public:
         std::vector<DatatypeHierarchy> possibleDatatypes;

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -234,7 +234,11 @@ class Node : public std::enable_shared_from_this<Node> {
             return queueConnections;
         }
 
-        [[deprecated("Use 'createOutputQueue()' instead")]] std::shared_ptr<MessageQueue> createQueue(unsigned int maxSize = 16, bool blocking = true);
+        /** Default value for the blocking argument in the createOutputQueue method */
+        static constexpr bool OUTPUT_QUEUE_DEFAULT_BLOCKING = false;
+
+        /** Default value for the maxSize argument in the createOutputQueue method */
+        static constexpr unsigned int OUTPUT_QUEUE_DEFAULT_MAX_SIZE = 16;
 
         /**
          * @brief Construct and return a shared pointer to an output message queue
@@ -244,7 +248,8 @@ class Node : public std::enable_shared_from_this<Node> {
          *
          * @return std::shared_ptr<dai::MessageQueue>: shared pointer to an output queue
          */
-        std::shared_ptr<dai::MessageQueue> createOutputQueue(unsigned int maxSize = 16, bool blocking = true);
+        std::shared_ptr<dai::MessageQueue> createOutputQueue(unsigned int maxSize = OUTPUT_QUEUE_DEFAULT_MAX_SIZE,
+                                                             bool blocking = OUTPUT_QUEUE_DEFAULT_BLOCKING);
 
        private:
         void link(const std::shared_ptr<dai::MessageQueue>& queue) {
@@ -411,6 +416,12 @@ class Node : public std::enable_shared_from_this<Node> {
          */
         std::string getGroup() const;
 
+        /** Default value for the blocking argument in the createInputQueue method */
+        static constexpr bool INPUT_QUEUE_DEFAULT_BLOCKING = false;
+
+        /** Default value for the maxSize argument in the createInputQueue method */
+        static constexpr unsigned int INPUT_QUEUE_DEFAULT_MAX_SIZE = 16;
+
         /**
          * @brief Create an shared pointer to an input queue that can be used to send messages to this input from onhost
          *
@@ -419,7 +430,7 @@ class Node : public std::enable_shared_from_this<Node> {
          *
          * @return std::shared_ptr<InputQueue>: shared pointer to an input queue
          */
-        std::shared_ptr<InputQueue> createInputQueue(unsigned int maxSize = 16, bool blocking = false);
+        std::shared_ptr<InputQueue> createInputQueue(unsigned int maxSize = INPUT_QUEUE_DEFAULT_MAX_SIZE, bool blocking = INPUT_QUEUE_DEFAULT_BLOCKING);
     };
 
     /**

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -652,7 +652,17 @@ class Node : public std::enable_shared_from_this<Node> {
 };
 
 class InputQueue : public Node {
+    friend class Input;
+
    public:
+    /**
+     * @brief Send a message to the connected input
+     *
+     * @param msg Message to send
+     */
+    void send(const std::shared_ptr<ADatatype>& msg);
+
+   private:
     /**
      * @brief Construct a new Input Queue object
      *
@@ -661,26 +671,18 @@ class InputQueue : public Node {
      */
     InputQueue(unsigned int maxSize = 16, bool blocking = false);
 
+    /**
+     * @brief InputQueue's main thread function that takes care of sending messages from onhost to the connected ondevice input
+     */
+    void run();
+
     void start() override;
     void stop() override;
     void wait() override;
     bool runOnHost() const override;
     const char* getName() const override;
 
-    /**
-     * @brief Send a message to the connected input
-     *
-     * @param msg Message to send
-     */
-    void send(const std::shared_ptr<ADatatype>& msg);
-
     Output output{*this, {.name = "output", .types = {{DatatypeEnum::Buffer, true}}}};
-
-   private:
-    /**
-     * @brief InputQueue's main thread function that takes care of sending messages from onhost to the connected ondevice input
-     */
-    void run();
 
     JoiningThread inputQueueThread;
     std::unique_ptr<MessageQueue> queuePtr;

--- a/src/pipeline/InputQueue.cpp
+++ b/src/pipeline/InputQueue.cpp
@@ -2,22 +2,28 @@
 
 namespace dai {
 
-InputQueue::InputQueue(unsigned int maxSize, bool blocking) : ThreadedHostNode() {
+void InputQueue::send(const std::shared_ptr<ADatatype>& msg) {
+    inputQueueNode->send(msg);
+}
+
+InputQueue::InputQueue(unsigned int maxSize, bool blocking) : inputQueueNode(std::make_shared<InputQueueNode>(maxSize, blocking)) {}
+
+InputQueue::InputQueueNode::InputQueueNode(unsigned int maxSize, bool blocking) : ThreadedHostNode() {
     input.setBlocking(blocking);
     input.setMaxSize(maxSize);
 }
 
-void InputQueue::run() {
+void InputQueue::InputQueueNode::run() {
     while(isRunning()) {
         output.send(input.get());
     }
 }
 
-void InputQueue::send(const std::shared_ptr<ADatatype>& msg) {
+void InputQueue::InputQueueNode::send(const std::shared_ptr<ADatatype>& msg) {
     input.send(msg);
 }
 
-const char* InputQueue::getName() const {
+const char* InputQueue::InputQueueNode::getName() const {
     return "InputQueue";
 }
 

--- a/src/pipeline/InputQueue.cpp
+++ b/src/pipeline/InputQueue.cpp
@@ -1,0 +1,24 @@
+#include "depthai/pipeline/InputQueue.hpp"
+
+namespace dai {
+
+InputQueue::InputQueue(unsigned int maxSize, bool blocking) : ThreadedHostNode() {
+    input.setBlocking(blocking);
+    input.setMaxSize(maxSize);
+}
+
+void InputQueue::run() {
+    while(isRunning()) {
+        output.send(input.get());
+    }
+}
+
+void InputQueue::send(const std::shared_ptr<ADatatype>& msg) {
+    input.send(msg);
+}
+
+const char* InputQueue::getName() const {
+    return "InputQueue";
+}
+
+}  // namespace dai

--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -154,10 +154,6 @@ void Node::Output::link(Input& in) {
     connectedInputs.push_back(&in);
 }
 
-std::shared_ptr<dai::MessageQueue> Node::Output::createQueue(unsigned int maxSize, bool blocking) {
-    return createOutputQueue(maxSize, blocking);
-}
-
 std::shared_ptr<dai::MessageQueue> Node::Output::createOutputQueue(unsigned int maxSize, bool blocking) {
     // Check if pipeline is already started - if so, throw an error
     auto pipelinePtr = parent.get().getParentPipeline();

--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<InputQueue> Node::Input::createInputQueue(unsigned int maxSize, 
     if(pipelinePtr.isBuilt()) {
         throw std::runtime_error("Cannot create input queue after pipeline is built");
     }
-    auto inputQueuePtr = std::make_shared<InputQueue>(maxSize, blocking);
+    auto inputQueuePtr = std::shared_ptr<InputQueue>(new InputQueue(maxSize, blocking));
     pipelinePtr.add(inputQueuePtr);
     inputQueuePtr->output.link(*this);
     connectedQueues.push_back(std::move(inputQueuePtr));


### PR DESCRIPTION
This PR renames the old `createQueue` method to `createOutputQueue` for the `Output` class. The old function stayed in the code, however it was marked as deprecated.

Additionally, a new class, `InputQueue` was introduced, allowing for communication between host and the connected device. A new method called `createInputQueue` was added to the `Input` class. This method returns a shared pointer to an `InputQueue` working as a communication interface between the host and the device via its `send(...)` method.

Lastly, all the `createQueue` function calls were replaced with `createOutputQueue` function calls throughout the entire codebase.

The relevant clickup task is available here: https://app.clickup.com/t/86bym8w49