### PR TITLE
Add method to custom ThreadedHostNode node to create a subnode

### DIFF
--- a/bindings/python/src/pipeline/node/HostNodeBindings.cpp
+++ b/bindings/python/src/pipeline/node/HostNodeBindings.cpp
@@ -142,6 +142,13 @@ void bind_hostnode(pybind11::module& m, void* pCallstack){
                 cls.__init__ = __init__
 
         node.HostNode.__init_subclass__ = classmethod(__init_subclass__)
+
+        # Create a subnode as part of this user node
+        def createSubnode(self, class_, *args, **kwargs):
+            return self.getParentPipeline().create(class_, *args, **kwargs)
+
+        node.HostNode.createSubnode = createSubnode
+        node.ThreadedHostNode.createSubnode = createSubnode
     )",
              m.attr("__dict__"));
 }

--- a/examples/python/HostNodes/threaded_host_nodes.py
+++ b/examples/python/HostNodes/threaded_host_nodes.py
@@ -2,16 +2,17 @@ import depthai as dai
 import time
 
 class TestPassthrough(dai.node.ThreadedHostNode):
-    def __init__(self):
+    def __init__(self, name: str):
         super().__init__()
+        self.name = name
         self.input = self.createInput()
         self.output = self.createOutput()
 
     def onStart(self):
-        print("Hello, this is", __class__.__name__)
+        print("Hello, this is", self.name)
 
     def onStop(self):
-        print("Goodbye from", __class__.__name__)
+        print("Goodbye from", self.name)
 
     def run(self):
         while self.isRunning():
@@ -20,36 +21,70 @@ class TestPassthrough(dai.node.ThreadedHostNode):
             self.output.send(buffer)
 
 class TestSink(dai.node.ThreadedHostNode):
-    def __init__(self):
+    def __init__(self, name: str):
         super().__init__()
         self.input = self.createInput()
+        self.name = name
 
     def onStart(self):
-        print("Hello, this is", __class__.__name__)
+        print("Hello, this is", self.name)
 
     def run(self):
         while self.isRunning():
             buffer = self.input.get()
-            print("The sync node received a buffer!")
+            del buffer
+            print(f"{self.name} node received a buffer!")
 
 class TestSource(dai.node.ThreadedHostNode):
-    def __init__(self):
+    def __init__(self, name: str):
         super().__init__()
+        self.name = name
         self.output = self.createOutput()
 
     def run(self):
         while self.isRunning():
             buffer = dai.Buffer()
-            print("The source node is sending a buffer!")
+            print(f"{self.name} node is sending a buffer!")
             self.output.send(buffer)
             time.sleep(1)
 
+class TestPassthroughSubnodes(dai.node.ThreadedHostNode):
+    def __init__(self, name: str):
+        super().__init__()
+        self.passthrough1 = self.createSubnode(TestPassthrough, name + "_subnode1")
+        self.passthrough2 = self.createSubnode(TestPassthrough, name + "_subnode2")
+        self.input = self.passthrough1.input
+        self.output = self.passthrough2.output
+
+        # Link the two subnodes together
+        self.passthrough1.output.link(self.passthrough2.input)
+
+    def run(self):
+        while self.isRunning():
+            buffer = self.input.get()
+            self.output.send(buffer)
+
 with dai.Pipeline(False) as p:
-    source = TestSource()
-    sink = TestSink()
-    passthrough = TestPassthrough()
+    """
+    Create the following pipeline:
+    source -> passthrough -> sink1
+           |
+           -> passthroughSubnodes -> sink2
+    """
+
+    # Create nodes
+    source = TestSource("source")
+    passthrough = TestPassthrough("passthrough")
+    passthroughSubnodes = TestPassthroughSubnodes("passthroughSubnodes")
+    sink1 = TestSink("sink1")
+    sink2 = TestSink("sink2")
+
+    # Link nodes
     source.output.link(passthrough.input)
-    passthrough.output.link(sink.input)
+    source.output.link(passthroughSubnodes.input)
+    passthrough.output.link(sink1.input)
+    passthroughSubnodes.output.link(sink2.input)
+
     p.start()
     while p.isRunning():
         time.sleep(1)


### PR DESCRIPTION
This PR adds the possibility of creating "sub-nodes" as part user defined python nodes. Though user-defined nodes are host-only, i.e. they cannot run on camera, a sub-node running on a camera can be created.

Clickup [task](https://app.clickup.com/t/86byk5a7x).