### PR TITLE
V3 restart optimization

### DIFF
--- a/bindings/python/src/XLinkBindings.cpp
+++ b/bindings/python/src/XLinkBindings.cpp
@@ -138,8 +138,11 @@ void XLinkBindings::bind(pybind11::module& m, void* pCallstack) {
     xLinkConnection.def(py::init<const DeviceInfo&, std::vector<std::uint8_t> >())
         .def(py::init<const DeviceInfo&, std::string>())
         .def(py::init<const DeviceInfo&>())
-        .def_static(
-            "getAllConnectedDevices", &XLinkConnection::getAllConnectedDevices, py::arg("state") = X_LINK_ANY_STATE, py::arg("skipInvalidDevices") = true, py::arg("timeoutMs") = XLINK_DEVICE_DEFAULT_SEARCH_TIMEOUT_MS)
+        .def_static("getAllConnectedDevices",
+                    &XLinkConnection::getAllConnectedDevices,
+                    py::arg("state") = X_LINK_ANY_STATE,
+                    py::arg("skipInvalidDevices") = true,
+                    py::arg("timeoutMs") = XLINK_DEVICE_DEFAULT_SEARCH_TIMEOUT_MS)
         .def_static("getFirstDevice", &XLinkConnection::getFirstDevice, py::arg("state") = X_LINK_ANY_STATE, py::arg("skipInvalidDevice") = true)
         .def_static(
             "getDeviceById", &XLinkConnection::getDeviceById, py::arg("deviceId"), py::arg("state") = X_LINK_ANY_STATE, py::arg("skipInvalidDevice") = true)

--- a/bindings/python/src/XLinkBindings.cpp
+++ b/bindings/python/src/XLinkBindings.cpp
@@ -139,7 +139,7 @@ void XLinkBindings::bind(pybind11::module& m, void* pCallstack) {
         .def(py::init<const DeviceInfo&, std::string>())
         .def(py::init<const DeviceInfo&>())
         .def_static(
-            "getAllConnectedDevices", &XLinkConnection::getAllConnectedDevices, py::arg("state") = X_LINK_ANY_STATE, py::arg("skipInvalidDevices") = true)
+            "getAllConnectedDevices", &XLinkConnection::getAllConnectedDevices, py::arg("state") = X_LINK_ANY_STATE, py::arg("skipInvalidDevices") = true, py::arg("timeoutMs") = XLINK_DEVICE_DEFAULT_SEARCH_TIMEOUT_MS)
         .def_static("getFirstDevice", &XLinkConnection::getFirstDevice, py::arg("state") = X_LINK_ANY_STATE, py::arg("skipInvalidDevice") = true)
         .def_static(
             "getDeviceById", &XLinkConnection::getDeviceById, py::arg("deviceId"), py::arg("state") = X_LINK_ANY_STATE, py::arg("skipInvalidDevice") = true)

--- a/cmake/ports/xlink/portfile.cmake
+++ b/cmake/ports/xlink/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luxonis/XLink
-    REF 6615e0721021c136dc50a3af5a5bf16919ffef87
-    SHA512 35fb1c1ee8dea69a6bf577fb374fe6dd3cf815e7baef70671732fa8062d81fc34c17439fbe95f3bfe1a4266e0bc4e47b0d033c8abf586bbd7e0713891ffe6c28
+    REF 33f7a294d4b02f22257f9876f3b704fe3b0f3cf4
+    SHA512 2ede385c77bd773c817e6b76554675c808a4c4fbbd8c8df4d8dc64bd57ced3775193e1c57a4badb988bd72651661960331b6652df077b4b768af58b3b992f797
     HEAD_REF develop_server
     PATCHES
         no-hunter.patch

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -999,6 +999,8 @@ class DeviceBase {
     // Watchdog thread
     std::thread watchdogThread;
     std::atomic<bool> watchdogRunning{true};
+    std::condition_variable watchdogCondVar;
+    std::mutex watchdogMtx;
 
     // Timesync thread
     std::thread timesyncThread;

--- a/include/depthai/xlink/XLinkConnection.hpp
+++ b/include/depthai/xlink/XLinkConnection.hpp
@@ -60,7 +60,7 @@ class XLinkConnection {
      * @param skipInvalidDevices whether or not to skip over devices that cannot be successfully communicated with
      * @returns Vector of connected device information
      */
-    static std::vector<DeviceInfo> getAllConnectedDevices(XLinkDeviceState_t state = X_LINK_ANY_STATE, bool skipInvalidDevices = true);
+    static std::vector<DeviceInfo> getAllConnectedDevices(XLinkDeviceState_t state = X_LINK_ANY_STATE, bool skipInvalidDevices = true, int timeoutMs = XLINK_DEVICE_DEFAULT_SEARCH_TIMEOUT_MS);
 
     /**
      * Returns information of first device with given state

--- a/include/depthai/xlink/XLinkConnection.hpp
+++ b/include/depthai/xlink/XLinkConnection.hpp
@@ -60,7 +60,9 @@ class XLinkConnection {
      * @param skipInvalidDevices whether or not to skip over devices that cannot be successfully communicated with
      * @returns Vector of connected device information
      */
-    static std::vector<DeviceInfo> getAllConnectedDevices(XLinkDeviceState_t state = X_LINK_ANY_STATE, bool skipInvalidDevices = true, int timeoutMs = XLINK_DEVICE_DEFAULT_SEARCH_TIMEOUT_MS);
+    static std::vector<DeviceInfo> getAllConnectedDevices(XLinkDeviceState_t state = X_LINK_ANY_STATE,
+                                                          bool skipInvalidDevices = true,
+                                                          int timeoutMs = XLINK_DEVICE_DEFAULT_SEARCH_TIMEOUT_MS);
 
     /**
      * Returns information of first device with given state

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -55,6 +55,7 @@ namespace dai {
 const std::string MAGIC_PROTECTED_FLASHING_VALUE = "235539980";
 const std::string MAGIC_FACTORY_FLASHING_VALUE = "413424129";
 const std::string MAGIC_FACTORY_PROTECTED_FLASHING_VALUE = "868632271";
+constexpr int DEVICE_SEARCH_FIRST_TIMEOUT_MS = 30;
 
 const unsigned int DEFAULT_CRASHDUMP_TIMEOUT = 9000;
 
@@ -116,7 +117,7 @@ std::tuple<bool, DeviceInfo> DeviceBase::getAnyAvailableDevice(std::chrono::mill
     do {
         int timeoutMs = XLINK_DEVICE_DEFAULT_SEARCH_TIMEOUT_MS;
         if(first) {
-            timeoutMs = 30;  // for the first iteraton, have a shorter timeout
+            timeoutMs = DEVICE_SEARCH_FIRST_TIMEOUT_MS;  // for the first iteraton, have a shorter timeout
             first = false;
         }
         auto devices = XLinkConnection::getAllConnectedDevices(X_LINK_ANY_STATE, false, timeoutMs);

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -112,8 +112,14 @@ std::tuple<bool, DeviceInfo> DeviceBase::getAnyAvailableDevice(std::chrono::mill
     bool found = false;
     DeviceInfo deviceInfo;
     std::unordered_map<std::string, DeviceInfo> invalidDevices;
+    bool first = true;
     do {
-        auto devices = XLinkConnection::getAllConnectedDevices(X_LINK_ANY_STATE, false);
+        int timeoutMs = XLINK_DEVICE_DEFAULT_SEARCH_TIMEOUT_MS;
+        if(first) {
+            timeoutMs = 30;  // for the first iteraton, have a shorter timeout
+            first = false;
+        }
+        auto devices = XLinkConnection::getAllConnectedDevices(X_LINK_ANY_STATE, false, timeoutMs);
         for(auto searchState : {X_LINK_UNBOOTED, X_LINK_BOOTLOADER, X_LINK_FLASH_BOOTED, X_LINK_GATE}) {
             for(const auto& device : devices) {
                 if(device.state == searchState) {

--- a/src/device/DeviceGate.cpp
+++ b/src/device/DeviceGate.cpp
@@ -210,7 +210,7 @@ bool DeviceGate::stopSession() {
 
 bool DeviceGate::destroySession() {
     if(getState() == SessionState::DESTROYED) {
-        spdlog::warn("DeviceGate trying to destroy already destroyed session");
+        spdlog::debug("DeviceGate trying to destroy already destroyed session");
         return true;
     }
 

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -187,7 +187,7 @@ std::vector<DeviceInfo> filterDevices(const std::vector<DeviceInfo>& deviceInfos
     return filtered;
 }
 
-std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState_t state, bool skipInvalidDevices) {
+std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState_t state, bool skipInvalidDevices, int timeoutMs) {
     initialize();
 
     std::vector<DeviceInfo> devices;
@@ -199,7 +199,7 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
     suitableDevice.platform = getDefaultPlatform();
     suitableDevice.state = state;
 
-    auto status = XLinkFindAllSuitableDevices(suitableDevice, deviceDescAll.data(), static_cast<unsigned int>(deviceDescAll.size()), &numdev);
+    auto status = XLinkFindAllSuitableDevices(suitableDevice, deviceDescAll.data(), static_cast<unsigned int>(deviceDescAll.size()), &numdev, timeoutMs);
     if(status == X_LINK_DEVICE_NOT_FOUND) {
         return devices;
     }
@@ -239,7 +239,7 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
         deviceDesc_t desc = suitableDevice;
         desc.name[sizeof(desc.name) - 1] = 0;
         strncpy(desc.name, name.c_str(), sizeof(desc.name) - 1);
-        auto status = XLinkFindAllSuitableDevices(desc, deviceDescAll.data(), static_cast<unsigned int>(deviceDescAll.size()), &numdev);
+        auto status = XLinkFindAllSuitableDevices(desc, deviceDescAll.data(), static_cast<unsigned int>(deviceDescAll.size()), &numdev, timeoutMs);
         if(status != X_LINK_SUCCESS) throw std::runtime_error("Couldn't retrieve all connected devices while searching by name");
         for(unsigned i = 0; i < numdev; i++) {
             DeviceInfo info(deviceDescAll.at(i));

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -230,7 +230,7 @@ std::vector<DeviceInfo> XLinkConnection::getAllConnectedDevices(XLinkDeviceState
         }
     }
 
-    if(!devicesFiltered.empty() && allDevicesInEnvVarsFound) { // If a device from the list is found, return it without further searching
+    if(!devicesFiltered.empty() && allDevicesInEnvVarsFound) {  // If a device from the list is found, return it without further searching
         return devicesFiltered;
     }
 


### PR DESCRIPTION
## Purpose
Improve device re-connection time.

## Specification
This PR drastically improves the device re-connection time by improving the logic for joining threads with condition variables and
an XLink update to first do a brief search with a very short timeout.

Alongside with an Luxonis OS update the time to reconnect to a device went from ~13 seconds to ~0.3 seconds.

## Dependencies & Potential Impact
XLink dependency was updated to allow specifying a custom timeout.

## Deployment Plan
/

## Testing & Validation
Manually tested, CI tests will be added once an OS update is in place.
