### PR TITLE
Updating getCameraExtrinsics

### DIFF
--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -219,15 +219,6 @@ class CalibrationHandler {
     std::vector<std::vector<float>> getCameraExtrinsics(CameraBoardSocket srcCamera, CameraBoardSocket dstCamera, bool useSpecTranslation = false) const;
 
     /**
-     * Get the Transformation matrix from the given camera to the coordinate system origin (one without extrinsics
-     * and linked to CameraBoardSocket.AUTO)
-     * @param cameraId Camera Id of the camera for which the origin matrix is being calculated
-     * @param useSpecTranslation Enabling this bool uses the translation information from the board design data
-     * @return a transformationMatrix which is 4x4 in homogeneous coordinate system
-     */
-    std::vector<std::vector<float>> getOriginMatrix(CameraBoardSocket cameraId, bool useSpecTranslation) const;
-
-    /**
      * Get the Camera translation vector between two cameras from the calibration data.
      *
      * @param srcCamera Camera Id of the camera which will be considered as origin.
@@ -557,6 +548,15 @@ class CalibrationHandler {
     std::vector<std::vector<float>> computeExtrinsicMatrix(CameraBoardSocket srcCamera, CameraBoardSocket dstCamera, bool useSpecTranslation = false) const;
     bool checkExtrinsicsLink(CameraBoardSocket srcCamera, CameraBoardSocket dstCamera) const;
     bool checkSrcLinks(CameraBoardSocket headSocket) const;
+
+    /**
+     * Get the Transformation matrix from the given camera to the coordinate system origin (one without extrinsics
+     * and linked to CameraBoardSocket.AUTO)
+     * @param cameraId Camera Id of the camera for which the origin matrix is being calculated
+     * @param useSpecTranslation Enabling this bool uses the translation information from the board design data
+     * @return a transformationMatrix which is 4x4 in homogeneous coordinate system
+     */
+    std::vector<std::vector<float>> getCamToOriginMatrix(CameraBoardSocket cameraId, bool useSpecTranslation, CameraBoardSocket& originSocket) const;
 };
 
 }  // namespace dai

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -219,7 +219,7 @@ class CalibrationHandler {
     std::vector<std::vector<float>> getCameraExtrinsics(CameraBoardSocket srcCamera, CameraBoardSocket dstCamera, bool useSpecTranslation = false) const;
 
     /**
-     * Get the Transformation matrix from the given camera to the coordinate system origin (one without extrinsics 
+     * Get the Transformation matrix from the given camera to the coordinate system origin (one without extrinsics
      * and linked to CameraBoardSocket.AUTO)
      * @param cameraId Camera Id of the camera for which the origin matrix is being calculated
      * @param useSpecTranslation Enabling this bool uses the translation information from the board design data

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -556,7 +556,7 @@ class CalibrationHandler {
      * @param useSpecTranslation Enabling this bool uses the translation information from the board design data
      * @return a transformationMatrix which is 4x4 in homogeneous coordinate system
      */
-    std::vector<std::vector<float>> getCamToOriginMatrix(CameraBoardSocket cameraId, bool useSpecTranslation, CameraBoardSocket& originSocket) const;
+    std::vector<std::vector<float>> getExtrinsicsToOrigin(CameraBoardSocket cameraId, bool useSpecTranslation, CameraBoardSocket& originSocket) const;
 };
 
 }  // namespace dai

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -219,6 +219,15 @@ class CalibrationHandler {
     std::vector<std::vector<float>> getCameraExtrinsics(CameraBoardSocket srcCamera, CameraBoardSocket dstCamera, bool useSpecTranslation = false) const;
 
     /**
+     * Get the Transformation matrix from the given camera to the coordinate system origin (one without extrinsics 
+     * and linked to CameraBoardSocket.AUTO)
+     * @param cameraId Camera Id of the camera for which the origin matrix is being calculated
+     * @param useSpecTranslation Enabling this bool uses the translation information from the board design data
+     * @return a transformationMatrix which is 4x4 in homogeneous coordinate system
+     */
+    std::vector<std::vector<float>> getOriginMatrix(CameraBoardSocket cameraId, bool useSpecTranslation) const;
+
+    /**
      * Get the Camera translation vector between two cameras from the calibration data.
      *
      * @param srcCamera Camera Id of the camera which will be considered as origin.

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -392,19 +392,19 @@ std::vector<std::vector<float>> CalibrationHandler::getOriginMatrix(CameraBoardS
     // Check if the cameraId exists in the data
     logger::debug("Checking if camera ID {} exists in the calibration data.", static_cast<int>(cameraId));
     auto cameraIt = eepromData.cameraData.find(cameraId);
-    if (cameraIt == eepromData.cameraData.end()) {
+    if(cameraIt == eepromData.cameraData.end()) {
         logger::error("Camera ID {} does not exist in the calibration data.", static_cast<int>(cameraId));
         throw std::runtime_error("Camera ID does not exist in the calibration data.");
     }
 
     // Traverse to find the origin camera (the one that has toCameraSocket == AUTO/-1)
     CameraBoardSocket currentCameraId = cameraId;
-    std::vector<CameraBoardSocket> path; // To store the path of sockets
+    std::vector<CameraBoardSocket> path;  // To store the path of sockets
     path.push_back(currentCameraId);
 
-    while (true) {
+    while(true) {
         auto currentIt = eepromData.cameraData.find(currentCameraId);
-        if (currentIt == eepromData.cameraData.end()) {
+        if(currentIt == eepromData.cameraData.end()) {
             logger::error("Invalid camera link detected at camera ID {}.", static_cast<int>(currentCameraId));
             throw std::runtime_error("Invalid camera link detected.");
         }
@@ -412,11 +412,11 @@ std::vector<std::vector<float>> CalibrationHandler::getOriginMatrix(CameraBoardS
         CameraBoardSocket nextCameraSocket = currentIt->second.extrinsics.toCameraSocket;
 
         // Prevent infinite loop in case of cyclic connections
-        if (std::find(path.begin(), path.end(), nextCameraSocket) != path.end()) {
+        if(std::find(path.begin(), path.end(), nextCameraSocket) != path.end()) {
             throw std::runtime_error("Cyclic extrinsics detected in device calibration data.");
         }
 
-        if (nextCameraSocket == CameraBoardSocket::AUTO) {
+        if(nextCameraSocket == CameraBoardSocket::AUTO) {
             break;
         }
 
@@ -426,9 +426,9 @@ std::vector<std::vector<float>> CalibrationHandler::getOriginMatrix(CameraBoardS
     }
 
     // Now compute the extrinsic matrix from cameraId to the origin
-    
+
     // If the cameraId is the origin (no actual transformation needed), return identity matrix
-    if (cameraId == currentCameraId) {
+    if(cameraId == currentCameraId) {
         extrinsics = {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}};
     } else {
         extrinsics = computeExtrinsicMatrix(cameraId, currentCameraId, useSpecTranslation);


### PR DESCRIPTION
Update getCameraExtrinsics() so any two sockets can be used regardless of how they are linked. 

Calculation changed to:
1. src -> origin 
2. dst -> origin 
3. src->origin->dst

Due to some inaccuracies in calculations, the results might be slightly different than the old method. 
Tested for cyclic links as well. 

Excuse my cpp inexperience :)