### PR TITLE
Fix setNNArchive method

### DIFF
--- a/bindings/python/src/pipeline/node/DetectionNetworkBindings.cpp
+++ b/bindings/python/src/pipeline/node/DetectionNetworkBindings.cpp
@@ -74,7 +74,8 @@ void bind_detectionnetwork(pybind11::module& m, void* pCallstack) {
              py::arg("numNCEPerThread"),
              DOC(dai, node, DetectionNetwork, setNumNCEPerInferenceThread))
         .def("getNumInferenceThreads", &DetectionNetwork::getNumInferenceThreads, DOC(dai, node, DetectionNetwork, getNumInferenceThreads))
-        .def("setNNArchive", &DetectionNetwork::setNNArchive, DOC(dai, node, DetectionNetwork, setNNArchive))
+        .def("setNNArchive", py::overload_cast<const NNArchive&>(&DetectionNetwork::setNNArchive), py::arg("archive"), DOC(dai, node, DetectionNetwork, setNNArchive))
+        .def("setNNArchive", py::overload_cast<const NNArchive&, int>(&DetectionNetwork::setNNArchive), py::arg("archive"), py::arg("numShaves"), DOC(dai, node, DetectionNetwork, setNNArchive))
         .def("setBlob", py::overload_cast<dai::OpenVINO::Blob>(&DetectionNetwork::setBlob), py::arg("blob"), DOC(dai, node, DetectionNetwork, setBlob))
         .def("setBlob", py::overload_cast<const dai::Path&>(&DetectionNetwork::setBlob), py::arg("path"), DOC(dai, node, DetectionNetwork, setBlob, 2))
         .def("setModelPath",

--- a/bindings/python/src/pipeline/node/SpatialDetectionNetworkBindings.cpp
+++ b/bindings/python/src/pipeline/node/SpatialDetectionNetworkBindings.cpp
@@ -52,7 +52,8 @@ void bind_spatialdetectionnetwork(pybind11::module& m, void* pCallstack){
              py::arg("numNCEPerThread"),
              DOC(dai, node, SpatialDetectionNetwork, setNumNCEPerInferenceThread))
         .def("getNumInferenceThreads", &SpatialDetectionNetwork::getNumInferenceThreads, DOC(dai, node, SpatialDetectionNetwork, getNumInferenceThreads))
-        .def("setNNArchive", &SpatialDetectionNetwork::setNNArchive, DOC(dai, node, SpatialDetectionNetwork, setNNArchive))
+        .def("setNNArchive", py::overload_cast<const NNArchive&>(&SpatialDetectionNetwork::setNNArchive), py::arg("archive"), DOC(dai, node, SpatialDetectionNetwork, setNNArchive))
+        .def("setNNArchive", py::overload_cast<const NNArchive&, int>(&SpatialDetectionNetwork::setNNArchive), py::arg("archive"), py::arg("numShaves"), DOC(dai, node, SpatialDetectionNetwork, setNNArchive))
         .def("setBlob",
              py::overload_cast<dai::OpenVINO::Blob>(&SpatialDetectionNetwork::setBlob),
              py::arg("blob"),

--- a/examples/python/RVC2/NNArchive/nn_archive.py
+++ b/examples/python/RVC2/NNArchive/nn_archive.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python3
 
-from pathlib import Path
-import sys
 import cv2
 import depthai as dai
 import numpy as np
 import time
 
 # Get argument first
-modelDescription = dai.NNModelDescription(
-    modelSlug="yolov6n-r2-288x512-8shave-blob", platform="RVC2"
-)
+modelDescription = dai.NNModelDescription(modelSlug="yolov6n", platform="RVC2")
 archivePath = dai.getModelFromZoo(modelDescription, useCached=True)
 
 # Create pipeline
@@ -25,11 +21,18 @@ with dai.Pipeline() as pipeline:
     nnArchive = dai.NNArchive(archivePath)
     h, w = nnArchive.getConfig().getConfigV1().model.inputs[0].shape[-2:]
     camRgb.setPreviewSize(w, h)
-    print(h, w)
     detectionNetwork = pipeline.create(dai.node.DetectionNetwork).build(
         camRgb.preview, nnArchive
     )
     detectionNetwork.setNumInferenceThreads(2)
+
+    # If needed, you can set the NNArchive by yourself
+    # detectionNetwork.setNNArchive(nnArchive)
+
+    # If nnArchive.getArchiveType() == dai.NNArchiveType.SUPERBLOB
+    # you can specify the number of shaves
+    # detectionNetwork.setNNArchive(nnArchive, numShaves=9)
+    # When ^^^ is used and the archive type is not SUPERBLOB, an exception will be thrown
 
     qRgb = detectionNetwork.passthrough.createOutputQueue()
     qDet = detectionNetwork.out.createOutputQueue()

--- a/examples/python/RVC2/NNArchive/nn_archive_superblob.py
+++ b/examples/python/RVC2/NNArchive/nn_archive_superblob.py
@@ -11,7 +11,6 @@ modelDescription.platform = "RVC2"
 
 # Download model from zoo and load it
 archivePath = dai.getModelFromZoo(modelDescription, useCached=True)
-assert archivePath.endswith("yolov6n-r2-288x512.tar.xz")
 archive = dai.NNArchive(archivePath)
 
 # Archive knows it is a blob archive

--- a/include/depthai/pipeline/node/DetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/DetectionNetwork.hpp
@@ -56,10 +56,19 @@ class DetectionNetwork : public NodeGroup {
     Output& passthrough;
 
     /**
-     * Apply NNArchive config to this Node and load network blob into assets and use once pipeline is started.
+     * @brief Set NNArchive for this Node. If the archive's type is SUPERBLOB, use default number of shaves.
      *
+     * @param nnArchive: NNArchive to set
      */
     void setNNArchive(const NNArchive& nnArchive);
+
+    /**
+     * @brief Set NNArchive for this Node, throws if the archive's type is not SUPERBLOB
+     *
+     * @param nnArchive: NNArchive to set
+     * @param numShaves: Number of shaves to use
+     */
+    void setNNArchive(const NNArchive& nnArchive, int numShaves);
 
     // Specify local filesystem path to load the blob (which gets loaded at loadAssets)
     /**
@@ -150,6 +159,10 @@ class DetectionNetwork : public NodeGroup {
     std::optional<std::vector<std::string>> getClasses() const;
 
    private:
+    void setNNArchiveBlob(const NNArchive& nnArchive);
+    void setNNArchiveSuperblob(const NNArchive& nnArchive, int numShaves);
+    void setNNArchiveOther(const NNArchive& nnArchive);
+
     class Impl;
     Pimpl<Impl> pimpl;
 

--- a/include/depthai/pipeline/node/DetectionParser.hpp
+++ b/include/depthai/pipeline/node/DetectionParser.hpp
@@ -7,7 +7,10 @@
 
 // shared
 #include <depthai/nn_archive/NNArchive.hpp>
+#include <depthai/nn_archive/NNArchiveConfig.hpp>
+#include <depthai/openvino/OpenVINO.hpp>
 #include <depthai/properties/DetectionParserProperties.hpp>
+#include <optional>
 
 namespace dai {
 namespace node {
@@ -51,9 +54,21 @@ class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, Detec
      */
     int getNumFramesPool();
 
-    std::reference_wrapper<const OpenVINO::Blob> setNNArchive(const NNArchive& nnArchive);
+    /**
+     * @brief Set NNArchive for this Node. If the archive's type is SUPERBLOB, use default number of shaves.
+     *
+     * @param nnArchive: NNArchive to set
+     */
+    void setNNArchive(const NNArchive& nnArchive);
 
-    // Specify local filesystem path to load the blob (which gets loaded at loadAssets)
+    /**
+     * @brief Set NNArchive for this Node, throws if the archive's type is not SUPERBLOB
+     *
+     * @param nnArchive: NNArchive to set
+     * @param numShaves: Number of shaves to use
+     */
+    void setNNArchive(const NNArchive& nnArchive, int numShaves);
+
     /**
      * Load network blob into assets and use once pipeline is started.
      *
@@ -137,11 +152,18 @@ class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, Detec
     /// Get Iou threshold
     float getIouThreshold() const;
 
-    const NNArchive* getNNArchive() const;
+    const NNArchiveConfig& getNNArchiveConfig() const;
 
    private:
+    void setNNArchiveBlob(const NNArchive& nnArchive);
+    void setNNArchiveSuperblob(const NNArchive& nnArchive, int numShaves);
+    void setNNArchiveOther(const NNArchive& nnArchive);
+    void setConfigAndBlob(const dai::NNArchiveConfig& config, const dai::OpenVINO::Blob& blob);
+
     std::optional<std::vector<std::string>> mClasses;
     std::optional<NNArchive> mArchive;
+
+    std::optional<NNArchiveConfig> archiveConfig;
 };
 
 }  // namespace node

--- a/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
@@ -99,7 +99,20 @@ class SpatialDetectionNetwork : public DeviceNodeCRTP<DeviceNode, SpatialDetecti
      */
     Output spatialLocationCalculatorOutput{*this, {"spatialLocationCalculatorOutput", DEFAULT_GROUP, {{{DatatypeEnum::SpatialLocationCalculatorData, false}}}}};
 
+    /**
+     * @brief Set NNArchive for this Node. If the archive's type is SUPERBLOB, use default number of shaves.
+     *
+     * @param nnArchive: NNArchive to set
+     */
     void setNNArchive(const NNArchive& nnArchive);
+
+    /**
+     * @brief Set NNArchive for this Node, throws if the archive's type is not SUPERBLOB
+     *
+     * @param nnArchive: NNArchive to set
+     * @param numShaves: Number of shaves to use
+     */
+    void setNNArchive(const NNArchive& nnArchive, int numShaves);
 
     /** Backwards compatibility interface **/
     // Specify local filesystem path to load the blob (which gets loaded at loadAssets)
@@ -220,6 +233,11 @@ class SpatialDetectionNetwork : public DeviceNodeCRTP<DeviceNode, SpatialDetecti
 
     /// Get classes labels
     std::optional<std::vector<std::string>> getClasses() const;
+
+   private:
+    void setNNArchiveBlob(const NNArchive& nnArchive);
+    void setNNArchiveSuperblob(const NNArchive& nnArchive, int numShaves);
+    void setNNArchiveOther(const NNArchive& nnArchive);
 
    protected:
     using DeviceNodeCRTP::DeviceNodeCRTP;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -378,3 +378,11 @@ dai_add_test(resolutions_test src/ondevice_tests/resolutions_test.cpp ondevice)
 
 # Serialization test
 dai_add_test(serialization_test src/onhost_tests/serialization_test.cpp ondevice)
+
+# Detection network test
+dai_add_test(detection_network_test src/ondevice_tests/pipeline/node/detection_network_test.cpp ondevice)
+target_compile_definitions(detection_network_test PRIVATE
+    BLOB_ARCHIVE_PATH="${yolo_blob_nnarchive_path}"
+    SUPERBLOB_ARCHIVE_PATH="${yolo_superblob_nnarchive_path}"
+    ONNX_ARCHIVE_PATH="${yolo_onnx_nnarchive_path}"
+)

--- a/tests/src/ondevice_tests/pipeline/node/detection_network_test.cpp
+++ b/tests/src/ondevice_tests/pipeline/node/detection_network_test.cpp
@@ -1,0 +1,47 @@
+#include <catch2/catch_all.hpp>
+#include <depthai/openvino/OpenVINO.hpp>
+
+#include "depthai/depthai.hpp"
+
+TEST_CASE("DetectionNetwork can load BLOB properly") {
+    const std::string archivePath = BLOB_ARCHIVE_PATH;
+
+    // Create pipeline
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::DetectionNetwork>();
+
+    // Load NNArchive
+    dai::NNArchive nnArchive(archivePath);
+    REQUIRE_NOTHROW(nn->setNNArchive(nnArchive));
+
+    // Throws if number of shaves is specified
+    REQUIRE_THROWS(nn->setNNArchive(nnArchive, 6));
+}
+
+TEST_CASE("DetectionNetwork can load SUPERBLOB properly") {
+    const std::string archivePath = SUPERBLOB_ARCHIVE_PATH;
+
+    // Create pipeline
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::DetectionNetwork>();
+
+    // Load NNArchive
+    dai::NNArchive nnArchive(archivePath);
+    REQUIRE_NOTHROW(nn->setNNArchive(nnArchive));
+
+    // Does not throw if number of shaves is specified
+    REQUIRE_NOTHROW(nn->setNNArchive(nnArchive, 6));
+}
+
+TEST_CASE("DetectionNetwork throws when passed the OTHER NNArchive type") {
+    const std::string archivePath = ONNX_ARCHIVE_PATH;
+
+    // Create pipeline
+    dai::Pipeline p;
+    auto nn = p.create<dai::node::DetectionNetwork>();
+
+    // Load NNArchive
+    dai::NNArchive nnArchive(archivePath);
+    REQUIRE_THROWS(nn->setNNArchive(nnArchive));
+    REQUIRE_THROWS(nn->setNNArchive(nnArchive, 6));
+}


### PR DESCRIPTION
This PR fixes the `setNNArchive` method. Previously, it was only possible to use `setNNArchive` for archives with the `BLOB` type (`getArchiveType`).