### PR TITLE
Improve depthai-core's responsiveness upon a device crash or a node error, attempt 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The following environment variables can be set to alter default behavior of the 
 | DEPTHAI_ALLOW_FACTORY_FLASHING | Internal use only |
 | DEPTHAI_LIBUSB_ANDROID_JAVAVM | JavaVM pointer that is passed to libusb for rootless Android interaction with devices. Interpreted as decimal value of uintptr_t |
 | DEPTHAI_CRASHDUMP | Directory in which to save the crash dump. |
-| DEPTHAI_CRASHDUMP_TIMEOUT | Specifies the duration in seconds to wait for device reboot when obtaining a crash dump. Crash dump retrieval disabled if 0. |
+| DEPTHAI_CRASHDUMP_TIMEOUT | Specifies the duration in milliseconds to wait for device reboot when obtaining a crash dump. Crash dump retrieval disabled if 0. |
 | DEPTHAI_ENABLE_ANALYTICS_COLLECTION | Enables automatic analytics collection (pipeline schemas) used to improve the library |
 | DEPTHAI_DISABLE_CRASHDUMP_COLLECTION | Disables automatic crash dump collection used to improve the library |
 | DEPTHAI_HUB_API_KEY | API key for the Luxonis Hub |

--- a/bindings/python/src/DeviceBindings.cpp
+++ b/bindings/python/src/DeviceBindings.cpp
@@ -25,30 +25,6 @@ PYBIND11_MAKE_OPAQUE(std::unordered_map<std::int8_t, dai::BoardConfig::UART>);
 // Searches for available devices (as Device constructor)
 // but pooling, to check for python interrupts, and releases GIL in between
 
-template <typename DEVICE, class... Args>
-static auto deviceSearchHelper(Args&&... args) {
-    bool found;
-    dai::DeviceInfo deviceInfo;
-    // releases python GIL
-    py::gil_scoped_release release;
-    std::tie(found, deviceInfo) = DEVICE::getAnyAvailableDevice(DEVICE::getDefaultSearchTime(), []() {
-        py::gil_scoped_acquire acquire;
-        if(PyErr_CheckSignals() != 0) throw py::error_already_set();
-    });
-
-    // if no devices found, then throw
-    if(!found) {
-        auto numConnected = DEVICE::getAllAvailableDevices().size();
-        if(numConnected > 0) {
-            throw std::runtime_error("No available devices (" + std::to_string(numConnected) + " connected, but in use)");
-        } else {
-            throw std::runtime_error("No available devices");
-        }
-    }
-
-    return deviceInfo;
-}
-
 // static std::vector<std::string> deviceGetQueueEventsHelper(dai::Device& d, const std::vector<std::string>& queueNames, std::size_t maxNumEvents,
 // std::chrono::microseconds timeout){
 //     using namespace std::chrono;

--- a/bindings/python/src/DeviceBindings.hpp
+++ b/bindings/python/src/DeviceBindings.hpp
@@ -1,7 +1,32 @@
 #pragma once
 
 // pybind
+#include "depthai/device/Device.hpp"
 #include "pybind11_common.hpp"
