### PR TITLE
Replace custom python implementations for cvFrame with bindings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "bindings/python/external/xtensor-python"]
 	path = bindings/python/external/xtensor-python
 	url = https://github.com/xtensor-stack/xtensor-python.git
+[submodule "3rdparty/pybind11_opencv_numpy"]
+	path = bindings/python/external/pybind11_opencv_numpy
+	url = git@github.com:edmBernard/pybind11_opencv_numpy.git

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -147,6 +147,11 @@ set(SOURCE_LIST
     src/modelzoo/NNModelDescriptionBindings.cpp
     src/modelzoo/ZooBindings.cpp
 )
+if(DEPTHAI_MERGED_TARGET)
+    list(APPEND SOURCE_LIST
+        external/pybind11_opencv_numpy/ndarray_converter.cpp
+    )
+endif()
 
 if(DEPTHAI_BASALT_SUPPORT)
     list(APPEND SOURCE_LIST
@@ -263,6 +268,9 @@ endif()
 
 # Add include directory
 target_include_directories(${TARGET_NAME} PRIVATE src ${DOCSTRINGS_INCLUDE_PLACEHOLDER_DIR})
+if(DEPTHAI_MERGED_TARGET)
+    target_include_directories(${TARGET_NAME} PRIVATE external/pybind11_opencv_numpy)
+endif()
 
 set(DEPTHAI_LINK_TARGET depthai::core)
 if(NOT DEPTHAI_MERGED_TARGET)

--- a/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
@@ -2,10 +2,9 @@
 #include "pipeline/CommonBindings.hpp"
 #include <unordered_map>
 #include <memory>
-
 // depthai
 #include "depthai/pipeline/datatype/ImgFrame.hpp"
-
+#include "ndarray_converter.h"
 //pybind
 #include <pybind11/chrono.h>
 #include <pybind11/numpy.h>
@@ -115,14 +114,16 @@ void bind_imgframe(pybind11::module& m, void* pCallstack){
     // TODO add RawImgFrame::CameraSettings
 
     // Message
-        imgFrame
-        .def(py::init<>())
+    imgFrame.def(py::init<>())
         .def(py::init<size_t>())
         // getters
         .def("getTimestamp", py::overload_cast<>(&ImgFrame::Buffer::getTimestamp, py::const_), DOC(dai, Buffer, getTimestamp))
         .def("getTimestampDevice", py::overload_cast<>(&ImgFrame::Buffer::getTimestampDevice, py::const_), DOC(dai, Buffer, getTimestampDevice))
         .def("getTimestamp", py::overload_cast<CameraExposureOffset>(&ImgFrame::getTimestamp, py::const_), py::arg("offset"), DOC(dai, ImgFrame, getTimestamp))
-        .def("getTimestampDevice", py::overload_cast<CameraExposureOffset>(&ImgFrame::getTimestampDevice, py::const_), py::arg("offset"), DOC(dai, ImgFrame, getTimestampDevice))
+        .def("getTimestampDevice",
+             py::overload_cast<CameraExposureOffset>(&ImgFrame::getTimestampDevice, py::const_),
+             py::arg("offset"),
+             DOC(dai, ImgFrame, getTimestampDevice))
         .def("getSequenceNum", &ImgFrame::Buffer::getSequenceNum, DOC(dai, Buffer, getSequenceNum))
         .def("getInstanceNum", &ImgFrame::getInstanceNum, DOC(dai, ImgFrame, getInstanceNum))
         .def("getCategory", &ImgFrame::getCategory, DOC(dai, ImgFrame, getCategory))
@@ -138,215 +139,34 @@ void bind_imgframe(pybind11::module& m, void* pCallstack){
         .def("getColorTemperature", &ImgFrame::getColorTemperature, DOC(dai, ImgFrame, getColorTemperature))
         .def("getLensPosition", &ImgFrame::getLensPosition, DOC(dai, ImgFrame, getLensPosition))
         .def("getLensPositionRaw", &ImgFrame::getLensPositionRaw, DOC(dai, ImgFrame, getLensPositionRaw))
-
-        // OpenCV Support section
-        .def("setFrame", [](dai::ImgFrame& frm, py::array arr){
-             // Try importing 'numpy' module
-            py::module numpy;
-            try {
-                numpy = py::module::import("numpy");
-            } catch (const py::error_already_set& err){
-                throw std::runtime_error("Function 'setFrame' requires 'numpy' module");
-            }
-
-            py::array contiguous = numpy.attr("ascontiguousarray")(arr);
-            frm.setData({(uint8_t*) contiguous.data(), (uint8_t*) contiguous.data() + contiguous.nbytes()});
-            // frm.getData().resize(contiguous.nbytes());
-            // memcpy(frm.getData().data(), contiguous.data(), contiguous.nbytes());
-
-        }, py::arg("array"), "Copies array bytes to ImgFrame buffer")
-        .def("getFrame", [](py::object &obj, bool copy){
-
-            // Try importing 'numpy' module
-            py::module numpy;
-            try {
-                numpy = py::module::import("numpy");
-            } catch (const py::error_already_set& err){
-                throw std::runtime_error("Function 'getFrame' requires 'numpy' module");
-            }
-
-            // obj is "Python" object, which we used then to bind the numpy view lifespan to
-            // creates numpy array (zero-copy) which holds correct information such as shape, ...
-            auto& img = obj.cast<dai::ImgFrame&>();
-
-            // shape
-            bool valid = img.getWidth() > 0 && img.getHeight() > 0;
-            std::vector<std::size_t> shape = {img.getData().size()};
-            std::vector<std::size_t> strides = {};
-            py::dtype dtype = py::dtype::of<uint8_t>();
-
-            switch(img.getType()){
-
-                case ImgFrame::Type::RGB888i :
-                case ImgFrame::Type::BGR888i :
-                    // HWC
-                    shape = {img.getHeight(), img.getWidth(), 3};
-                    strides = {img.getStride(), 3, static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
-                    dtype = py::dtype::of<uint8_t>();
-                break;
-
-                case ImgFrame::Type::RGB888p :
-                case ImgFrame::Type::BGR888p :
-                    // CHW
-                    shape = {3, img.getHeight(), img.getWidth()};
-                    strides = {img.fb.p2Offset - img.fb.p1Offset, img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
-                    dtype = py::dtype::of<uint8_t>();
-                break;
-
-                case ImgFrame::Type::YUV420p:
-                case ImgFrame::Type::NV12:
-                case ImgFrame::Type::NV21:
-                    // Height 1.5x actual size
-                    shape = {img.getPlaneHeight() * 3 / 2, img.getWidth()};
-                    strides = {img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
-                    dtype = py::dtype::of<uint8_t>();
-                break;
-
-                case ImgFrame::Type::RAW8:
-                case ImgFrame::Type::GRAY8:
-                    shape = {img.getHeight(), img.getWidth()};
-                    strides = {img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
-                    dtype = py::dtype::of<uint8_t>();
-                break;
-
-                case ImgFrame::Type::GRAYF16:
-                    shape = {img.getHeight(), img.getWidth()};
-                    strides = {img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
-                    dtype = py::dtype("half");
-                break;
-
-                case ImgFrame::Type::RAW16:
-                case ImgFrame::Type::RAW14:
-                case ImgFrame::Type::RAW12:
-                case ImgFrame::Type::RAW10:
-                    shape = {img.getHeight(), img.getWidth()};
-                    strides = {img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
-                    dtype = py::dtype::of<uint16_t>();
-                break;
-
-                case ImgFrame::Type::RGBF16F16F16i:
-                case ImgFrame::Type::BGRF16F16F16i:
-                    shape = {img.getHeight(), img.getWidth(), 3};
-                    strides = {img.getStride(), 3, 1};
-                    dtype = py::dtype("half");
-                break;
-
-                case ImgFrame::Type::RGBF16F16F16p:
-                case ImgFrame::Type::BGRF16F16F16p:
-                    shape = {3, img.getHeight(), img.getWidth()};
-                    strides = {img.fb.p2Offset - img.fb.p1Offset, img.getStride(), 1};
-                    dtype = py::dtype("half");
-                break;
-
-                case ImgFrame::Type::BITSTREAM :
-                default:
-                    shape = {img.getData().size()};
-                    dtype = py::dtype::of<uint8_t>();
-                    break;
-            }
-
-            // Check if enough data
-            long actualSize = img.getData().size();
-            long requiredSize = dtype.itemsize();
-            for(const auto& dim : shape) requiredSize *= dim;
-            if(actualSize < requiredSize){
-                throw std::runtime_error("ImgFrame doesn't have enough data to encode specified frame, required " + std::to_string(requiredSize)
-                        + ", actual " + std::to_string(actualSize) + ". Maybe metadataOnly transfer was made?");
-            } else if(actualSize > requiredSize) {
-                // FIXME check build on Windows
-                // logger::warn("ImgFrame has excess data: actual {}, expected {}", actualSize, requiredSize);
-            }
-            if(img.getWidth() <= 0 || img.getHeight() <= 0){
-                throw std::runtime_error("ImgFrame size invalid (width: " + std::to_string(img.getWidth()) + ", height: " + std::to_string(img.getHeight()) + ")");
-            }
-
-            if(copy){
-                py::array a(dtype, shape);
-                std::memcpy(a.mutable_data(), img.getData().data(), std::min( (long) (img.getData().size()), (long) (a.nbytes())));
-                // TODO handle strides
-                return a;
-            } else {
-                return py::array(dtype, shape, strides, img.getData().data(), obj);
-            }
-
-        }, py::arg("copy") = false, "Returns numpy array with shape as specified by width, height and type")
-
-        .def("getCvFrame", [](py::object &obj){
-            using namespace pybind11::literals;
-
-            // Try importing 'cv2' module
-            py::module cv2;
-            py::module numpy;
-            try {
-                cv2 = py::module::import("cv2");
-                numpy = py::module::import("numpy");
-            } catch (const py::error_already_set& err){
-                throw std::runtime_error("Function 'getCvFrame' requires 'cv2' module (opencv-python package)");
-            }
-
-            // ImgFrame
-            auto& img = obj.cast<dai::ImgFrame&>();
-
-            // Get numpy frame (python object) by calling getFrame
-            auto frame = obj.attr("getFrame")();
-
-            // Convert numpy array to bgr frame using cv2 module
-            switch(img.getType()) {
-
-                case ImgFrame::Type::BGR888p:
-                    return numpy.attr("ascontiguousarray")(frame.attr("transpose")(1, 2, 0));
-                    break;
-
-                case ImgFrame::Type::BGR888i:
-                    return frame.attr("copy")();
-                    break;
-
-                case ImgFrame::Type::RGB888p:
-                    // Transpose to RGB888i then convert to BGR
-                    return cv2.attr("cvtColor")(frame.attr("transpose")(1, 2, 0), cv2.attr("COLOR_RGB2BGR"));
-                    break;
-
-                case ImgFrame::Type::RGB888i:
-                    return cv2.attr("cvtColor")(frame, cv2.attr("COLOR_RGB2BGR"));
-                    break;
-
-                case ImgFrame::Type::YUV420p:
-                    return cv2.attr("cvtColor")(frame, cv2.attr("COLOR_YUV2BGR_IYUV"));
-                    break;
-
-                case ImgFrame::Type::NV12:
-                case ImgFrame::Type::NV21: {
-                    auto code = (img.getType() == ImgFrame::Type::NV12) ? cv2.attr("COLOR_YUV2BGR_NV12") : cv2.attr("COLOR_YUV2BGR_NV21");
-                    if(img.getPlaneHeight() <= img.getHeight() && img.getStride() <= img.getWidth()) {
-                        return cv2.attr("cvtColor")(frame, code);
-                    } else {
-                        py::dtype dtype = py::dtype::of<uint8_t>();
-                        std::vector<std::size_t> shapeY = {img.getHeight(), img.getWidth()};
-                        std::vector<std::size_t> shapeUV = {img.getHeight() / 2, img.getWidth() / 2};
-                        std::vector<std::size_t> strides = {img.getStride(), 1};
-                        auto frameY = py::array(dtype, shapeY, strides, img.getData().data(), obj);
-                        auto frameUV = py::array(dtype, shapeUV, strides, img.getData().data() + img.getPlaneStride(), obj);
-                        return cv2.attr("cvtColorTwoPlane")(frameY, frameUV, code);
-                    }
-                } break;
-
-                case ImgFrame::Type::RAW8:
-                case ImgFrame::Type::RAW16:
-                case ImgFrame::Type::RAW14:
-                case ImgFrame::Type::RAW12:
-                case ImgFrame::Type::RAW10:
-                case ImgFrame::Type::GRAY8:
-                case ImgFrame::Type::GRAYF16:
-                default:
-                    return frame.attr("copy")();
-                    break;
-            }
-
-            // Default case
-            return frame.attr("copy")();
-
-        }, "Returns BGR or grayscale frame compatible with use in other opencv functions")
-
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
+        .def("getFrame", &ImgFrame::getFrame, py::arg("copy") = true, DOC(dai, ImgFrame, getFrame))
+        .def("setFrame", &ImgFrame::setFrame, DOC(dai, ImgFrame, setFrame))
+        .def("getCvFrame", &ImgFrame::getCvFrame, DOC(dai, ImgFrame, getCvFrame))
+        .def("setCvFrame", &ImgFrame::setCvFrame, DOC(dai, ImgFrame, setCvFrame))
+#else
+        .def(
+            "getFrame",
+            [](ImgFrame& self, bool copy) {
+                throw std::runtime_error("OpenCV support is not available. Please recompile with OpenCV support to use this function.");
+            },
+            py::arg("copy") = true,
+            DOC(dai, ImgFrame, getFrame))
+        .def(
+            "setFrame",
+            [](ImgFrame& self, cv::Mat frame) {
+                throw std::runtime_error("OpenCV support is not available. Please recompile with OpenCV support to use this function.");
+            },
+            DOC(dai, ImgFrame, setFrame))
+        .def(
+            "getCvFrame",
+            []() { throw std::runtime_error("OpenCV support is not available. Please recompile with OpenCV support to use this function."); },
+            DOC(dai, ImgFrame, getCvFrame))
+        .def(
+            "setCvFrame",
+            [](cv::Mat frame) { throw std::runtime_error("OpenCV support is not available. Please recompile with OpenCV support to use this function."); },
+            DOC(dai, ImgFrame, setCvFrame))
+#endif
         // setters
         // .def("setTimestamp", &ImgFrame::setTimestamp, py::arg("timestamp"), DOC(dai, ImgFrame, setTimestamp))
         // .def("setTimestampDevice", &ImgFrame::setTimestampDevice, DOC(dai, ImgFrame, setTimestampDevice))

--- a/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
@@ -181,7 +181,7 @@ void bind_imgframe(pybind11::module& m, void* pCallstack){
                 case ImgFrame::Type::BGR888i :
                     // HWC
                     shape = {img.getHeight(), img.getWidth(), 3};
-                    strides = {img.getStride(), 3, 1};
+                    strides = {img.getStride(), 3, static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
                     dtype = py::dtype::of<uint8_t>();
                 break;
 
@@ -189,7 +189,7 @@ void bind_imgframe(pybind11::module& m, void* pCallstack){
                 case ImgFrame::Type::BGR888p :
                     // CHW
                     shape = {3, img.getHeight(), img.getWidth()};
-                    strides = {img.fb.p2Offset - img.fb.p1Offset, img.getStride(), 1};
+                    strides = {img.fb.p2Offset - img.fb.p1Offset, img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
                     dtype = py::dtype::of<uint8_t>();
                 break;
 
@@ -198,20 +198,20 @@ void bind_imgframe(pybind11::module& m, void* pCallstack){
                 case ImgFrame::Type::NV21:
                     // Height 1.5x actual size
                     shape = {img.getPlaneHeight() * 3 / 2, img.getWidth()};
-                    strides = {img.getStride(), 1};
+                    strides = {img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
                     dtype = py::dtype::of<uint8_t>();
                 break;
 
                 case ImgFrame::Type::RAW8:
                 case ImgFrame::Type::GRAY8:
                     shape = {img.getHeight(), img.getWidth()};
-                    strides = {img.getStride(), 1};
+                    strides = {img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
                     dtype = py::dtype::of<uint8_t>();
                 break;
 
                 case ImgFrame::Type::GRAYF16:
                     shape = {img.getHeight(), img.getWidth()};
-                    strides = {img.getStride(), 1};
+                    strides = {img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
                     dtype = py::dtype("half");
                 break;
 
@@ -220,7 +220,7 @@ void bind_imgframe(pybind11::module& m, void* pCallstack){
                 case ImgFrame::Type::RAW12:
                 case ImgFrame::Type::RAW10:
                     shape = {img.getHeight(), img.getWidth()};
-                    strides = {img.getStride(), 1};
+                    strides = {img.getStride(), static_cast<std::size_t>(std::round(img.getBytesPerPixel()))};
                     dtype = py::dtype::of<uint16_t>();
                 break;
 

--- a/bindings/python/src/py_bindings.cpp
+++ b/bindings/python/src/py_bindings.cpp
@@ -35,6 +35,9 @@
 #include "capabilities/ImgFrameCapabilityBindings.hpp"
 #include "modelzoo/NNModelDescriptionBindings.hpp"
 #include "modelzoo/ZooBindings.hpp"
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
+    #include <ndarray_converter.h>
+#endif
 
 #ifdef DEPTHAI_PYTHON_EMBEDDED_MODULE
 #include <pybind11/embed.h>
@@ -48,7 +51,9 @@ PYBIND11_EMBEDDED_MODULE(depthai, m)
 PYBIND11_MODULE(depthai, m)
 #endif
 {
-
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
+    NDArrayConverter::init_numpy();
+#endif
     // Depthai python version consists of: (depthai-core).(bindings revision)[+bindings hash]
     m.attr("__version__") = DEPTHAI_PYTHON_VERSION;
     m.attr("__commit__") = DEPTHAI_PYTHON_COMMIT_HASH;

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -63,8 +63,11 @@ unsigned int ImgFrame::getCategory() const {
 unsigned int ImgFrame::getWidth() const {
     return fb.width;
 }
+
 unsigned int ImgFrame::getStride() const {
-    if(fb.stride == 0) return getWidth();
+    if(fb.stride == 0) {
+        return static_cast<unsigned>(std::round(static_cast<float>(getWidth()) * getBytesPerPixel()));
+    }
     return fb.stride;
 }
 unsigned int ImgFrame::getPlaneStride(int planeIndex) const {


### PR DESCRIPTION
Added bindings instead of custom python implementations for the `getCvFrame` and `getFrame` functions.

Should be easier to maintain with a single source of truth.

Another thing we get for free is `setCvFrame` from python  - that one is quite neat :)

TODO before merge:
*  Test with numpy2
*  Add tests