### PR TITLE
Add missing serialize method for Tracklets

### DIFF
--- a/include/depthai/pipeline/datatype/Tracklets.hpp
+++ b/include/depthai/pipeline/datatype/Tracklets.hpp
@@ -72,6 +72,11 @@ class Tracklets : public Buffer {
      */
     std::vector<Tracklet> tracklets;
 
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
+        metadata = utility::serialize(*this);
+        datatype = DatatypeEnum::Tracklets;
+    };
+
     DEPTHAI_SERIALIZE(Tracklets, tracklets, Buffer::ts, Buffer::tsDevice, Buffer::sequenceNum);
 };
 


### PR DESCRIPTION
The `serialize` method would not be defined for `Tracklets` and thus we would silently fall back to `Buffer`'s serialization method... 

This PR aims to fix this silent bug.