### PR TITLE
V3 VIO correction

### DIFF
--- a/src/basalt/BasaltVIO.cpp
+++ b/src/basalt/BasaltVIO.cpp
@@ -31,12 +31,12 @@ void BasaltVIO::buildInternal() {
     imu.addCallback(std::bind(&BasaltVIO::imuCB, this, std::placeholders::_1));
 
     basalt::PoseState<double>::SE3 initTrans(Eigen::Quaterniond::Identity(), Eigen::Vector3d(0, 0, 0));
-    Eigen::Matrix<double, 3, 3> R180;
-    R180 << -1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0;
-    Eigen::Quaterniond q180(R180);
-    basalt::PoseState<double>::SE3 opticalTransform180(q180, Eigen::Vector3d(0, 0, 0));
+    Eigen::Matrix<double, 3, 3> R;
+    R << 0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0;
+    Eigen::Quaterniond q(R);
+    basalt::PoseState<double>::SE3 initialRotation(q, Eigen::Vector3d(0, 0, 0));
     // to output pose in FLU world coordinates
-    localTransform = std::make_shared<basalt::PoseState<double>::SE3>(initTrans * opticalTransform180.inverse());
+    localTransform = std::make_shared<basalt::PoseState<double>::SE3>(initTrans * initialRotation.inverse());
     setDefaultVIOConfig();
 }
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Update BasaltVIO initial orientation to reflect new IMU extrinsics - without this change Camera's position is rotated to the left vs position from RTABMap
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Just update the initial rotation

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested with VIO/VSLAM examples with OAK-D Pro/Pro W