### PR TITLE
Added `getNNArchive` method to NeuralNetwork

### DIFF
--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -70,6 +70,13 @@ class NeuralNetwork : public DeviceNodeCRTP<DeviceNode, NeuralNetwork, NeuralNet
     OutputMap passthroughs{*this, "passthroughs", {"", DEFAULT_GROUP, {{{DatatypeEnum::Buffer, true}}}}};
 
     /**
+     * @brief Get the archive owned by this Node.
+     *
+     * @returns constant reference to this Nodes archive
+     */
+    std::optional<std::reference_wrapper<const NNArchive>> getNNArchive() const;
+
+    /**
      * @brief Set NNArchive for this Node. If the archive's type is SUPERBLOB, use default number of shaves.
      *
      * @param nnArchive: NNArchive to set

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -121,6 +121,12 @@ NNArchive NeuralNetwork::createNNArchive(NNModelDescription& modelDesc) {
     return nnArchive;
 }
 
+std::optional<std::reference_wrapper<const NNArchive>> NeuralNetwork::getNNArchive() const {
+    if(nnArchive) return std::cref(*nnArchive);
+    return std::nullopt;
+}
+
+
 void NeuralNetwork::setNNArchive(const NNArchive& nnArchive) {
     constexpr int DEFAULT_SUPERBLOB_NUM_SHAVES = 8;
     this->nnArchive = nnArchive;


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Allows downstream custom nodes that own a Subnode<NeuralNetwork> to delegate to NeuralNetwork build and then just read the results. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Add class method to NeuralNetwork to allow read only access to owned NNArchive.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / only additions

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Build succeeded and downstream package already using it as described [here](https://discuss.luxonis.com/d/6203-are-depthai-core-contributions-welcome/3)