### PR TITLE
Improve `depthai-core`'s responsiveness upon device crash or node errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The following environment variables can be set to alter default behavior of the 
 | DEPTHAI_ALLOW_FACTORY_FLASHING | Internal use only |
 | DEPTHAI_LIBUSB_ANDROID_JAVAVM | JavaVM pointer that is passed to libusb for rootless Android interaction with devices. Interpreted as decimal value of uintptr_t |
 | DEPTHAI_CRASHDUMP | Directory in which to save the crash dump. |
-| DEPTHAI_CRASHDUMP_TIMEOUT | Specifies the duration in seconds to wait for device reboot when obtaining a crash dump. Crash dump retrieval disabled if 0. |
+| DEPTHAI_CRASHDUMP_TIMEOUT | Specifies the duration in milliseconds to wait for device reboot when obtaining a crash dump. Crash dump retrieval disabled if 0. |
 | DEPTHAI_ENABLE_ANALYTICS_COLLECTION | Enables automatic analytics collection (pipeline schemas) used to improve the library |
 | DEPTHAI_DISABLE_CRASHDUMP_COLLECTION | Disables automatic crash dump collection used to improve the library |
 | DEPTHAI_HUB_API_KEY | API key for the Luxonis Hub |

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -58,7 +58,7 @@ const std::string MAGIC_FACTORY_FLASHING_VALUE = "413424129";
 const std::string MAGIC_FACTORY_PROTECTED_FLASHING_VALUE = "868632271";
 constexpr int DEVICE_SEARCH_FIRST_TIMEOUT_MS = 30;
 
-const unsigned int DEFAULT_CRASHDUMP_TIMEOUT = 9000;
+const unsigned int DEFAULT_CRASHDUMP_TIMEOUT_MS = 9000;
 
 // local static function
 static void getFlashingPermissions(bool& factoryPermissions, bool& protectedPermissions) {
@@ -401,10 +401,8 @@ void DeviceBase::close() {
 }
 
 unsigned int getCrashdumpTimeout(XLinkProtocol_t protocol) {
-    int defaultTimeout =
-        DEFAULT_CRASHDUMP_TIMEOUT + (protocol == X_LINK_TCP_IP ? device::XLINK_TCP_WATCHDOG_TIMEOUT.count() : device::XLINK_USB_WATCHDOG_TIMEOUT.count());
-    int timeoutSeconds = utility::getEnvAs<int>("DEPTHAI_CRASHDUMP_TIMEOUT", defaultTimeout);
-    int timeoutMs = timeoutSeconds * 1000;
+    std::chrono::milliseconds protocolTimeout = (protocol == X_LINK_TCP_IP ? device::XLINK_TCP_WATCHDOG_TIMEOUT : device::XLINK_USB_WATCHDOG_TIMEOUT);
+    int timeoutMs = utility::getEnvAs<int>("DEPTHAI_CRASHDUMP_TIMEOUT", DEFAULT_CRASHDUMP_TIMEOUT_MS + protocolTimeout.count());
     return timeoutMs;
 }
 


### PR DESCRIPTION
## Purpose
Currently, in case of python applications, when a device is disconnected or the firmware crashes, the code in `Device`'s `__exit__` method tries to retrieve a crashdump from the device. This usually takes several seconds during which the application (pybind11) doesn't check for interrupts or other errors, thus rendering the running program unresponsive.

This PR moves the mentioned long-blocking code into a detached thread and periodically checks for interrupts and other signals in the main thread. Doing this will allow users to interrupt the crashdump collecting procedure and exit their application essentially immediately.

Moreover, this PR introduces a tiny fix where the crashdump collection timeout was set to 9000 seconds (2.5 hours). I presume the intended unit of time in this case was meant to be milliseconds.