### PR TITLE
Fix remapped rect angle

### DIFF
--- a/src/utility/ImageManipImpl.cpp
+++ b/src/utility/ImageManipImpl.cpp
@@ -545,6 +545,11 @@ std::array<std::array<float, 2>, 4> dai::impl::getOuterRotatedRect(const std::ve
     for(size_t i = 1; i < hull.size(); ++i) {
         std::array<float, 2> vec = {hull[i][0] - hull[i - 1][0], hull[i][1] - hull[i - 1][1]};
         std::array<float, 2> vecOrth = {-vec[1], vec[0]};
+        float len = sqrtf(vec[0] * vec[0] + vec[1] * vec[1]);
+        vec[0] /= len;
+        vec[1] /= len;
+        vecOrth[0] /= len;
+        vecOrth[1] /= len;
         std::array<std::array<float, 2>, 2> mat = {{{vec[0], vecOrth[0]}, {vec[1], vecOrth[1]}}};
         std::array<std::array<float, 2>, 2> matInv = getInverse(mat);
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fix calculation of min area outer rect to prevent 90deg rotation. Before, if the rect was tall, the remapped (scaled, translated) rectangle would have width/height switched with a 90deg angle.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable