### PR TITLE
Support compilation against spdlog 1.14 with fmt 10

### DIFF
--- a/src/device/DataQueue.cpp
+++ b/src/device/DataQueue.cpp
@@ -18,6 +18,7 @@
 
 // libraries
 #include "utility/Logging.hpp"
+#include "utility/spdlog-fmt.hpp"
 
 // Additions
 #include "spdlog/fmt/bin_to_hex.h"

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -27,6 +27,7 @@
 #include "utility/Initialization.hpp"
 #include "utility/PimplImpl.hpp"
 #include "utility/Resources.hpp"
+#include "utility/spdlog-fmt.hpp"
 
 // libraries
 #include "XLink/XLink.h"

--- a/src/pipeline/datatype/StreamMessageParser.cpp
+++ b/src/pipeline/datatype/StreamMessageParser.cpp
@@ -9,6 +9,7 @@
 #include <spdlog/spdlog.h>
 
 #include "utility/Logging.hpp"
+#include "utility/spdlog-fmt.hpp"
 
 // project
 #include "depthai/pipeline/datatype/ADatatype.hpp"

--- a/src/utility/spdlog-fmt.hpp
+++ b/src/utility/spdlog-fmt.hpp
@@ -4,6 +4,13 @@
 
 #include "depthai/utility/Path.hpp"
 