+
+template <typename DEVICE, class... Args>
+static auto deviceSearchHelper(Args&&... args) {
+    bool found;
+    dai::DeviceInfo deviceInfo;
+    // releases python GIL
+    py::gil_scoped_release release;
+    std::tie(found, deviceInfo) = DEVICE::getAnyAvailableDevice(DEVICE::getDefaultSearchTime(), []() {
+        py::gil_scoped_acquire acquire;
+        if(PyErr_CheckSignals() != 0) throw py::error_already_set();
+    });
+
+    // if no devices found, then throw
+    if(!found) {
+        auto numConnected = DEVICE::getAllAvailableDevices().size();
+        if(numConnected > 0) {
+            throw std::runtime_error("No available devices (" + std::to_string(numConnected) + " connected, but in use)");
+        } else {
+            throw std::runtime_error("No available devices");
+        }
+    }
+
+    return deviceInfo;
+}
 
 struct DeviceBindings {
     static void bind(pybind11::module& m, void* pCallstack);

--- a/bindings/python/src/pipeline/PipelineBindings.cpp
+++ b/bindings/python/src/pipeline/PipelineBindings.cpp
@@ -124,8 +124,10 @@ void PipelineBindings::bind(pybind11::module& m, void* pCallstack) {
                  // While the thread above is cleaning up, check for interrupts
                  // (The thread above is necessary as PyErr_CheckSignals works when called from the main thread only)
                  // https://docs.python.org/3/c-api/exceptions.html#c.PyErr_CheckSignals
+                 py::gil_scoped_release release;
                  while(threadRunning) {
                      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                     py::gil_scoped_acquire acquire;
                      if(PyErr_CheckSignals() != 0) {
                          throw py::error_already_set();
                      }

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -755,6 +755,11 @@ class DeviceBase {
     void close();
 
     /**
+     * @brief Close the device as quickly as possible without performing any cleanup tasks or other checks. Users should preferablly use close() instead.
+     */
+    void closeQuick();
+
+    /**
      * Is the device already closed (or disconnected)
      *
      * @warning This function is thread-unsafe and may return outdated incorrect values. It is
@@ -815,6 +820,13 @@ class DeviceBase {
      * @note Remember to call this function in the overload to setup the communication properly
      */
     virtual void closeImpl();
+
+    /**
+     * @brief Whether the device should be closed as quickly as possible. Long-running methods ought to check this flag every so often and return if true, all
+     * long-running operations should be aborted.
+     * @note It is a responsibility of the developer to ensure that this flag is checked frequently.
+     */
+    std::atomic<bool> shouldCloseQuickly{false};
 
    protected:
     // protected functions

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -228,8 +228,17 @@ class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
     void resetConnections();
     void disconnectXLinkHosts();
 
+    inline void closeQuick() {
+        shouldCloseQuickly = true;
+        if(!isHostOnly()) {
+            defaultDevice->closeQuick();
+        }
+    }
+
    private:
     // Resource
+    std::atomic<bool> shouldCloseQuickly{false};
+
     std::vector<uint8_t> loadResource(fs::path uri);
     std::vector<uint8_t> loadResourceCwd(fs::path uri, fs::path cwd, bool moveAsset = false);
 };
@@ -501,6 +510,10 @@ class Pipeline {
 
     void addTask(std::function<void()> task) {
         impl()->addTask(std::move(task));
+    }
+
+    void closeQuick() {
+        impl()->closeQuick();
     }
 
     /// Record and Replay

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -58,7 +58,7 @@ const std::string MAGIC_FACTORY_FLASHING_VALUE = "413424129";
 const std::string MAGIC_FACTORY_PROTECTED_FLASHING_VALUE = "868632271";
 constexpr int DEVICE_SEARCH_FIRST_TIMEOUT_MS = 30;
 
-const unsigned int DEFAULT_CRASHDUMP_TIMEOUT = 9000;
+const unsigned int DEFAULT_CRASHDUMP_TIMEOUT_MS = 9000;
 
 // local static function
 static void getFlashingPermissions(bool& factoryPermissions, bool& protectedPermissions) {
@@ -401,10 +401,8 @@ void DeviceBase::close() {
 }
 
 unsigned int getCrashdumpTimeout(XLinkProtocol_t protocol) {
-    int defaultTimeout =
-        DEFAULT_CRASHDUMP_TIMEOUT + (protocol == X_LINK_TCP_IP ? device::XLINK_TCP_WATCHDOG_TIMEOUT.count() : device::XLINK_USB_WATCHDOG_TIMEOUT.count());
-    int timeoutSeconds = utility::getEnvAs<int>("DEPTHAI_CRASHDUMP_TIMEOUT", defaultTimeout);
-    int timeoutMs = timeoutSeconds * 1000;
+    std::chrono::milliseconds protocolTimeout = (protocol == X_LINK_TCP_IP ? device::XLINK_TCP_WATCHDOG_TIMEOUT : device::XLINK_USB_WATCHDOG_TIMEOUT);
+    int timeoutMs = utility::getEnvAs<int>("DEPTHAI_CRASHDUMP_TIMEOUT", DEFAULT_CRASHDUMP_TIMEOUT_MS + protocolTimeout.count());
     return timeoutMs;
 }
 

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -843,7 +843,7 @@ void PipelineImpl::disconnectXLinkHosts() {
 void PipelineImpl::wait() {
     // Waits for all nodes to finish the execution
     for(const auto& node : getAllNodes()) {
-        if(node->runOnHost()) {
+        if(node->runOnHost() && !shouldCloseQuickly) {
             node->wait();
         }
     }


### PR DESCRIPTION
There are several shortcomings in the changes introduces [PR1404](https://github.com/luxonis/depthai-core/pull/1404). Specifically the use of detached threads is a potentially problematic element that could lead to data races or invalid memory accesses (i.e. accesses to already deleted chucks of memory)

This PR tries to mitigate that by introducing a new attribute to the `DeviceBase` and `PipelineImpl` classes called `shouldCloseQuickly` indicating that threads and other long-running methods should return as quickly as possible without sacrificing memory access safety and program correctness. 

I've done extensive testing and the responsiveness of `depthai`-based python scripts has increased dramatically, with programs now typically reacting to keyboard interrupts within a single second as opposed to tens of seconds without the changes in this PR.

Finally, just like PR1404, this PR introduces a tiny fix where the crashdump collection timeout was set to 9000 seconds (2.5 hours). The intended unit of time in this case was presumably meant to be milliseconds.