### PR TITLE
Update flashCalibration

### DIFF
--- a/bindings/python/src/DeviceBindings.cpp
+++ b/bindings/python/src/DeviceBindings.cpp
@@ -696,13 +696,13 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
             },
             DOC(dai, DeviceBase, readCalibration))
         .def(
-            "flashCalibration",
+            "tryFlashCalibration",
             [](DeviceBase& d, CalibrationHandler calibrationDataHandler) {
                 py::gil_scoped_release release;
-                return d.flashCalibration(calibrationDataHandler);
+                return d.tryFlashCalibration(calibrationDataHandler);
             },
             py::arg("calibrationDataHandler"),
-            DOC(dai, DeviceBase, flashCalibration))
+            DOC(dai, DeviceBase, tryFlashCalibration))
         .def(
             "setXLinkChunkSize",
             [](DeviceBase& d, int s) {
@@ -752,12 +752,12 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
             },
             DOC(dai, DeviceBase, isEepromAvailable))
         .def(
-            "flashCalibration2",
+            "flashCalibration",
             [](DeviceBase& d, CalibrationHandler ch) {
                 py::gil_scoped_release release;
-                return d.flashCalibration2(ch);
+                return d.flashCalibration(ch);
             },
-            DOC(dai, DeviceBase, flashCalibration2))
+            DOC(dai, DeviceBase, flashCalibration))
         .def(
             "readCalibration2",
             [](DeviceBase& d) {

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -605,7 +605,7 @@ class DeviceBase {
      *
      * @return true on successful flash, false on failure
      */
-    bool flashCalibration(CalibrationHandler calibrationDataHandler);
+    bool tryFlashCalibration(CalibrationHandler calibrationDataHandler);
 
     /**
      * Stores the Calibration and Device information to the Device EEPROM
@@ -613,7 +613,7 @@ class DeviceBase {
      * @throws std::runtime_exception if failed to flash the calibration
      * @param calibrationObj CalibrationHandler object which is loaded with calibration information.
      */
-    void flashCalibration2(CalibrationHandler calibrationDataHandler);
+    void flashCalibration(CalibrationHandler calibrationDataHandler);
 
     /**
      * Sets the Calibration at runtime. This is not persistent and will be lost after device reset.

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1380,7 +1380,7 @@ bool DeviceBase::isEepromAvailable() {
     return pimpl->rpcClient->call("isEepromAvailable").as<bool>();
 }
 
-bool DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
+bool DeviceBase::tryFlashCalibration(CalibrationHandler calibrationDataHandler) {
     try {
         flashCalibration2(calibrationDataHandler);
     } catch(const EepromError&) {
@@ -1389,7 +1389,7 @@ bool DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
     return true;
 }
 
-void DeviceBase::flashCalibration2(CalibrationHandler calibrationDataHandler) {
+void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
     bool factoryPermissions = false;
     bool protectedPermissions = false;
     getFlashingPermissions(factoryPermissions, protectedPermissions);

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1382,8 +1382,9 @@ bool DeviceBase::isEepromAvailable() {
 
 bool DeviceBase::tryFlashCalibration(CalibrationHandler calibrationDataHandler) {
     try {
-        flashCalibration2(calibrationDataHandler);
-    } catch(const EepromError&) {
+        flashCalibration(calibrationDataHandler);
+    } catch(const EepromError& e) {
+        pimpl->logger.error("Failed to flash calibration: {}", e.what());
         return false;
     }
     return true;
@@ -1405,7 +1406,7 @@ void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
                                       .as<std::tuple<bool, std::string>>();
 
     if(!success) {
-        throw std::runtime_error(errorMsg);
+        throw EepromError(errorMsg);
     }
 }
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Update function signatures to match docs.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
`flashCalibration2` has been renamed to `flashCalibration` and `flashCalibration` has been renamed to `tryFlashCalibration`


## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable