### PR TITLE
Zoo: check for write permissions before updating a model

### DIFF
--- a/src/utility/Platform.cpp
+++ b/src/utility/Platform.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #if defined(_WIN32) || defined(__USE_W32_SOCKETS)
+    #include <io.h>
     #include <windows.h>
 #endif
 
@@ -101,23 +102,19 @@ bool checkPathExists(const std::filesystem::path& path, bool directory) {
 
 bool checkWritePermissions(const std::filesystem::path& path) {
 #if defined(_WIN32) || defined(__USE_W32_SOCKETS)
-    DWORD ftyp = GetFileAttributesA(path.string().c_str());
-    if(ftyp == INVALID_FILE_ATTRIBUTES) {
-        return false;  // Path does not exist
-    } else if(ftyp & FILE_ATTRIBUTE_READONLY) {
-        return false;  // Path is read-only
-    } else {
-        return true;  // Path is writable
-    }
+    // 2 = write permission
+    return (_access(path.string().c_str(), 2) == 0);
 #else
-    struct stat info;
-    if(stat(path.string().c_str(), &info) != 0) {
-        return false;  // Path does not exist
-    } else if(info.st_mode & S_IWUSR) {
-        return true;  // Path is writable
-    } else {
-        return false;  // Path is read-only
-    }
+    return (access(path.string().c_str(), W_OK) == 0);
+#endif
+}
+
+bool checkReadPermissions(const std::filesystem::path& path) {
+#if defined(_WIN32) || defined(__USE_W32_SOCKETS)
+    // 4 = read permission
+    return (_access(path.string().c_str(), 4) == 0);
+#else
+    return (access(path.string().c_str(), R_OK) == 0);
 #endif
 }
 

--- a/src/utility/Platform.hpp
+++ b/src/utility/Platform.hpp
@@ -45,6 +45,13 @@ bool checkPathExists(const std::filesystem::path& path, bool directory = false);
 bool checkWritePermissions(const std::filesystem::path& path);
 
 /**
+ * @brief Check if a path has read permissions
+ * @param path Path to check
+ * @return True if path has read permissions, false otherwise
+ */
+bool checkReadPermissions(const std::filesystem::path& path);
+
+/**
  * @brief Join two paths, OS-agnostic. This is a wrapper around std::filesystem::path::operator/
  * @param path1 First path
  * @param path2 Second path

--- a/tests/src/ondevice_tests/xlink_tests.cpp
+++ b/tests/src/ondevice_tests/xlink_tests.cpp
@@ -1,10 +1,9 @@
 #include <catch2/catch_all.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
 #include <depthai/depthai.hpp>
 #include <depthai/pipeline/node/internal/XLinkIn.hpp>
-
 #include <thread>
-#include <chrono>
 using namespace std::chrono_literals;
 
 TEST_CASE("XLinkIn lazy allocation test") {
@@ -14,10 +13,10 @@ TEST_CASE("XLinkIn lazy allocation test") {
     auto xLinkInImage = p.create<dai::node::internal::XLinkIn>();
     auto xLinkInConfig = p.create<dai::node::internal::XLinkIn>();
 
-    xLinkInImage->setMaxDataSize(1024 * 1024 * 1024); // 1GB per frame
+    xLinkInImage->setMaxDataSize(1024 * 1024 * 1024);  // 1GB per frame
     xLinkInImage->setNumFrames(64);
 
-    xLinkInConfig->setMaxDataSize(1024 * 1024 * 1024); // 1GB per frame
+    xLinkInConfig->setMaxDataSize(1024 * 1024 * 1024);  // 1GB per frame
     xLinkInConfig->setNumFrames(64);
 
     xLinkInImage->out.link(manip->inputImage);


### PR DESCRIPTION
## Purpose
Without this check, the zoo manager tries to update a model, create a lock and in case of a protected path (such as `/usr/lib`) this leads to an insufficient permission error.

With this check in place, we do not try to update the model and simply return the already cached one or in the edge case of there being no cached model, we error out.