### PR TITLE
Set the cmake version as latest doesn't work on Macs

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        cmake: ['3.10.x', ''] # Older version (Ubuntu 18.04) and newest
+        cmake: ['3.10.x', '3.29.x'] # Older version (Ubuntu 18.04) and newest
         exclude:
           - os: windows-latest
             cmake: '3.10.x'


### PR DESCRIPTION
Latest CMake `3.30.2` does not work on MacOS with Hunter (highly likely not depthai related).
The behavior is that it gets only pulls one hunter dependency but gets stuck in the next one, so something is not cleaning up properly.

To workaround it use the latest working version instead (which is one before latest).