### PR TITLE
V3 VectorPoint2f fix

### DIFF
--- a/bindings/python/src/common/ModelTypeBindings.cpp
+++ b/bindings/python/src/common/ModelTypeBindings.cpp
@@ -2,11 +2,9 @@
 
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
 
 #include <depthai/common/ModelType.hpp>
 
-PYBIND11_MAKE_OPAQUE(std::vector<uint8_t>);
 
 void ModelTypeBindings::bind(pybind11::module& m, void* pCallstack) {
     using namespace dai;

--- a/bindings/python/src/nn_archive/NNArchiveBindings.cpp
+++ b/bindings/python/src/nn_archive/NNArchiveBindings.cpp
@@ -2,7 +2,6 @@
 
 #include <pybind11/functional.h>
 #include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
 
 #include "depthai/nn_archive/NNArchive.hpp"
 #include "depthai/nn_archive/NNArchiveEntry.hpp"
@@ -20,7 +19,6 @@
 #include "depthai/nn_archive/v1/Output.hpp"
 #include "depthai/nn_archive/v1/PreprocessingBlock.hpp"
 
-PYBIND11_MAKE_OPAQUE(std::vector<uint8_t>);
 
 void NNArchiveBindings::bind(pybind11::module& m, void* pCallstack) {
     using namespace dai;

--- a/bindings/python/src/pipeline/CommonBindings.cpp
+++ b/bindings/python/src/pipeline/CommonBindings.cpp
@@ -45,7 +45,7 @@ void CommonBindings::bind(pybind11::module& m, void* pCallstack) {
     py::class_<Timestamp> timestamp(m, "Timestamp", DOC(dai, Timestamp));
     py::class_<Point2f> point2f(m, "Point2f", DOC(dai, Point2f));
     py::class_<Point3f> point3f(m, "Point3f", DOC(dai, Point3f));
-    py::class_<Point3fRGBA> point3fRGB(m, "Point3fRGBA", DOC(dai, Point3fRGBA));
+    py::class_<Point3fRGBA> point3fRGBA(m, "Point3fRGBA", DOC(dai, Point3fRGBA));
     py::class_<Point3d> point3d(m, "Point3d", DOC(dai, Point3d));
     py::class_<Quaterniond> quaterniond(m, "Quaterniond", DOC(dai, Quaterniond));
     py::class_<Size2f> size2f(m, "Size2f", DOC(dai, Size2f));
@@ -151,7 +151,7 @@ void CommonBindings::bind(pybind11::module& m, void* pCallstack) {
         .def_readwrite("x", &Point3f::x)
         .def_readwrite("y", &Point3f::y)
         .def_readwrite("z", &Point3f::z);
-    point3fRGB.def(py::init<>())
+    point3fRGBA.def(py::init<>())
         .def(py::init<float, float, float, int, int, int>())
         .def_readwrite("x", &Point3fRGBA::x)
         .def_readwrite("y", &Point3fRGBA::y)

--- a/bindings/python/src/pipeline/datatype/ImgAnnotationsBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgAnnotationsBindings.cpp
@@ -32,6 +32,7 @@ void bind_imageannotations(pybind11::module& m, void* pCallstack) {
     py::class_<ImgAnnotation> imageAnnotation(m, "ImgAnnotation", DOC(dai, ImgAnnotation));
 
     py::bind_vector<std::vector<dai::Color>>(m, "VectorColor");
+    py::bind_vector<std::vector<dai::Point2f>>(m, "VectorPoint2f");
     py::bind_vector<std::vector<dai::CircleAnnotation>>(m, "VectorCircleAnnotation");
     py::bind_vector<std::vector<dai::PointsAnnotation>>(m, "VectorPointsAnnotation");
     py::bind_vector<std::vector<dai::TextAnnotation>>(m, "VectorTextAnnotation");

--- a/bindings/python/src/pipeline/datatype/ImgAnnotationsBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgAnnotationsBindings.cpp
@@ -16,7 +16,6 @@
 // #include "spdlog/spdlog.h"
 
 PYBIND11_MAKE_OPAQUE(std::vector<dai::Color>);
-PYBIND11_MAKE_OPAQUE(std::vector<dai::Point2f>);
 PYBIND11_MAKE_OPAQUE(std::vector<dai::CircleAnnotation>);
 PYBIND11_MAKE_OPAQUE(std::vector<dai::PointsAnnotation>);
 PYBIND11_MAKE_OPAQUE(std::vector<dai::TextAnnotation>);
@@ -33,7 +32,6 @@ void bind_imageannotations(pybind11::module& m, void* pCallstack) {
     py::class_<ImgAnnotation> imageAnnotation(m, "ImgAnnotation", DOC(dai, ImgAnnotation));
 
     py::bind_vector<std::vector<dai::Color>>(m, "VectorColor");
-    py::bind_vector<std::vector<dai::Point2f>>(m, "VectorPoint2f");
     py::bind_vector<std::vector<dai::CircleAnnotation>>(m, "VectorCircleAnnotation");
     py::bind_vector<std::vector<dai::PointsAnnotation>>(m, "VectorPointsAnnotation");
     py::bind_vector<std::vector<dai::TextAnnotation>>(m, "VectorTextAnnotation");

--- a/bindings/python/src/pybind11_common.hpp
+++ b/bindings/python/src/pybind11_common.hpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <depthai/utility/Path.hpp>
+#include <depthai/common/Point2f.hpp>
 #include <pybind11_json/pybind11_json.hpp>
 #include <stack>
 #include <utility/SpanBindings.hpp>
@@ -21,6 +22,8 @@
 // Include docstring file
 #include "docstring.hpp"
 
+PYBIND11_MAKE_OPAQUE(std::vector<uint8_t>);
+PYBIND11_MAKE_OPAQUE(std::vector<dai::Point2f>);
 namespace pybind11 {
 namespace detail {
 template <>


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes errors when appending VectorPoints2f on some platforms.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
In terms of API nothing changes, just definitions of some STL containers have been moved since they violated One definition rule (not sure why only those)

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested with following MRE:
```
import depthai as dai

pts_annot = dai.PointsAnnotation()
pts_annot.points = dai.VectorPoint2f([dai.Point2f(0.3, 0.2)])
```