+#if FMT_VERSION >= 100000
+#include <spdlog/fmt/ostr.h>
+
+#include "depthai/common/CameraBoardSocket.hpp"
+#include "depthai-shared/datatype/DatatypeEnum.hpp"
+#endif
+
 namespace dai {
 namespace utility {
 static constexpr char path_convert_err[] = "<Unicode path not convertible>";
@@ -25,3 +32,15 @@ struct fmt::formatter<dai::Path> : formatter<std::string> {
         return formatter<std::string>::format(output, ctx);
     }
 };
+
+#if FMT_VERSION >= 100000
+template <>
+struct fmt::formatter<dai::CameraBoardSocket> : ostream_formatter {};
+
+template <>
+struct fmt::formatter<dai::DatatypeEnum> : fmt::formatter<std::string> {
+    auto format(dai::DatatypeEnum my, format_context& ctx) const -> decltype(ctx.out()) {
+        return fmt::format_to(ctx.out(), "{}", static_cast<int32_t>(my));
+    }
+};
+#endif


### PR DESCRIPTION
I need to integrate depthai-core with a codebase that already uses a recent version of spdlog 1.14 with fmt 10, but trying to patch depthai-core to use an external spdlog 1.14 using fmt 10 (using the patch in https://github.com/luxonis/depthai-core/issues/1021#issuecomment-2159320367), resulted in the following errors:

<details>

<summary>Click to see errors</summary>

~~~
(idjlluxonisenv) D:\src\depthaicorestint1\depthai-core\build2>ninja -j1
[1/119] Building CXX object CMakeFiles\depthai-core.dir\src\device\DeviceBase.cpp.obj
FAILED: CMakeFiles/depthai-core.dir/src/device/DeviceBase.cpp.obj
C:\PROGRA~2\MICROS~4\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe  /nologo /TP -DBACKWARD_HAS_BACKTRACE=0 -DBACKWARD_HAS_BACKTRACE_SYMBOL=0 -DBACKWARD_HAS_BFD=0 -DBACKWARD_HAS_DW=0 -DBACKWARD_HAS_DWARF=0 -DBACKWARD_HAS_LIBUNWIND=0 -DBACKWARD_HAS_UNWIND=1 -DCURL_STATICLIB -DDEPTHAI_BOOTLOADER_VERSION=\"0.0.28\" -DDEPTHAI_DEVICE_VERSION=\"9822af7082d67b87c5307b9c37ec7f6ab8e1bbce\" -DDEPTHAI_ENABLE_BACKWARD -DDEPTHAI_ENABLE_CURL -DDEPTHAI_ENABLE_LIBUSB -DDEPTHAI_PATCH_ONLY_MODE -DDEPTHAI_RESOURCE_COMPILED_BINARIES -DDEPTHAI_TARGET_CORE -DFMT_SHARED -DJSON_USE_IMPLICIT_CONVERSIONS=1 -DLIBARCHIVE_STATIC -DLZMA_API_STATIC -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -Ddepthai_core_EXPORTS -ID:\miniforge3\envs\idjlluxonisenv\Library\include\eigen3 -ID:\src\depthaicorestint1\depthai-core\include -ID:\src\depthaicorestint1\depthai-core\shared\depthai-shared\include -ID:\src\depthaicorestint1\depthai-core\shared\depthai-bootloader-shared\include -ID:\src\depthaicorestint1\depthai-core\include\depthai -ID:\src\depthaicorestint1\depthai-core\src -ID:\src\depthaicorestint1\depthai-core\shared\depthai-shared\src -ID:\src\depthaicorestint1\depthai-core\shared\depthai-bootloader-shared\src -ID:\miniforge3\envs\idjlluxonisenv\Library\include\pcl-1.14 -ID:\miniforge3\envs\idjlluxonisenv\Library\include\vtk-9.3 -ID:\miniforge3\envs\idjlluxonisenv\Library\include\freetype2 -external:ID:\src\depthaicorestint1\depthai-core\shared\depthai-shared\3rdparty -external:ID:\miniforge3\envs\idjlluxonisenv\Library\include -external:IC:\Users\straversaro\.hunter\_Base\16cc954\48b6799\a274529\Install\include -external:ID:\src\depthaicorestint1\depthai-core\build2\_cmrc\include -external:IC:\Users\straversaro\.hunter\_Base\16cc954\48b6799\a274529\Install\lib\backward -external:W0 /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MD /O2 /Ob2 /DNDEBUG -std:c++14 -DNOMINMAX -DWIN32_LEAN_AND_MEAN /wd4251 /wd4275 /utf-8 /showIncludes /FoCMakeFiles\depthai-core.dir\src\device\DeviceBase.cpp.obj /FdCMakeFiles\depthai-core.dir\ /FS -c D:\src\depthaicorestint1\depthai-core\src\device\DeviceBase.cpp
D:\src\depthaicorestint1\depthai-core\src\device\DeviceBase.cpp(528): warning C4244: 'return': conversion from '_Rep' to 'unsigned int', possible loss of data
        with
        [
            _Rep=__int64
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\fmt/core.h(1604): error C2338: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
D:\miniforge3\envs\idjlluxonisenv\Library\include\fmt/core.h(1842): note: see reference to function template instantiation 'fmt::v10::detail::value<Context> fmt::v10::detail::make_arg<true,Context,TargetType,0>(T &)' being compiled
        with
        [
            Context=fmt::v10::format_context,
            TargetType=dai::CameraBoardSocket,
            T=dai::CameraBoardSocket
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\fmt/core.h(1860): note: see reference to function template instantiation 'fmt::v10::format_arg_store<fmt::v10::format_context,dai::CameraBoardSocket,dai::CameraBoardSocket>::format_arg_store<TargetType,TargetType>(TargetType &,TargetType &)' being compiled
        with
        [
            TargetType=dai::CameraBoardSocket
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\fmt/core.h(1860): note: see reference to function template instantiation 'fmt::v10::format_arg_store<fmt::v10::format_context,dai::CameraBoardSocket,dai::CameraBoardSocket>::format_arg_store<TargetType,TargetType>(TargetType &,TargetType &)' being compiled
        with
        [
            TargetType=dai::CameraBoardSocket
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\spdlog/logger.h(328): note: see reference to function template instantiation 'fmt::v10::format_arg_store<fmt::v10::format_context,dai::CameraBoardSocket,dai::CameraBoardSocket> fmt::v10::make_format_args<fmt::v10::format_context,TargetType,TargetType>(TargetType &,TargetType &)' being compiled
        with
        [
            TargetType=dai::CameraBoardSocket
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\spdlog/logger.h(80): note: see reference to function template instantiation 'void spdlog::logger::log_<TargetType&,TargetType&>(spdlog::source_loc,spdlog::level::level_enum,spdlog::string_view_t,TargetType &,TargetType &)' being compiled
        with
        [
            TargetType=dai::CameraBoardSocket
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\spdlog/logger.h(85): note: see reference to function template instantiation 'void spdlog::logger::log<TargetType&,TargetType&>(spdlog::source_loc,spdlog::level::level_enum,fmt::v10::basic_format_string<char,const _Ty1 &,const _Ty1 &>,TargetType &,TargetType &)' being compiled
        with
        [
            TargetType=dai::CameraBoardSocket,
            _Ty1=const dai::CameraBoardSocket
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\spdlog/logger.h(135): note: see reference to function template instantiation 'void spdlog::logger::log<TargetType&,TargetType&>(spdlog::level::level_enum,fmt::v10::basic_format_string<char,const _Ty1 &,const _Ty1 &>,TargetType &,TargetType &)' being compiled
        with
        [
            TargetType=dai::CameraBoardSocket,
            _Ty1=const dai::CameraBoardSocket
        ]
D:\src\depthaicorestint1\depthai-core\src\device\DeviceBase.cpp(1070): note: see reference to function template instantiation 'void spdlog::logger::debug<const _Ty1&,const _Ty1&>(fmt::v10::basic_format_string<char,const _Ty1 &,const _Ty1 &>,const _Ty1 &,const _Ty1 &)' being compiled
        with
        [
            _Ty1=const dai::CameraBoardSocket
        ]
ninja: build stopped: subcommand failed.
~~~

and 

~~~
[1/122] Building CXX object CMakeFiles\depthai-core.dir\src\device\DataQueue.cpp.obj
FAILED: CMakeFiles/depthai-core.dir/src/device/DataQueue.cpp.obj
C:\PROGRA~2\MICROS~4\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe  /nologo /TP -DBACKWARD_HAS_BACKTRACE=0 -DBACKWARD_HAS_BACKTRACE_SYMBOL=0 -DBACKWARD_HAS_BFD=0 -DBACKWARD_HAS_DW=0 -DBACKWARD_HAS_DWARF=0 -DBACKWARD_HAS_LIBUNWIND=0 -DBACKWARD_HAS_UNWIND=1 -DCURL_STATICLIB -DDEPTHAI_BOOTLOADER_VERSION=\"0.0.28\" -DDEPTHAI_DEVICE_VERSION=\"9822af7082d67b87c5307b9c37ec7f6ab8e1bbce\" -DDEPTHAI_ENABLE_BACKWARD -DDEPTHAI_ENABLE_CURL -DDEPTHAI_ENABLE_LIBUSB -DDEPTHAI_PATCH_ONLY_MODE -DDEPTHAI_RESOURCE_COMPILED_BINARIES -DDEPTHAI_TARGET_CORE -DFMT_SHARED -DJSON_USE_IMPLICIT_CONVERSIONS=1 -DLIBARCHIVE_STATIC -DLZMA_API_STATIC -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -Ddepthai_core_EXPORTS -ID:\miniforge3\envs\idjlluxonisenv\Library\include\eigen3 -ID:\src\depthaicorestint1\depthai-core\include -ID:\src\depthaicorestint1\depthai-core\shared\depthai-shared\include -ID:\src\depthaicorestint1\depthai-core\shared\depthai-bootloader-shared\include -ID:\src\depthaicorestint1\depthai-core\include\depthai -ID:\src\depthaicorestint1\depthai-core\src -ID:\src\depthaicorestint1\depthai-core\shared\depthai-shared\src -ID:\src\depthaicorestint1\depthai-core\shared\depthai-bootloader-shared\src -ID:\miniforge3\envs\idjlluxonisenv\Library\include\pcl-1.14 -ID:\miniforge3\envs\idjlluxonisenv\Library\include\vtk-9.3 -ID:\miniforge3\envs\idjlluxonisenv\Library\include\freetype2 -external:ID:\src\depthaicorestint1\depthai-core\shared\depthai-shared\3rdparty -external:ID:\miniforge3\envs\idjlluxonisenv\Library\include -external:IC:\Users\straversaro\.hunter\_Base\16cc954\48b6799\a274529\Install\include -external:ID:\src\depthaicorestint1\depthai-core\build2\_cmrc\include -external:IC:\Users\straversaro\.hunter\_Base\16cc954\48b6799\a274529\Install\lib\backward -external:W0 /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MD /O2 /Ob2 /DNDEBUG -std:c++14 -DNOMINMAX -DWIN32_LEAN_AND_MEAN /wd4251 /wd4275 /utf-8 /showIncludes /FoCMakeFiles\depthai-core.dir\src\device\DataQueue.cpp.obj /FdCMakeFiles\depthai-core.dir\ /FS -c D:\src\depthaicorestint1\depthai-core\src\device\DataQueue.cpp
D:\src\depthaicorestint1\depthai-core\src\device\DataQueue.cpp(48): warning C4244: 'initializing': conversion from 'int64_t' to 'unsigned int', possible loss of data
D:\miniforge3\envs\idjlluxonisenv\Library\include\fmt/core.h(1604): error C2338: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
D:\miniforge3\envs\idjlluxonisenv\Library\include\fmt/core.h(1842): note: see reference to function template instantiation 'fmt::v10::detail::value<Context> fmt::v10::detail::make_arg<true,Context,dai::DatatypeEnum,0>(T &)' being compiled
        with
        [
            Context=fmt::v10::format_context,
            T=dai::DatatypeEnum
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\fmt/core.h(1860): note: see reference to function template instantiation 'fmt::v10::format_arg_store<fmt::v10::format_context,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>>::format_arg_store<const std::string,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>>(const std::string &,std::chrono::duration<__int64,std::micro> &,unsigned __int64 &,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>> &)' being compiled
        with
        [
            _Ty=uint8_t
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\fmt/core.h(1860): note: see reference to function template instantiation 'fmt::v10::format_arg_store<fmt::v10::format_context,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>>::format_arg_store<const std::string,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>>(const std::string &,std::chrono::duration<__int64,std::micro> &,unsigned __int64 &,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>> &)' being compiled
        with
        [
            _Ty=uint8_t
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\spdlog/logger.h(328): note: see reference to function template instantiation 'fmt::v10::format_arg_store<fmt::v10::format_context,std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>> fmt::v10::make_format_args<fmt::v10::format_context,const std::string,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>>(const std::string &,std::chrono::duration<__int64,std::micro> &,unsigned __int64 &,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>> &)' being compiled
        with
        [
            _Ty=uint8_t
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\spdlog/logger.h(80): note: see reference to function template instantiation 'void spdlog::logger::log_<const std::string&,_Ty,unsigned __int64,dai::DatatypeEnum&,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>>>(spdlog::source_loc,spdlog::level::level_enum,spdlog::string_view_t,const std::string &,_Ty &&,unsigned __int64 &&,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>> &&)' being compiled
        with
        [
            _Ty=std::chrono::microseconds
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\spdlog/logger.h(85): note: see reference to function template instantiation 'void spdlog::logger::log<const std::string&,_Ty,unsigned __int64,dai::DatatypeEnum&,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>>>(spdlog::source_loc,spdlog::level::level_enum,fmt::v10::basic_format_string<char,const std::string &,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>>>,const std::string &,_Ty &&,unsigned __int64 &&,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>> &&)' being compiled
        with
        [
            _Ty=std::chrono::microseconds
        ]
D:\miniforge3\envs\idjlluxonisenv\Library\include\spdlog/logger.h(130): note: see reference to function template instantiation 'void spdlog::logger::log<const std::string&,_Ty,unsigned __int64,dai::DatatypeEnum&,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>>>(spdlog::level::level_enum,fmt::v10::basic_format_string<char,const std::string &,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>>>,const std::string &,_Ty &&,unsigned __int64 &&,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>> &&)' being compiled
        with
        [
            _Ty=std::chrono::microseconds
        ]
D:\src\depthaicorestint1\depthai-core\src\utility/Logging.hpp(72): note: see reference to function template instantiation 'void spdlog::logger::trace<const std::string&,_Ty,unsigned __int64,dai::DatatypeEnum&,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>>>(fmt::v10::basic_format_string<char,const std::string &,std::chrono::duration<__int64,std::micro>,unsigned __int64,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>>>,const std::string &,_Ty &&,unsigned __int64 &&,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<unsigned char>>>> &&)' being compiled
        with
        [
            _Ty=std::chrono::microseconds
        ]
D:\src\depthaicorestint1\depthai-core\src\device\DataQueue.cpp(238): note: see reference to function template instantiation 'void dai::logger::trace<char[100],const std::string&,_To,unsigned __int64,dai::DatatypeEnum&,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>>(const FormatString (&),const std::string &,_To &&,unsigned __int64 &&,dai::DatatypeEnum &,spdlog::details::dump_info<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>> &&)' being compiled
        with
        [
            _To=std::chrono::microseconds,
            _Ty=uint8_t,
            FormatString=char [100]
        ]
ninja: build stopped: subcommand failed.
~~~

</details>

I was able to get the project to compile (and run, tested on a OAD-D SR) with the modification proposed in this PR. The modifications proposed are backward compatible (thanks to the use of `#if FMT_VERSION >= 100000` blocks, that ensure that the additional code and include are only used if the fmt version is higher than 10.0.0 .

While this modifications can only be tested with a patch like https://github.com/luxonis/depthai-core/issues/1021#issuecomment-2159320367 or disabling hunter, I still think it could be helpful to have the change integrated in the main branch, as not using hunter seems a recurring need in depthai-core users (see https://github.com/luxonis/depthai-core/issues/1021, https://github.com/luxonis/depthai-core/issues/411, https://github.com/luxonis/depthai-core/issues/447, https://github.com/luxonis/depthai-core/issues/468).