### PR TITLE
Superblob support

### DIFF
--- a/bindings/python/src/openvino/OpenVINOBindings.cpp
+++ b/bindings/python/src/openvino/OpenVINOBindings.cpp
@@ -10,6 +10,7 @@ void OpenVINOBindings::bind(pybind11::module& m, void* pCallstack){
     py::class_<OpenVINO> openvino(m, "OpenVINO", DOC(dai, OpenVINO));
     py::enum_<OpenVINO::Version> openvinoVersion(openvino, "Version", DOC(dai, OpenVINO, Version));
     py::class_<OpenVINO::Blob> openvinoBlob(openvino, "Blob", DOC(dai, OpenVINO, Blob));
+    py::class_<OpenVINO::Superblob> openvinoSuperblob(openvino, "Superblob", DOC(dai, OpenVINO, Superblob));
     py::enum_<OpenVINO::Device> openvinoDevice(openvino, "Device", DOC(dai, OpenVINO, Device));
 
 
@@ -78,6 +79,12 @@ void OpenVINOBindings::bind(pybind11::module& m, void* pCallstack){
         .def_readwrite("data", &OpenVINO::Blob::data, DOC(dai, OpenVINO, Blob, data))
     ;
 
+    // Bind OpenVINO::Superblob
+    openvinoSuperblob
+        .def(py::init<std::string>(), py::arg("pathToSuperblobFile"), DOC(dai, OpenVINO, Superblob, Superblob))
+        .def("getBlobWithNShaves", &OpenVINO::Superblob::getBlobWithNShaves, py::arg("nShaves"), DOC(dai, OpenVINO, Superblob, getBlobWithNShaves))
+        .def_readonly_static("NUMBER_OF_PATCHES", &OpenVINO::Superblob::NUMBER_OF_PATCHES, DOC(dai, OpenVINO, Superblob, NUMBER_OF_PATCHES));
+    ;
 }
 
 

--- a/bindings/python/src/openvino/OpenVINOBindings.cpp
+++ b/bindings/python/src/openvino/OpenVINOBindings.cpp
@@ -10,7 +10,7 @@ void OpenVINOBindings::bind(pybind11::module& m, void* pCallstack){
     py::class_<OpenVINO> openvino(m, "OpenVINO", DOC(dai, OpenVINO));
     py::enum_<OpenVINO::Version> openvinoVersion(openvino, "Version", DOC(dai, OpenVINO, Version));
     py::class_<OpenVINO::Blob> openvinoBlob(openvino, "Blob", DOC(dai, OpenVINO, Blob));
-    py::class_<OpenVINO::Superblob> openvinoSuperblob(openvino, "Superblob", DOC(dai, OpenVINO, Superblob));
+    py::class_<OpenVINO::SuperBlob> openvinoSuperBlob(openvino, "SuperBlob", DOC(dai, OpenVINO, SuperBlob));
     py::enum_<OpenVINO::Device> openvinoDevice(openvino, "Device", DOC(dai, OpenVINO, Device));
 
 
@@ -79,11 +79,11 @@ void OpenVINOBindings::bind(pybind11::module& m, void* pCallstack){
         .def_readwrite("data", &OpenVINO::Blob::data, DOC(dai, OpenVINO, Blob, data))
     ;
 
-    // Bind OpenVINO::Superblob
-    openvinoSuperblob
-        .def(py::init<std::string>(), py::arg("pathToSuperblobFile"), DOC(dai, OpenVINO, Superblob, Superblob))
-        .def("getBlobWithNShaves", &OpenVINO::Superblob::getBlobWithNShaves, py::arg("nShaves"), DOC(dai, OpenVINO, Superblob, getBlobWithNShaves))
-        .def_readonly_static("NUMBER_OF_PATCHES", &OpenVINO::Superblob::NUMBER_OF_PATCHES, DOC(dai, OpenVINO, Superblob, NUMBER_OF_PATCHES));
+    // Bind OpenVINO::SuperBlob
+    openvinoSuperBlob
+        .def(py::init<std::string>(), py::arg("pathToSuperBlobFile"), DOC(dai, OpenVINO, SuperBlob, SuperBlob))
+        .def("getBlobWithNShaves", &OpenVINO::SuperBlob::getBlobWithNShaves, py::arg("numShaves"), DOC(dai, OpenVINO, SuperBlob, getBlobWithNShaves))
+        .def_readonly_static("NUMBER_OF_PATCHES", &OpenVINO::SuperBlob::NUMBER_OF_PATCHES, DOC(dai, OpenVINO, SuperBlob, NUMBER_OF_PATCHES));
     ;
 }
 

--- a/include/depthai/openvino/OpenVINO.hpp
+++ b/include/depthai/openvino/OpenVINO.hpp
@@ -54,6 +54,59 @@ class OpenVINO {
         std::vector<uint8_t> data;
     };
 
+    /**
+     * @brief A superblob is an efficient way of storing generated blobs for all different number of shaves.
+     */
+    class Superblob {
+       public:
+        /** Number of patches in a superblob*/
+        static constexpr size_t NUMBER_OF_PATCHES = 16;
+
+        /**
+         * @brief Construct a new Superblob object
+         *
+         * @param pathToSuperblobFile: Path to the superblob file (.superblob suffix)
+         */
+        Superblob(const std::string& pathToSuperblobFile);
+
+        /**
+         * @brief Generate a blob with a specific number of shaves
+         *
+         * @param nShaves: Number of shaves to generate the blob for. Must be between 1 and NUMBER_OF_PATCHES.
+         * @return dai::OpenVINO::Blob: Blob compiled for the specified number of shaves
+         */
+        dai::OpenVINO::Blob getBlobWithNShaves(int nShaves);
+
+       private:
+        // A header in the superblob containing metadata about the blob and patches
+        struct SuperblobHeader {
+            static constexpr size_t HEADER_SIZE = 1 * sizeof(uint64_t) + NUMBER_OF_PATCHES * sizeof(uint64_t);
+
+            static SuperblobHeader fromData(const std::vector<uint8_t>& data);
+
+            int64_t blobSize;
+            std::vector<int64_t> patchSizes;
+        };
+
+        // Read the superblob file into memory
+        std::vector<uint8_t> readSuperblobFile(const std::string& path);
+
+        // Get a pointer to the first byte of the blob data
+        const uint8_t* getBlobDataPointer();
+
+        // Get the size in bytes of the blob data
+        int64_t getBlobDataSize();
+
+        // Get a pointer to the first byte of the patch data for a specific number of shaves
+        const uint8_t* getPatchDataPointer(int nShaves);
+
+        // Get the size in bytes of the patch data for a specific number of shaves
+        int64_t getPatchDataSize(int nShaves);
+
+        SuperblobHeader header;
+        std::vector<uint8_t> data;
+    };
+
     /// Main OpenVINO version
     constexpr static const Version DEFAULT_VERSION = VERSION_2022_1;
 

--- a/include/depthai/openvino/OpenVINO.hpp
+++ b/include/depthai/openvino/OpenVINO.hpp
@@ -75,7 +75,7 @@ class OpenVINO {
          * @param nShaves: Number of shaves to generate the blob for. Must be between 1 and NUMBER_OF_PATCHES.
          * @return dai::OpenVINO::Blob: Blob compiled for the specified number of shaves
          */
-        dai::OpenVINO::Blob getBlobWithNShaves(int nShaves);
+        dai::OpenVINO::Blob getBlobWithNumShaves(int numShaves);
 
        private:
         // A header in the superblob containing metadata about the blob and patches

--- a/include/depthai/openvino/OpenVINO.hpp
+++ b/include/depthai/openvino/OpenVINO.hpp
@@ -57,39 +57,39 @@ class OpenVINO {
     /**
      * @brief A superblob is an efficient way of storing generated blobs for all different number of shaves.
      */
-    class Superblob {
+    class SuperBlob {
        public:
         /** Number of patches in a superblob*/
         static constexpr size_t NUMBER_OF_PATCHES = 16;
 
         /**
-         * @brief Construct a new Superblob object
+         * @brief Construct a new SuperBlob object
          *
-         * @param pathToSuperblobFile: Path to the superblob file (.superblob suffix)
+         * @param pathToSuperBlobFile: Path to the superblob file (.superblob suffix)
          */
-        Superblob(const std::string& pathToSuperblobFile);
+        SuperBlob(const std::string& pathToSuperBlobFile);
 
         /**
          * @brief Generate a blob with a specific number of shaves
          *
-         * @param nShaves: Number of shaves to generate the blob for. Must be between 1 and NUMBER_OF_PATCHES.
+         * @param numShaves: Number of shaves to generate the blob for. Must be between 1 and NUMBER_OF_PATCHES.
          * @return dai::OpenVINO::Blob: Blob compiled for the specified number of shaves
          */
-        dai::OpenVINO::Blob getBlobWithNumShaves(int numShaves);
+        dai::OpenVINO::Blob getBlobWithNShaves(int numShaves);
 
        private:
         // A header in the superblob containing metadata about the blob and patches
-        struct SuperblobHeader {
+        struct SuperBlobHeader {
             static constexpr size_t HEADER_SIZE = 1 * sizeof(uint64_t) + NUMBER_OF_PATCHES * sizeof(uint64_t);
 
-            static SuperblobHeader fromData(const std::vector<uint8_t>& data);
+            static SuperBlobHeader fromData(const std::vector<uint8_t>& data);
 
             int64_t blobSize;
             std::vector<int64_t> patchSizes;
         };
 
-        // Read the superblob file into memory
-        std::vector<uint8_t> readSuperblobFile(const std::string& path);
+        // Read the SuperBlob file into memory
+        std::vector<uint8_t> readSuperBlobFile(const std::string& path);
 
         // Get a pointer to the first byte of the blob data
         const uint8_t* getBlobDataPointer();
@@ -98,12 +98,12 @@ class OpenVINO {
         int64_t getBlobDataSize();
 
         // Get a pointer to the first byte of the patch data for a specific number of shaves
-        const uint8_t* getPatchDataPointer(int nShaves);
+        const uint8_t* getPatchDataPointer(int numShaves);
 
         // Get the size in bytes of the patch data for a specific number of shaves
-        int64_t getPatchDataSize(int nShaves);
+        int64_t getPatchDataSize(int numShaves);
 
-        SuperblobHeader header;
+        SuperBlobHeader header;
         std::vector<uint8_t> data;
     };
 

--- a/src/openvino/OpenVINO.cpp
+++ b/src/openvino/OpenVINO.cpp
@@ -90,14 +90,6 @@ OpenVINO::Superblob::Superblob(const std::string& pathToSuperblobFile) {
     header = SuperblobHeader::fromData(data);
 }
 
-std::vector<uint8_t> OpenVINO::Superblob::readSuperblobFile(const std::string& path) {
-    std::ifstream file(path, std::ios::binary);
-    if(!file.is_open()) {
-        throw std::runtime_error("Cannot open file: " + path);
-    }
-    return std::vector<uint8_t>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
-}
-
 dai::OpenVINO::Blob OpenVINO::Superblob::getBlobWithNShaves(int nShaves) {
     if(nShaves < 1 || nShaves > static_cast<int>(OpenVINO::Superblob::NUMBER_OF_PATCHES)) {
         throw std::runtime_error("Invalid number of shaves: " + std::to_string(nShaves) + " (expected 1 to "
@@ -133,6 +125,18 @@ dai::OpenVINO::Blob OpenVINO::Superblob::getBlobWithNShaves(int nShaves) {
     // Convert to OpenVINO Blob
     dai::OpenVINO::Blob patchedBlob(patchedBlobData);
     return patchedBlob;
+}
+
+std::vector<uint8_t> OpenVINO::Superblob::readSuperblobFile(const std::string& path) {
+    // Make sure file exists before opening it
+    if(!std::filesystem::exists(path)) throw std::runtime_error("File does not exist: " + path);
+
+    // Open file and read bytes
+    std::ifstream file(path, std::ios::binary);
+    if(!file.is_open()) {
+        throw std::runtime_error("Cannot open file: " + path);
+    }
+    return std::vector<uint8_t>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
 }
 
 OpenVINO::Superblob::SuperblobHeader OpenVINO::Superblob::SuperblobHeader::fromData(const std::vector<uint8_t>& data) {

--- a/src/openvino/OpenVINO.cpp
+++ b/src/openvino/OpenVINO.cpp
@@ -85,15 +85,15 @@ static uint64_t readInt64(const uint8_t* data) {
     return bigEndianToHost(value);
 }
 
-OpenVINO::Superblob::Superblob(const std::string& pathToSuperblobFile) {
-    data = readSuperblobFile(pathToSuperblobFile);
-    header = SuperblobHeader::fromData(data);
+OpenVINO::SuperBlob::SuperBlob(const std::string& pathToSuperBlobFile) {
+    data = readSuperBlobFile(pathToSuperBlobFile);
+    header = SuperBlobHeader::fromData(data);
 }
 
-dai::OpenVINO::Blob OpenVINO::Superblob::getBlobWithNShaves(int nShaves) {
-    if(nShaves < 1 || nShaves > static_cast<int>(OpenVINO::Superblob::NUMBER_OF_PATCHES)) {
-        throw std::runtime_error("Invalid number of shaves: " + std::to_string(nShaves) + " (expected 1 to "
-                                 + std::to_string(OpenVINO::Superblob::NUMBER_OF_PATCHES) + ")");
+dai::OpenVINO::Blob OpenVINO::SuperBlob::getBlobWithNShaves(int numShaves) {
+    if(numShaves < 1 || numShaves > static_cast<int>(OpenVINO::SuperBlob::NUMBER_OF_PATCHES)) {
+        throw std::runtime_error("Invalid number of shaves: " + std::to_string(numShaves) + " (expected 1 to "
+                                 + std::to_string(OpenVINO::SuperBlob::NUMBER_OF_PATCHES) + ")");
     }
 
     // Load main blob data
@@ -101,8 +101,8 @@ dai::OpenVINO::Blob OpenVINO::Superblob::getBlobWithNShaves(int nShaves) {
     int64_t blobSize = getBlobDataSize();
 
     // Load blob patch
-    const uint8_t* patchData = getPatchDataPointer(nShaves);
-    int64_t patchSize = getPatchDataSize(nShaves);
+    const uint8_t* patchData = getPatchDataPointer(numShaves);
+    int64_t patchSize = getPatchDataSize(numShaves);
 
     // Prepare patched blob data
     std::vector<uint8_t> patchedBlobData;
@@ -127,7 +127,7 @@ dai::OpenVINO::Blob OpenVINO::Superblob::getBlobWithNShaves(int nShaves) {
     return patchedBlob;
 }
 
-std::vector<uint8_t> OpenVINO::Superblob::readSuperblobFile(const std::string& path) {
+std::vector<uint8_t> OpenVINO::SuperBlob::readSuperBlobFile(const std::string& path) {
     // Make sure file exists before opening it
     if(!std::filesystem::exists(path)) throw std::runtime_error("File does not exist: " + path);
 
@@ -139,37 +139,37 @@ std::vector<uint8_t> OpenVINO::Superblob::readSuperblobFile(const std::string& p
     return std::vector<uint8_t>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
 }
 
-OpenVINO::Superblob::SuperblobHeader OpenVINO::Superblob::SuperblobHeader::fromData(const std::vector<uint8_t>& data) {
-    SuperblobHeader header;
+OpenVINO::SuperBlob::SuperBlobHeader OpenVINO::SuperBlob::SuperBlobHeader::fromData(const std::vector<uint8_t>& data) {
+    SuperBlobHeader header;
     const uint8_t* ptr = data.data();
     header.blobSize = readInt64(ptr);
     ptr += sizeof(uint64_t);
 
-    header.patchSizes.resize(OpenVINO::Superblob::NUMBER_OF_PATCHES);
-    for(size_t i = 0; i < OpenVINO::Superblob::NUMBER_OF_PATCHES; ++i) {
+    header.patchSizes.resize(OpenVINO::SuperBlob::NUMBER_OF_PATCHES);
+    for(size_t i = 0; i < OpenVINO::SuperBlob::NUMBER_OF_PATCHES; ++i) {
         header.patchSizes[i] = readInt64(ptr);
         ptr += sizeof(uint64_t);
     }
     return header;
 }
 
-const uint8_t* OpenVINO::Superblob::getBlobDataPointer() {
-    const uint64_t offset = SuperblobHeader::HEADER_SIZE;
+const uint8_t* OpenVINO::SuperBlob::getBlobDataPointer() {
+    const uint64_t offset = SuperBlobHeader::HEADER_SIZE;
     return data.data() + offset;
 }
 
-int64_t OpenVINO::Superblob::getBlobDataSize() {
+int64_t OpenVINO::SuperBlob::getBlobDataSize() {
     return header.blobSize;
 }
 
-const uint8_t* OpenVINO::Superblob::getPatchDataPointer(int nShaves) {
+const uint8_t* OpenVINO::SuperBlob::getPatchDataPointer(int numShaves) {
     const uint64_t offset =
-        SuperblobHeader::HEADER_SIZE + header.blobSize + std::accumulate(header.patchSizes.begin(), header.patchSizes.begin() + nShaves - 1, 0);
+        SuperBlobHeader::HEADER_SIZE + header.blobSize + std::accumulate(header.patchSizes.begin(), header.patchSizes.begin() + numShaves - 1, 0);
     return data.data() + offset;
 }
 
-int64_t OpenVINO::Superblob::getPatchDataSize(int nShaves) {
-    return header.patchSizes[nShaves - 1];
+int64_t OpenVINO::SuperBlob::getPatchDataSize(int numShaves) {
+    return header.patchSizes[numShaves - 1];
 }
 
 std::vector<OpenVINO::Version> OpenVINO::getVersions() {


### PR DESCRIPTION
This PR adds support for `superblobs` = blobs compiled for all number of shaves combined into a single binary file.

Once constructed (the only argument to the constructor is a path to a `.superblob` file), a regular `OpenVINO::Blob` struct may be generated by calling `getBlobWithNShaves(numShaves)`, whose output is a regular blob compiled for  `numShaves` shaves.

The relevant clickup task is [here](https://app.clickup.com/t/86by234am)