### PR TITLE
Added queue.getFps() function and tests for this function

### DIFF
--- a/bindings/python/src/MessageQueueBindings.cpp
+++ b/bindings/python/src/MessageQueueBindings.cpp
@@ -81,6 +81,7 @@ void MessageQueueBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("getMaxSize", &MessageQueue::getMaxSize, DOC(dai, MessageQueue, getMaxSize))
         .def("getSize", &MessageQueue::getSize, DOC(dai, MessageQueue, getSize))
         .def("isFull", &MessageQueue::isFull, DOC(dai, MessageQueue, isFull))
+        .def("getFps", &MessageQueue::getFps, DOC(dai, MessageQueue, getFps))
         .def("addCallback", addCallbackLambda, py::arg("callback"), DOC(dai, MessageQueue, addCallback))
         .def("removeCallback", &MessageQueue::removeCallback, py::arg("callbackId"), DOC(dai, MessageQueue, removeCallback))
         .def("has", static_cast<bool (MessageQueue::*)()>(&MessageQueue::has), DOC(dai, MessageQueue, has))

--- a/include/depthai/pipeline/MessageQueue.hpp
+++ b/include/depthai/pipeline/MessageQueue.hpp
@@ -3,6 +3,8 @@
 // std
 #include <memory>
 #include <vector>
+#include <deque>
+#include <chrono>
 
 // project
 #include "depthai/pipeline/datatype/ADatatype.hpp"
@@ -26,10 +28,12 @@ class MessageQueue : public std::enable_shared_from_this<MessageQueue> {
 
    private:
     static constexpr auto CLOSED_QUEUE_MESSAGE = "MessageQueue was closed";
+    static constexpr size_t FPS_QUEUE_MAX_SIZE = 10;
     LockingQueue<std::shared_ptr<ADatatype>> queue;
     std::string name;
     std::mutex callbacksMtx;
     std::unordered_map<CallbackId, std::function<void(std::string, std::shared_ptr<ADatatype>)>> callbacks;
+    std::deque<std::chrono::steady_clock::time_point> fpsQueue;
     CallbackId uniqueCallbackId{0};
     void callCallbacks(std::shared_ptr<ADatatype> msg);
 
@@ -127,6 +131,13 @@ class MessageQueue : public std::enable_shared_from_this<MessageQueue> {
      * @returns True if queue is full, false otherwise
      */
     unsigned int isFull() const;
+
+    /**
+     * Gets current FPS of the queue
+     *
+     * @returns Current FPS
+     */
+    float getFps();
 
     /**
      * Adds a callback on message received


### PR DESCRIPTION
Tests fail anyways due to other tests:
```
./message_queue_test
Randomness seeded to: 2974482811
message_queue_test(41900,0x16bb27000) malloc: double free for ptr 0x14a009200
message_queue_test(41900,0x16bb27000) malloc: *** set a breakpoint in malloc_error_break to debug

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
message_queue_test is a Catch2 v3.7.1 host application.
Run with -? for options

-------------------------------------------------------------------------------
MessageQueue - Multiple producers and consumers
-------------------------------------------------------------------------------
/Users/erik/Documents/luxonis/depthai-core/tests/src/onhost_tests/message_queue_test.cpp:58
...............................................................................

/Users/erik/Documents/luxonis/depthai-core/tests/src/onhost_tests/message_queue_test.cpp:58: FAILED:
due to a fatal error condition:
  SIGABRT - Abort (abnormal termination) signal

===============================================================================
test cases: 4 | 3 passed | 1 failed
assertions: 7 | 6 passed | 1 failed

zsh: abort      ./message_queue_test
```