### PR TITLE
Fix Vec2f list assignment in python bindings

### DIFF
--- a/bindings/python/src/pipeline/datatype/ImgAnnotationsBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgAnnotationsBindings.cpp
@@ -32,11 +32,17 @@ void bind_imageannotations(pybind11::module& m, void* pCallstack) {
     py::class_<ImgAnnotation> imageAnnotation(m, "ImgAnnotation", DOC(dai, ImgAnnotation));
 
     py::bind_vector<std::vector<dai::Color>>(m, "VectorColor");
+    py::implicitly_convertible<py::list, std::vector<dai::Color>>();
     py::bind_vector<std::vector<dai::Point2f>>(m, "VectorPoint2f");
+    py::implicitly_convertible<py::list, std::vector<dai::Point2f>>();
     py::bind_vector<std::vector<dai::CircleAnnotation>>(m, "VectorCircleAnnotation");
+    py::implicitly_convertible<py::list, std::vector<dai::CircleAnnotation>>();
     py::bind_vector<std::vector<dai::PointsAnnotation>>(m, "VectorPointsAnnotation");
+    py::implicitly_convertible<py::list, std::vector<dai::PointsAnnotation>>();
     py::bind_vector<std::vector<dai::TextAnnotation>>(m, "VectorTextAnnotation");
+    py::implicitly_convertible<py::list, std::vector<dai::TextAnnotation>>();
     py::bind_vector<std::vector<dai::ImgAnnotation>>(m, "VectorImgAnnotation");
+    py::implicitly_convertible<py::list, std::vector<dai::ImgAnnotation>>();
 
     ///////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fix warp_mesh.py example, it threw following error

```
2025-04-09T07:18:50.9953395Z [RVC4] 114:     warp.setWarpMesh([
2025-04-09T07:18:50.9953676Z [RVC4] 114: TypeError: setWarpMesh(): incompatible function arguments. The following argument types are supported:
2025-04-09T07:18:50.9954043Z [RVC4] 114:     1. (self: depthai.node.Warp, arg0: depthai.VectorPoint2f, arg1: int, arg2: int) -> None
2025-04-09T07:18:50.9954363Z [RVC4] 114:     2. (self: depthai.node.Warp, arg0: list[tuple[float, float]], arg1: int, arg2: int) -> None
2025-04-09T07:18:50.9954589Z [RVC4] 114:
2025-04-09T07:18:50.9955428Z [RVC4] 114: Invoked with: <depthai.node.Warp object at 0x788998143bf0>, [<depthai.Point2f object at 0x78899c1eea70>, <depthai.Point2f object at 0x788998186230>, <depthai.Point2f object at 0x788998194630>, <depthai.Point2f object at 0x78899816ca30>, <depthai.Point2f object at 0x788998133cb0>, <depthai.Point2f object at 0x78899c1cf270>, <depthai.Point2f object at 0x7889981d06b0>, <depthai.Point2f object at 0x7889981d3f70>, <depthai.Point2f object at 0x7889981d3930>], 3, 3
```
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Add 
```
py::implicitly_convertible<py::list, std::vector<dai::Point2f>>();
```
in ImageAnnotationsBindings, added also for other types

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable