### PR TITLE
Bugfix/device subnodes

### DIFF
--- a/include/depthai/pipeline/DeviceNode.hpp
+++ b/include/depthai/pipeline/DeviceNode.hpp
@@ -44,6 +44,8 @@ class DeviceNode : public ThreadedNode {
 
     template <typename T>
     friend class Subnode;
+    friend class Pipeline;
+    friend class PipelineImpl;
 
     /**
      * @brief Set device for this node

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -577,6 +577,11 @@ void PipelineImpl::add(std::shared_ptr<Node> node) {
             throw std::invalid_argument("Cannot add a node that is already part of another pipeline");
         }
 
+        // In case we have a device node without an assigned device (usually subnodes in non-DeviceNode nodes), use the default device
+        if(std::dynamic_pointer_cast<DeviceNode>(curNode) != nullptr && std::dynamic_pointer_cast<DeviceNode>(curNode)->getDevice() == nullptr) {
+            std::dynamic_pointer_cast<DeviceNode>(curNode)->setDevice(defaultDevice);
+        }
+
         for(auto& n : curNode->nodeMap) {
             n->parentId = curNode->id;  // Set node parent id
             search.push(n);


### PR DESCRIPTION
## Purpose
When we have a `HostRunnable` device node that is a subnode of a `ThreadedNode`, this node's device does not get set properly. This PR patches that by setting any `DeviceNode`'s device if it was not set in it's constructor

## Testing & Validation
Added a test to `subnode_tests.cpp`
<!-- How was this tested? Include relevant test results. -->
