### PR TITLE
Set default transformation when replaying video without metadata

### DIFF
--- a/cmake/triplets/x64-linux.cmake
+++ b/cmake/triplets/x64-linux.cmake
@@ -9,3 +9,4 @@ if(PORT MATCHES "libusb|ffmpeg")
 endif()
 
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+set(VCPKG_LINKER_FLAGS "-Wl,-z,noseparate-code")

--- a/cmake/triplets/x64-linux.cmake
+++ b/cmake/triplets/x64-linux.cmake
@@ -9,4 +9,3 @@ if(PORT MATCHES "libusb|ffmpeg")
 endif()
 
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
-set(VCPKG_LINKER_FLAGS "-Wl,-z,noseparate-code")

--- a/src/pipeline/node/host/Replay.cpp
+++ b/src/pipeline/node/host/Replay.cpp
@@ -253,6 +253,7 @@ void ReplayVideo::run() {
             frame.setTimestampDevice(std::chrono::time_point<std::chrono::steady_clock>(time));
             frame.setSequenceNum(index++);
             frame.sourceFb = frame.fb;
+            frame.transformation = ImgTransformation(width, height);
             auto protoMsg = utility::getProtoMessage(&frame, true);
             std::shared_ptr<google::protobuf::Message> sharedProtoMsg = std::move(protoMsg);
             metadata = std::dynamic_pointer_cast<proto::img_frame::ImgFrame>(sharedProtoMsg);

--- a/tests/src/onhost_tests/replay_test.cpp
+++ b/tests/src/onhost_tests/replay_test.cpp
@@ -85,3 +85,30 @@ TEST_CASE("ReplayVideo node") {
         p.stop();
     }
 }
+
+TEST_CASE("ReplayVideo no metadata") {
+    {
+        TestHelper helper;
+
+        dai::Pipeline p(false);
+
+        auto replayNode = p.create<dai::node::ReplayVideo>();
+        replayNode->setReplayVideoFile(helper.testFolder + "/extracted/CameraCAM_A.mp4");
+        replayNode->setOutFrameType(dai::ImgFrame::Type::NV12);
+        replayNode->setLoop(true);
+
+        auto q = replayNode->out.createOutputQueue();
+
+        p.start();
+        for(auto i = 0U; i < NUM_MSGS; i++) {
+            if(!p.isRunning()) break;
+            auto data = q->get<dai::ImgFrame>();
+            REQUIRE(data != nullptr);
+            REQUIRE(data->getWidth() > 0);
+            REQUIRE(data->getHeight() > 0);
+            REQUIRE(data->getType() == dai::ImgFrame::Type::NV12);
+            REQUIRE(data->validateTransformations());
+        }
+        p.stop();
+    }
+}


### PR DESCRIPTION
## Purpose
Transformation data was not set on ImgFrame when replaying without metadata, now it is.

## Specification
None / not applicable

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable