### PR TITLE
Expanded RotatedRect object definition to accept floats

### DIFF
--- a/bindings/python/src/pipeline/CommonBindings.cpp
+++ b/bindings/python/src/pipeline/CommonBindings.cpp
@@ -97,7 +97,7 @@ void CommonBindings::bind(pybind11::module& m, void* pCallstack){
         .def(py::init<>())
         .def(py::init<Point2f, Size2f, float>())
         .def(py::init<Rect, float>())
-        .def(py::init<float float float float float>(), py::arg("center_x"), py::arg("center_y"), py::arg("size_width"), py::arg("size_height"), py::arg("angle"))
+        .def(py::init<float, float, float, float, float>(), py::arg("center_x"), py::arg("center_y"), py::arg("size_width"), py::arg("size_height"), py::arg("angle"))
         .def_readwrite("center", &RotatedRect::center)
         .def_readwrite("size", &RotatedRect::size)
         .def_readwrite("angle", &RotatedRect::angle)

--- a/bindings/python/src/pipeline/CommonBindings.cpp
+++ b/bindings/python/src/pipeline/CommonBindings.cpp
@@ -97,6 +97,7 @@ void CommonBindings::bind(pybind11::module& m, void* pCallstack){
         .def(py::init<>())
         .def(py::init<Point2f, Size2f, float>())
         .def(py::init<Rect, float>())
+        .def(py::init<float float float float float>(), py::arg("center_x"), py::arg("center_y"), py::arg("size_width"), py::arg("size_height"), py::arg("angle"))
         .def_readwrite("center", &RotatedRect::center)
         .def_readwrite("size", &RotatedRect::size)
         .def_readwrite("angle", &RotatedRect::angle)

--- a/include/depthai/common/RotatedRect.hpp
+++ b/include/depthai/common/RotatedRect.hpp
@@ -25,7 +25,11 @@ struct RotatedRect {
         }
     }
     RotatedRect(const Rect& rect, float angle) : center(rect.x + rect.width / 2.0f, rect.y + rect.height / 2.0f, rect.isNormalized()), size(rect.width, rect.height, rect.isNormalized()), angle(angle) {}
-
+    RotatedRect(float center_x, float center_y, float size_width, float size_height, float angle) : center(center_x, center_y), size(size_width, size_height), angle(angle) {
+        if(size.isNormalized() != center.isNormalized()) {
+            throw std::runtime_error("Cannot create RotatedRect with mixed normalization");
+        }
+    }
     bool isNormalized() const {
         if(size.isNormalized() != center.isNormalized()) {
             throw std::runtime_error("Cannot denormalize RotatedRect with mixed normalization");


### PR DESCRIPTION
This PR adds a new definition to initialize RotatedRect object with just floats.