### PR TITLE
Fix NNArchive issue with multiple users

### DIFF
--- a/src/nn_archive/NNArchive.cpp
+++ b/src/nn_archive/NNArchive.cpp
@@ -28,8 +28,10 @@ NNArchive::NNArchive(const std::string& archivePath, NNArchiveOptions options) :
     modelType = model::readModelType(modelPathInArchive);
 
     // Unpack model
-    unpackArchiveInDirectory(archivePath, (std::filesystem::path(archiveOptions.extractFolder()) / std::filesystem::path(archivePath).filename()).string());
-    unpackedModelPath = (std::filesystem::path(archiveOptions.extractFolder()) / std::filesystem::path(archivePath).filename() / modelPathInArchive).string();
+    std::filesystem::path unpackedArchivePath = std::filesystem::path(archiveOptions.extractFolder()) / std::filesystem::path(archivePath).filename();
+    unpackedArchivePath += "_" + std::to_string(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+    unpackArchiveInDirectory(archivePath, unpackedArchivePath.string());
+    unpackedModelPath = (unpackedArchivePath / modelPathInArchive).string();
 
     switch(modelType) {
         case model::ModelType::BLOB:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fix issue on linux where different users could not use the same model with NNArchive due to a conflict in /tmp

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Add timestamp to the end of the temporary directory to avoid conflicts

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable