### PR TITLE
examples: Added calibration examples from V2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ _builds/
 .depthai_cached_models/
 install*
 build*
+depthai_calib_backup.json

--- a/examples/python/calibration/calibration_dump.py
+++ b/examples/python/calibration/calibration_dump.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import depthai as dai
+import json
+
+device = dai.Device(dai.UsbSpeed.HIGH)
+print(f'Is EEPROM available: {device.isEepromAvailable()}')
+
+# User calibration
+try:
+    print(f'User calibration: {json.dumps(device.readCalibration2().eepromToJson(), indent=2)}')
+except Exception as ex:
+    print(f'No user calibration: {ex}')
+
+# Factory calibration
+try:
+    print(f'Factory calibration: {json.dumps(device.readFactoryCalibration().eepromToJson(), indent=2)}')
+except Exception as ex:
+    print(f'No factory calibration: {ex}')

--- a/examples/python/calibration/calibration_factory_reset.py
+++ b/examples/python/calibration/calibration_factory_reset.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import depthai as dai
+
+device = dai.Device(dai.UsbSpeed.HIGH)
+try:
+    device.factoryResetCalibration()
+    print(f'Factory reset calibration OK')
+except Exception as ex:
+    print(f'Factory reset calibration FAIL: {ex}')

--- a/examples/python/calibration/calibration_flash.py
+++ b/examples/python/calibration/calibration_flash.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import depthai as dai
+import argparse
+
+calibBackUpFile = str(
+    (Path(__file__).parent / Path("depthai_calib_backup.json")).resolve().absolute()
+)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("calibJsonFile", help="Path to calibration file in json")
+args = parser.parse_args()
+
+device = dai.Device(dai.UsbSpeed.HIGH)
+deviceCalib = device.readCalibration()
+deviceCalib.eepromToJsonFile(calibBackUpFile)
+print("Calibration Data on the device is backed up at:")
+print(calibBackUpFile)
+calibData = dai.CalibrationHandler(args.calibJsonFile)
+
+try:
+    device.flashCalibration(calibData)
+    print("Successfully flashed calibration")
+except Exception as ex:
+    print(f"Failed flashing calibration: {ex}")

--- a/examples/python/calibration/calibration_load.py
+++ b/examples/python/calibration/calibration_load.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import cv2
+import depthai as dai
+import argparse
+import cv2
+
+parser = argparse.ArgumentParser()
+parser.add_argument("calibJsonFile", help="Path to calibration file in json")
+args = parser.parse_args()
+
+calibData = dai.CalibrationHandler(args.calibJsonFile)
+
+with dai.Pipeline() as pipeline:
+    pipeline.setCalibrationData(calibData)
+    # Define sources and output
+    monoLeft = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_B)
+    monoRight = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_C)
+    resolution = (640, 480)
+    stereo = pipeline.create(dai.node.StereoDepth).build(
+        monoLeft.requestOutput(resolution), monoRight.requestOutput(resolution)
+    )
+    depthQueue = stereo.depth.createOutputQueue()
+    pipeline.start()
+    while True:
+        # blocking call, will wait until a new data has arrived
+        inDepth = depthQueue.get()
+        frame = inDepth.getFrame()
+        # frame is ready to be shown
+        cv2.imshow("depth", frame)
+        if cv2.waitKey(1) == ord("q"):
+            break


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Calibration examples/utils have been missing for a long time in depthai-core V3. Adding most of them back in.

I ommitted:
* `calibration_flash_v5.py`, because I don't know why it's useful.
* `calibreation_reader.py`, because it has some hardcoded models, and I don't want to spend time right now checking that this still works on all models.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested locally by running `calibration_dump.py`, `calibration_flash.py` and `calibration_factory_reset.py` on an R8 OAK-T.
Tested `calibration_load.py` on an OAK4-D-Pro.