### PR TITLE
Auto-detect VCM (focus chip) for IMX378

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "5d2d154519567b2e9586e10ff3773b38d639cd15")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "a6b14a3eaa955973c529dd456064a2d3678bd7d8")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
New OAK devices will have the VCM changed on IMX378 CCM, this FW update ensures focus will still work properly on those devices.