### PR TITLE
Bump os versions

### DIFF
--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/test_child.yml
     with:
       flavor: "vanilla"
-      luxonis_os_versions_to_test: "['r851.1.2', 'debug-1.6.0', '1.14.1']"
+      luxonis_os_versions_to_test: "['debug-1.6.0', '1.14.1', '1.15.0']"
     secrets:
       CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
 
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/test_child.yml
     with:
       flavor: "tsan"
-      luxonis_os_versions_to_test: "['1.14.1']"
+      luxonis_os_versions_to_test: "['1.15.0']"
     secrets:
       CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
 
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/test_child.yml
     with:
       flavor: "asan-ubsan"
-      luxonis_os_versions_to_test: "['1.14.1']"
+      luxonis_os_versions_to_test: "['1.15.0']"
     secrets:
       CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
 


### PR DESCRIPTION
Adding 1.15.0 to testing as latest version, removing 1.2

