### PR TITLE
Support using non-hunter version of bzip2, zlib and libarchive if HUNTER_ENABLED is OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,8 @@ endif()
 
 # Include project dependencies
 set(DEPTHAI_DEPENDENCY_INCLUDE "" CACHE FILEPATH "Optional cmake file to append to dependency processing, e.g. additional find_package()")
+# Set as it is used in depthaiDependencies
+set(DEPTHAI_HUNTER_ENABLED ${HUNTER_ENABLED})
 include(depthaiDependencies)
 
 # Add threads preference
@@ -461,6 +463,32 @@ if(DEPTHAI_CLANG_FORMAT)
     target_clangformat_setup(${TARGET_CORE_NAME} "${header_dirs}")
 endif()
 
+# Some libraries have target names that change between the hunter/luxonis fork
+# and the upstream version. If HUNTER_ENABLED is ON we want to force the
+# use of the hunter/luxonis fork target, otherwise if HUNTER_ENABLED is OFF we
+# fallback to the upstream target name if the hunter/luxonis fork one is not available
+if(HUNTER_ENABLED)
+    set(DEPTHAI_BZIP2_TARGET "BZip2::bz2")
+    set(DEPTHAI_ARCHIVE_TARGET "archive_static")
+    set(DEPTHAI_ZLIB_TARGET "ZLIB::zlib")
+else()
+    if(TARGET BZip2::bz2)
+        set(DEPTHAI_BZIP2_TARGET "BZip2::bz2")
+    else()
+        set(DEPTHAI_BZIP2_TARGET "BZip2::BZip2")
+    endif()
+    if(TARGET archive_static)
+        set(DEPTHAI_ARCHIVE_TARGET "archive_static")
+    else()
+        set(DEPTHAI_ARCHIVE_TARGET "LibArchive::LibArchive")
+    endif()
+    if(TARGET ZLIB::zlib)
+        set(DEPTHAI_ZLIB_TARGET "ZLIB::zlib")
+    else()
+        set(DEPTHAI_ZLIB_TARGET "ZLIB::ZLIB")
+    endif()
+endif()
+
 # link libraries
 target_link_libraries(${TARGET_CORE_NAME}
     PUBLIC
@@ -471,11 +499,11 @@ target_link_libraries(${TARGET_CORE_NAME}
     PRIVATE
         XLink
         Threads::Threads
-        BZip2::bz2
+        ${DEPTHAI_BZIP2_TARGET}
         FP16::fp16
-        archive_static
+        ${DEPTHAI_ARCHIVE_TARGET}
         spdlog::spdlog
-        ZLIB::zlib
+        ${DEPTHAI_ZLIB_TARGET}
         ghcFilesystem::ghc_filesystem
 )
 

--- a/cmake/depthaiConfig.cmake.in
+++ b/cmake/depthaiConfig.cmake.in
@@ -6,6 +6,9 @@ set(DEPTHAI_ENABLE_BACKWARD @DEPTHAI_ENABLE_BACKWARD@)
 
 set(DEPTHAI_ENABLE_CURL @DEPTHAI_ENABLE_CURL@)
 
+# Get if the library was built with Hunter or not
+set(DEPTHAI_HUNTER_ENABLED @HUNTER_ENABLED@)
+
 # Specify that this is config mode (Called by find_package)
 set(CONFIG_MODE TRUE)
 

--- a/cmake/depthaiDependencies.cmake
+++ b/cmake/depthaiDependencies.cmake
@@ -36,17 +36,44 @@ endif()
 # If library was build as static, find all dependencies
 if(NOT CONFIG_MODE OR (CONFIG_MODE AND NOT DEPTHAI_SHARED_LIBS))
 
-    # BZip2 (for bspatch)
-    find_package(BZip2 ${_QUIET} CONFIG REQUIRED)
-
     # FP16 for conversions
     find_package(FP16 ${_QUIET} CONFIG REQUIRED)
 
-    # libarchive for firmware packages
-    find_package(archive_static ${_QUIET} CONFIG REQUIRED)
-    find_package(lzma ${_QUIET} CONFIG REQUIRED)
-    # ZLIB for compressing Apps
-    find_package(ZLIB CONFIG REQUIRED)
+    # Some packages have different package names depending on which
+    # version is installed, if we are using hunter we want to make sure to
+    # use the hunter/luxonis fork, otherwise we try using the hunter/luxonis 
+    # fork and if that can't be found we found the regular version
+    if(DEPTHAI_HUNTER_ENABLED)
+        # BZip2 (for bspatch)
+        find_package(BZip2 ${_QUIET} CONFIG REQUIRED)
+
+        # libarchive for firmware packages
+        find_package(archive_static ${_QUIET} CONFIG REQUIRED)
+        find_package(lzma ${_QUIET} CONFIG REQUIRED)
+
+        # ZLIB for compressing Apps
+        find_package(ZLIB CONFIG REQUIRED)
+    else()
+        # BZip2 (for bspatch)
+        find_package(BZip2 ${_QUIET} CONFIG)
+        if(NOT BZip2_FOUND)
+            find_package(BZip2 ${_QUIET} REQUIRED)
+        endif()
+
+        # libarchive for firmware packages
+        find_package(archive_static ${_QUIET} CONFIG)
+        if(archive_static_FOUND)
+            find_package(lzma ${_QUIET} CONFIG REQUIRED)
+        else()
+            find_package(LibArchive ${_QUIET} REQUIRED)
+        endif()
+
+        # ZLIB for compressing Apps
+        find_package(ZLIB CONFIG)
+        if(NOT ZLIB_FOUND)
+            find_package(ZLIB REQUIRED)
+        endif()
+    endif()
 
     # spdlog for library and device logging
     find_package(spdlog ${_QUIET} CONFIG REQUIRED)


### PR DESCRIPTION
Introduction: among our modifications to support the HUNTER_ENABLED=OFF build (see also https://github.com/luxonis/depthai-core/pull/1048 and https://github.com/luxonis/depthai-core/pull/1049) this is probably the one that complicates the code the most, so I would understand if you prefer to not merge such modification. However, I think it was worth to isolate the change and made it available in the form of a PR.

When setting `HUNTER_ENABLED=OFF`, one can install all the dependencies via the usual CMake workflow in a directory that is added to `CMAKE_PREFIX_PATH`, and then build depthai-core . However, there are three packages that are installed in different ways depending of weather the hunter/luxonis fork is used, or if the upstream version is used. 

The three packages are:

**ZLIB**: The hunter/luxonis `ZLIB` is found via `find_package(ZLIB CONFIG)` and it defines the `ZLIB::zlib` imported target, while the regular ZLIB does not install any CMake config file, but it can be found by CMake's upstream `FindZLIB.cmake` that defines the `ZLIB::ZLIB` imported target.


**BZip2**: The hunter/luxonis `BZip2` is found via `find_package(BZip2 CONFIG)` and it defines the `BZip2::bz2` imported target, while the regular BZip2 does not install any CMake config file, but it can be found by CMake's upstream `FindBZip2.cmake` that defines the `BZip2::BZip2` imported target.

**libarchive**: The hunter/luxonis `libarchive` is found via `find_package(archive_static CONFIG)` and it defines the `archive_static` imported target, while the regular libarchivedoes not install any CMake config file, but it can be found by CMake's upstream `FindLibArchive.cmake` that defines the `LibArchive::LibArchive` imported target.

If you have a project that is already using the upstream version, in general you would like for depthai-core to also use the upstream version.

To achieve this, this PR modifies the logic if `HUNTER_ENABLED` is set to `OFF`. In that case, first the hunter/luxonis package names and target are tested, and if they can be found they are used, while if they do not exist the logic fallbacks to the upstream package names/target names.

If  `HUNTER_ENABLED` is set to `ON`, the PR does not change the existing logic.
