### PR TITLE
Fix depthai python stub files

### DIFF
--- a/bindings/python/generate_stubs.py
+++ b/bindings/python/generate_stubs.py
@@ -29,7 +29,7 @@ try:
         print(f'Could not import depthai: {ex}')
 
     print(f'PYTHONPATH set to {env["PYTHONPATH"]}')
-    subprocess.check_call(['stubgen', '-p', MODULE_NAME, '-o', f'{DIRECTORY}', '--recursive'], cwd=DIRECTORY, env=env)
+    subprocess.check_call(['stubgen', '-p', MODULE_NAME, '-o', f'{DIRECTORY}'], cwd=DIRECTORY, env=env)
 
     # Add py.typed
     open(f'{DIRECTORY}/depthai/py.typed', 'a').close()


### PR DESCRIPTION
There have been complaints about some of the `depthai` classes not having their types properly annotated.
The issue was that some of the `depthai` submodules were not properly included in the "master" `__init__.pyi` file, resulting in language servers not knowing the type of certain types (e.g. `depthai.nn_archive.v1.Config`).

This PR aims to fix that. The relevant clickup task can be viewed [here](https://app.clickup.com/t/86c016gy5). CI/CD action for this PR is also [available](https://github.com/luxonis/depthai-core/actions/runs/10801575179).

For your convenience, here's the command to install this commit's depthai python bindings:

```
pip3 install depthai==3.0.0a2.dev0+bd08fb2b7518c42cb0da8b8a8dc8cbc36491f491 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/

```
