### PR TITLE
Fix method responsible for creating python subnodes (createSubnode)

### DIFF
--- a/bindings/python/src/pipeline/node/HostNodeBindings.cpp
+++ b/bindings/python/src/pipeline/node/HostNodeBindings.cpp
@@ -172,7 +172,11 @@ void bind_hostnode(pybind11::module& m, void* pCallstack) {
 
         # Create a subnode as part of this user node
         def createSubnode(self, class_, *args, **kwargs):
-            return self.getParentPipeline().create(class_, *args, **kwargs)
+            pipeline = self.getParentPipeline()
+            child_node = pipeline.create(class_, *args, **kwargs)
+            pipeline.remove(child_node) # necessary so that the node is only registered once
+            self.add(child_node)
+            return child_node
 
         node.HostNode.createSubnode = createSubnode
         node.ThreadedHostNode.createSubnode = createSubnode

--- a/bindings/python/src/pipeline/node/NodeBindings.cpp
+++ b/bindings/python/src/pipeline/node/NodeBindings.cpp
@@ -430,7 +430,8 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("getAssetManager",
              static_cast<AssetManager& (Node::*)()>(&Node::getAssetManager),
              py::return_value_policy::reference_internal,
-             DOC(dai, Node, getAssetManager));
+             DOC(dai, Node, getAssetManager))
+        .def("add", &Node::add, py::arg("node"), DOC(dai, Node, add));
 
     // TODO(themarpe) - refactor, threaded node could be separate from Node
     pyThreadedNode.def("trace", [](dai::ThreadedNode& node, const std::string& msg) { node.logger->trace(msg); })

--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -589,7 +589,7 @@ void Node::remove(std::shared_ptr<Node> node) {
     auto pipeline = parent.lock();
 
     DAI_CHECK_V(pipeline != nullptr, "Pipeline is null");
-    DAI_CHECK_V(!pipeline->isBuilt(), "Cannot remove a node from another node once pipeline is built.");
+    DAI_CHECK_V(!pipeline->isBuilt(), "Cannot remove node from pipeline once it is built.");
 
     for(auto& n : pipeline->nodes) {
         for(auto& childNode : node->nodeMap) {

--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -587,10 +587,8 @@ void Node::add(std::shared_ptr<Node> node) {
 void Node::remove(std::shared_ptr<Node> node) {
     // Remove the connection to the removed node and all it's children from all the nodes in the pipeline
     auto pipeline = parent.lock();
-    if(pipeline == nullptr) {
-        throw std::runtime_error("Pipeline is null");
-    }
 
+    DAI_CHECK_V(pipeline != nullptr, "Pipeline is null");
     DAI_CHECK_V(!pipeline->isBuilt(), "Cannot remove a node from another node once pipeline is built.");
 
     for(auto& n : pipeline->nodes) {

--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -591,6 +591,8 @@ void Node::remove(std::shared_ptr<Node> node) {
         throw std::runtime_error("Pipeline is null");
     }
 
+    DAI_CHECK_V(!pipeline->isBuilt(), "Cannot remove a node from another node once pipeline is built.");
+
     for(auto& n : pipeline->nodes) {
         for(auto& childNode : node->nodeMap) {
             n->removeConnectionToNode(childNode);

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -18,6 +18,7 @@
 #include "utility/Platform.hpp"
 #include "utility/RecordReplayImpl.hpp"
 #include "utility/spdlog-fmt.hpp"
+#include "utility/ErrorMacros.hpp"
 
 // shared
 #include "depthai/pipeline/NodeConnectionSchema.hpp"
@@ -438,6 +439,8 @@ BoardConfig PipelineImpl::getBoardConfig() const {
 
 // Remove node capability
 void PipelineImpl::remove(std::shared_ptr<Node> toRemove) {
+    DAI_CHECK_V(!isBuilt(), "Cannot remove node from pipeline once it is built.");
+
     if(toRemove->parent.lock() == nullptr) {
         throw std::invalid_argument("Cannot remove a node that is not a part of any pipeline");
     }

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -13,12 +13,12 @@
 #include "pipeline/node/DetectionNetwork.hpp"
 #include "utility/Compression.hpp"
 #include "utility/Environment.hpp"
+#include "utility/ErrorMacros.hpp"
 #include "utility/HolisticRecordReplay.hpp"
 #include "utility/Logging.hpp"
 #include "utility/Platform.hpp"
 #include "utility/RecordReplayImpl.hpp"
 #include "utility/spdlog-fmt.hpp"
-#include "utility/ErrorMacros.hpp"
 
 // shared
 #include "depthai/pipeline/NodeConnectionSchema.hpp"
@@ -440,14 +440,8 @@ BoardConfig PipelineImpl::getBoardConfig() const {
 // Remove node capability
 void PipelineImpl::remove(std::shared_ptr<Node> toRemove) {
     DAI_CHECK_V(!isBuilt(), "Cannot remove node from pipeline once it is built.");
-
-    if(toRemove->parent.lock() == nullptr) {
-        throw std::invalid_argument("Cannot remove a node that is not a part of any pipeline");
-    }
-
-    if(toRemove->parent.lock() != parent.pimpl) {
-        throw std::invalid_argument("Cannot remove a node that is not a part of this pipeline");
-    }
+    DAI_CHECK_V(toRemove->parent.lock() != nullptr, "Cannot remove a node that is not a part of any pipeline");
+    DAI_CHECK_V(toRemove->parent.lock() == parent.pimpl, "Cannot remove a node that is not a part of this pipeline");
 
     // First remove the node from the pipeline directly
     auto it = std::remove(nodes.begin(), nodes.end(), toRemove);

--- a/src/pipeline/ThreadedNode.cpp
+++ b/src/pipeline/ThreadedNode.cpp
@@ -5,6 +5,7 @@
 #include "utility/Environment.hpp"
 #include "utility/Logging.hpp"
 #include "utility/Platform.hpp"
+#include "utility/ErrorMacros.hpp"
 
 namespace dai {
 ThreadedNode::ThreadedNode() {
@@ -17,6 +18,11 @@ ThreadedNode::ThreadedNode() {
 }
 
 void ThreadedNode::start() {
+
+    // A node should not be started if it is already running
+    // We would be creating multiple threads for the same node
+    DAI_CHECK_V(!isRunning(), "Node with id {} is already running. Cannot start it again. Node name: {}", id, getName());
+
     onStart();
     // Start the thread
     running = true;


### PR DESCRIPTION
## Purpose
Previously, a sub-node added to a node via the `createSubnode` python method would not be registered by the parent node. As a result of that, when deleting the parent node, the subnode would still remain in the pipeline. This PR fixes that. 

The way we go about doing it is by creating a node using the already established pipeline create method, we then remove that node from the pipeline and finally add it as a child node to the parent node. This is necessary because otherwise `getAllNodes` contains the same node twice, thereby breaking many other methods.

Clickup task: https://app.clickup.com/t/86c3cb67q
