### PR TITLE
Make Pipeline's run method catch signals

### DIFF
--- a/bindings/python/src/pipeline/PipelineBindings.cpp
+++ b/bindings/python/src/pipeline/PipelineBindings.cpp
@@ -249,21 +249,21 @@ void PipelineBindings::bind(pybind11::module& m, void* pCallstack){
              [](Pipeline& p) {
                  {
                      py::gil_scoped_release release;
-                     p.impl()->start();
+                     p.start();
                  }
                  constexpr double timeoutSeconds = 0.1;
                  while(p.isRunning()) {
                      {
                          // Process tasks
                          py::gil_scoped_release release;
-                         p.impl()->processTasks(false, timeoutSeconds);
+                         p.processTasks(false, timeoutSeconds);
                      }
                      if(PyErr_CheckSignals() != 0) throw py::error_already_set();
                  }
-                 p.impl()->stop();
+                 p.stop();
              })
         .def("isRunning", &Pipeline::isRunning)
-        .def("processTasks", &Pipeline::processTasks)
+        .def("processTasks", &Pipeline::processTasks, py::arg("waitForTasks") = false, py::arg("timeoutSeconds") = -1.0)
         .def("enableHolisticRecord", &Pipeline::enableHolisticRecord, py::arg("recordConfig"), DOC(dai, Pipeline, enableHolisticRecord))
         .def("enableHolisticReplay", &Pipeline::enableHolisticReplay, py::arg("recordingPath"), DOC(dai, Pipeline, enableHolisticReplay));
     ;

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -43,7 +43,7 @@ class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
     PipelineImpl& operator=(PipelineImpl&&) = delete;
     ~PipelineImpl();
 
-   public:
+   private:
     // static functions
     static bool isSamePipeline(const Node::Output& out, const Node::Input& in);
     static bool canConnect(const Node::Output& out, const Node::Input& in);
@@ -490,7 +490,9 @@ class Pipeline {
     void stop() {
         impl()->stop();
     }
-
+    void processTasks(bool waitForTasks = false, double timeoutSeconds = -1.0) {
+        impl()->processTasks(waitForTasks, timeoutSeconds);
+    }
     void run() {
         impl()->run();
     }
@@ -503,10 +505,6 @@ class Pipeline {
 
     void addTask(std::function<void()> task) {
         impl()->addTask(std::move(task));
-    }
-
-    void processTasks() {
-        impl()->processTasks();
     }
 
     /// Record and Replay


### PR DESCRIPTION
This PR  resolves the issue with the `Pipeline's` `run` method, where it would not catch signals and therefore make it impossible to stop some example programs using `Ctrl+C`.

The relevant clickup task is available [here](https://app.clickup.com/t/86bzv46rz)

Github [action](https://github.com/luxonis/depthai-core/actions/runs/10529898107)

Q: I've made all `PipelineImpl` methods public. Is there a better way to go about this?
Q: Instead of using the negative default value for the `timeoutSeconds` argument of the `processTasks` function, does it make sense to set it to `std::numeric_limits<double>::max()` by default, removing the need for the inner if statement?