### PR TITLE
Release the GIL in the waitKey function

### DIFF
--- a/bindings/python/src/remote_connection/RemoteConnectionBindings.cpp
+++ b/bindings/python/src/remote_connection/RemoteConnectionBindings.cpp
@@ -38,11 +38,8 @@ void RemoteConnectionBindings::bind(pybind11::module& m, void* pCallstack) {
              py::arg("maxSize") = 16,
              py::arg("blocking") = false)
         .def("registerPipeline", &RemoteConnection::registerPipeline, py::arg("pipeline"))
-        .def("registerService",
-             &RemoteConnection::registerService,
-             py::arg("serviceName"),
-             py::arg("callback"))
-        .def("waitKey", &RemoteConnection::waitKey, py::arg("delay"));
+        .def("registerService", &RemoteConnection::registerService, py::arg("serviceName"), py::arg("callback"))
+        .def("waitKey", &RemoteConnection::waitKey, py::arg("delay"), py::call_guard<py::gil_scoped_release>());
 #else
      // Define a placeholder class for RemoteConnection
     struct RemoteConnectionPlaceholder {


### PR DESCRIPTION
GIL can be safely released as there are no Python
API calls in the waitKey function.

Since this is often called in a hot loop, this can
severely reduce performance of the remaining
Python code.