### PR TITLE
Auto increase the XLink connection size Host->Dev

### DIFF
--- a/include/depthai/pipeline/node/host/XLinkOutHost.hpp
+++ b/include/depthai/pipeline/node/host/XLinkOutHost.hpp
@@ -12,6 +12,7 @@ class XLinkOutHost : public NodeCRTP<ThreadedHostNode, XLinkOutHost> {
     std::condition_variable isWaitingForReconnect;
     std::mutex mtx;
     bool isDisconnected = false;
+    bool allowResize = false;
 
    public:
     constexpr static const char* NAME = "XLinkOutHost";
@@ -20,6 +21,7 @@ class XLinkOutHost : public NodeCRTP<ThreadedHostNode, XLinkOutHost> {
     // XLinkOutHost(std::shared_ptr<XLinkConnection> conn, const std::string& streamName);
     void setStreamName(const std::string& name);
     void setConnection(std::shared_ptr<XLinkConnection> conn);
+    void allowStreamResize(bool allow);
     void disconnect();
     void run() override;
 };

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -777,6 +777,11 @@ void PipelineImpl::build() {
                 xLinkBridge.xLinkIn->setStreamName(streamName);
                 xLinkBridge.xLinkOutHost->setConnection(defaultDevice->getConnection());
                 xLinkBridge.xLinkIn->out.link(*connection.in);
+                if(defaultDevice->getPlatform() == Platform::RVC4 || defaultDevice->getPlatform() == Platform::RVC3) {
+                    xLinkBridge.xLinkOutHost->allowStreamResize(true);
+                } else {
+                    xLinkBridge.xLinkOutHost->allowStreamResize(false);
+                }
             }
             auto xLinkBridge = bridgesIn[connection.in];
             connection.out->unlink(*connection.in);  // Unlink the original connection

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -381,3 +381,8 @@ dai_set_test_labels(regression_camera_concurrency_test ondevice rvc4 ci)
 # Sync test
 dai_add_test(sync_test src/ondevice_tests/pipeline/node/sync_test.cpp)
 dai_set_test_labels(sync_test ondevice rvc2_all rvc4 ci)
+
+## Large messages tests
+dai_add_test(bridge_large_messages src/ondevice_tests/bridge_large_messages.cpp)
+# Only test on RVC4, as RVC2 is not yet supported to auto-increase the max stream capacity
+dai_set_test_labels(bridge_large_messages ondevice rvc4 ci)

--- a/tests/src/ondevice_tests/bridge_large_messages.cpp
+++ b/tests/src/ondevice_tests/bridge_large_messages.cpp
@@ -1,0 +1,40 @@
+#include <catch2/catch_all.hpp>
+
+// Include depthai library
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <depthai/depthai.hpp>
+
+#include "depthai/pipeline/node/MessageDemux.hpp"
+
+bool operator==(const dai::span<uint8_t>& lhs, const dai::span<uint8_t>& rhs) {
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+void testBridgeMessages(const std::vector<size_t>& sizes) {
+    dai::Pipeline p;
+    // Use sync node to force a minimal bridge to the device
+    auto sync = p.create<dai::node::Sync>();
+    auto demux = p.create<dai::node::MessageDemux>();
+    sync->out.link(demux->input);
+    // Create the input and output queues
+    auto inputQueue = sync->inputs["first"].createInputQueue();
+    auto outputQueue = demux->outputs["first"].createOutputQueue();
+    // Start the pipeline
+    p.start();
+    for(auto size : sizes) {
+        // Send a message
+        auto message = std::make_shared<dai::Buffer>();
+        message->setData(std::vector<std::uint8_t>(size, 3));
+        inputQueue->send(message);
+        auto receivedMessage = outputQueue->get<dai::Buffer>();
+        REQUIRE(receivedMessage != nullptr);
+        REQUIRE(receivedMessage->getData().size() == size);
+        auto equal = (receivedMessage->getData() == message->getData());
+        REQUIRE(equal);
+    }
+}
+
+TEST_CASE("Bridge large messages") {
+    testBridgeMessages({0, 1, 100, 100000, 200000, 300000, 100 * 1024 * 1024, 100 * 1024 * 1024 + 1});
+}


### PR DESCRIPTION
This commit adds the auto-increase functionality
for the XLink connection in the Host->Device
direction for RVC3 and RVC4 devices.

RVC2 will first need to support the auto-increase
of pool sizes before this feature can be enabled
for RVC2 devices too.