### PR TITLE
Fixing the error in implementation

### DIFF
--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -388,7 +388,7 @@ std::vector<std::vector<float>> CalibrationHandler::getCameraExtrinsics(CameraBo
     invertSe3Matrix4x4InPlace(dstOriginMatrix);
 
     // Get the matrix from src to dst camera
-    extrinsics = matMul(srcOriginMatrix, dstOriginMatrix);
+    extrinsics = matMul(dstOriginMatrix, srcOriginMatrix);
     return extrinsics;
 }
 


### PR DESCRIPTION
There is a mistake in the implementation of :getCameraExtrinsics in depthAI.
Based on the observation and the code, the statement 
    // Get the matrix from src to dst camera
    extrinsics = matMul(dstOriginMatrix, srcOriginMatrix);
suggests, that the follwoing path is srcToOrigin -> OriginToDst , but following matrix multiplication does the opposite of that so OriginToDst -> srcToOrigin, which leaves you nowhere near your desired result.

Suggested change:
    extrinsics = matMul(dstOriginMatrix, srcOriginMatrix);
Implementation of test for that could be pretty simple one:
getTranslationVector and Rotation matrix
again set them in same calibration
getTranslationVector and Rotation matrix

IN case implementation is correct, you should get same values before and after you set new vector, that was not the case here:
Calibration set before:
OLD IMPLEMENTATION
[[ 0.99996287 -0.00411839 -0.00755981]
 [ 0.00407606  0.99997592 -0.00560668]
 [ 0.00758272  0.00557566  0.99995571]]
[-7.5265584  -0.06545853  0.01463436]
CALIBRATION AFTER SET:
[[0.9999629855155945, -0.00409860722720623, -0.0075498041696846485], [0.004056117497384548, 0.9999758005142212, -0.00563457328826189], [0.007572715170681477, 0.005603741854429245, 0.9999557137489319]]
[-7.527095794677734, -0.11310863494873047, -0.021096184849739075]

NEW IMPLEMENTATION:
Calibration set before:
[[ 0.99996275 -0.00413823 -0.00756964]
 [ 0.00409605  0.99997598 -0.00557877]
 [ 0.00759254  0.00554755  0.99995583]]
[-7.52579308 -0.01762358  0.05024702]
Now I will initially set the camera matrix
CALIBRATION AFTER SET:
[[0.9999626874923706, -0.004138225689530373, -0.0075696357525885105], [0.004096050746738911, 0.9999759197235107, -0.005578766576945782], [0.007592540699988604, 0.005547555163502693, 0.9999558925628662]]
[-7.525793075561523, -0.017623579129576683, 0.05024702101945877]
Which suggested, there was an error in implementation of logic.

Example of integration test below:
# Print full EEPROM calibration as JSON
print("=== EEPROM Calibration Dump ===")
print(calibOld.eepromToJson())

# --- Before modification ---
print("\n=== Calibration Before Set ===")
rmat_before = np.array(calibOld.getCameraRotationMatrix(
    dai.CameraBoardSocket.CAM_B, dai.CameraBoardSocket.CAM_C))
tbefore = np.array(calibOld.getCameraTranslationVector(
    dai.CameraBoardSocket.CAM_B, dai.CameraBoardSocket.CAM_C, False))

print("Rotation matrix (CAM_B → CAM_C):")
print(rmat_before)

print("Translation vector (CAM_B → CAM_C):")
print(tbefore)

# --- Set extrinsics ---
print("\n=== Setting New Extrinsics ===")
spec_translation = np.array([-7.5, 0, 0])
calibOld.setCameraExtrinsics(
    dai.CameraBoardSocket.CAM_B,
    dai.CameraBoardSocket.CAM_C,
    rmat_before.tolist(),      # 3x3 rotation
    tbefore.tolist(),          # 3x1 translation
    spec_translation.tolist()  # 3x1 specTranslation
)
print(f"Applied specTranslation: {spec_translation}")

# --- After modification ---
print("\n=== Calibration After Set ===")
rmat_new = np.array(calibOld.getCameraRotationMatrix(
    dai.CameraBoardSocket.CAM_B, dai.CameraBoardSocket.CAM_C))
tnew = np.array(calibOld.getCameraTranslationVector(
    dai.CameraBoardSocket.CAM_B, dai.CameraBoardSocket.CAM_C, False))

print("New Rotation matrix (CAM_B → CAM_C):")
print(rmat_new)

print("New Translation vector (CAM_B → CAM_C):")
print(tnew)