### PR TITLE
V3 Fix token logic in EventsManager

### DIFF
--- a/src/utility/EventsManager.cpp
+++ b/src/utility/EventsManager.cpp
@@ -112,9 +112,6 @@ EventsManager::EventsManager(std::string url, bool uploadCachedOnStart, float pu
     sourceAppId = utility::getEnvAs<std::string>("AGENT_APP_ID", "");
     sourceAppIdentifier = utility::getEnvAs<std::string>("AGENT_APP_IDENTIFIER", "");
     token = utility::getEnvAs<std::string>("DEPTHAI_HUB_API_KEY", "");
-    if(token.empty()) {
-        throw std::runtime_error("Missing token, please set DEPTHAI_HUB_API_KEY environment variable or use setToken method");
-    }
     eventBufferThread = std::make_unique<std::thread>([this]() {
         while(!stopEventBuffer) {
             sendEventBuffer();
@@ -144,6 +141,10 @@ void EventsManager::sendEventBuffer() {
     {
         std::lock_guard<std::mutex> lock(eventBufferMutex);
         if(eventBuffer.empty()) {
+            return;
+        }
+        if(token.empty()) {
+            logger::warn("Missing token, please set DEPTHAI_HUB_API_KEY environment variable or use setToken method");
             return;
         }
         if(!checkConnection()) {

--- a/src/utility/EventsManager.cpp
+++ b/src/utility/EventsManager.cpp
@@ -109,8 +109,8 @@ EventsManager::EventsManager(std::string url, bool uploadCachedOnStart, float pu
       uploadCachedOnStart(uploadCachedOnStart),
       cacheIfCannotSend(false),
       stopEventBuffer(false) {
-    sourceAppId = utility::getEnvAs<std::string>("AGENT_APP_ID", "");
-    sourceAppIdentifier = utility::getEnvAs<std::string>("AGENT_APP_IDENTIFIER", "");
+    sourceAppId = utility::getEnvAs<std::string>("OAKAGENT_APP_VERSION", "");
+    sourceAppIdentifier = utility::getEnvAs<std::string>("OAKAGENT_APP_IDENTIFIER", "");
     token = utility::getEnvAs<std::string>("DEPTHAI_HUB_API_KEY", "");
     eventBufferThread = std::make_unique<std::thread>([this]() {
         while(!stopEventBuffer) {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes logic in EventsManager where it previously threw error when token was not set, now it just prints warnings before publishing events. Also updates APP ID/IDENTIFIER env variables to the latest convention
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable