### PR TITLE
Potential fix for ImageManipConfigV2 serialization crash on Windows

### DIFF
--- a/include/depthai/pipeline/datatype/ImageManipConfigV2.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfigV2.hpp
@@ -227,10 +227,7 @@ class ImageManipOpsBase : public ImageManipOpsEnums {
     Colormap colormap = Colormap::NONE;
     bool undistort = false;
 
-    C operations{};
-
-    ImageManipOpsBase() = default;
-    virtual ~ImageManipOpsBase() = default;
+    C operations;
 
     template <typename C2>
     void cloneTo(ImageManipOpsBase<C2>& to) const {


### PR DESCRIPTION
Fix ImageManipConfigV2 serialization on Windows

It seems to be a msvc compiler bug.
Likely causes more issues, an isolated MRE is here https://godbolt.org/z/Y3f856a46.