### PR TITLE
Updated github main workflow, so it's run only on PRs labeled testable

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -15,8 +15,39 @@ on:
 
 jobs:
 
+  # The precheck job determines whether a workflow should be run in full
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+    - name: Evaluate trigger condition
+      id: check
+      run: |
+        EVENT_NAME="${{ github.event_name }}"
+
+        RAW_LABELS='${{ toJson(github.event.pull_request.labels) }}'
+        if [[ "$RAW_LABELS" == "null" || -z "$RAW_LABELS" ]]; then
+          LABELS="[]"
+        else
+          LABELS="$RAW_LABELS"
+        fi
+
+        SHOULD_RUN="false"
+        if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          SHOULD_RUN="true"
+        elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+          if echo "$LABELS" | jq -r '.[].name' | grep -q "testable"; then
+            SHOULD_RUN="true"
+          fi
+        fi
+
+        echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+
   style:
     runs-on: ubuntu-24.04
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
 
     steps:
     - uses: actions/checkout@v4
@@ -37,6 +68,8 @@ jobs:
 
   tidy:
     runs-on: ubuntu-24.04
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
 
     steps:
     - uses: actions/checkout@v4
@@ -56,6 +89,8 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
@@ -95,6 +130,8 @@ jobs:
 
   integration:
     runs-on: ${{ matrix.os }}
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]

--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -22,9 +22,40 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 
+  # The precheck job determines whether a workflow should be run in full
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+    - name: Evaluate trigger condition
+      id: check
+      run: |
+        EVENT_NAME="${{ github.event_name }}"
+
+        RAW_LABELS='${{ toJson(github.event.pull_request.labels) }}'
+        if [[ "$RAW_LABELS" == "null" || -z "$RAW_LABELS" ]]; then
+          LABELS="[]"
+        else
+          LABELS="$RAW_LABELS"
+        fi
+
+        SHOULD_RUN="false"
+        if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          SHOULD_RUN="true"
+        elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+          if echo "$LABELS" | jq -r '.[].name' | grep -q "testable"; then
+            SHOULD_RUN="true"
+          fi
+        fi
+
+        echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+
   # Job which builds docstrings for the rest of the wheel builds
   build-docstrings:
     runs-on: ubuntu-latest
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
     env:
       VCPKG_BINARY_SOURCES: "clear;files,/home/runner/.vcpkg,readwrite"
     steps:

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -19,7 +19,38 @@ concurrency:
 
 jobs:
 
+  # The precheck job determines whether a workflow should be run in full
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+    - name: Evaluate trigger condition
+      id: check
+      run: |
+        EVENT_NAME="${{ github.event_name }}"
+
+        RAW_LABELS='${{ toJson(github.event.pull_request.labels) }}'
+        if [[ "$RAW_LABELS" == "null" || -z "$RAW_LABELS" ]]; then
+          LABELS="[]"
+        else
+          LABELS="$RAW_LABELS"
+        fi
+
+        SHOULD_RUN="false"
+        if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          SHOULD_RUN="true"
+        elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+          if echo "$LABELS" | jq -r '.[].name' | grep -q "testable"; then
+            SHOULD_RUN="true"
+          fi
+        fi
+
+        echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+
   run_vanilla_tests:
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
     uses: ./.github/workflows/test_child.yml
     with:
       flavor: "vanilla"
@@ -29,6 +60,8 @@ jobs:
       CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
 
   run_tsan_tests:
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
     uses: ./.github/workflows/test_child.yml
     with:
       flavor: "tsan"
@@ -37,6 +70,8 @@ jobs:
       CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
 
   run_asan-ubsan_tests:
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
     uses: ./.github/workflows/test_child.yml
     with:
       flavor: "asan-ubsan"
@@ -45,6 +80,8 @@ jobs:
       CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
 
   windows_rvc2_rvc4_test:
+    needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
     runs-on: ['self-hosted', 'windows', 'hil-test']
     env:
       LOCALAPPDATA: "C:/actions-runner/vcpkg_cache"


### PR DESCRIPTION
## Purpose
github workflows DepthAI Core CI/CD, Depthai Python CI/CD and DepthAI Core HIL Testing are run on every Pull Request into main and develop. To reduce the number of workflow runs, only manual triggers and PRs labeled "testable" will now result in a workflow being started.

## Specification
A new job precheck is added to these .yml files, which determines whether a workflow should be run.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
This was tested by opening Pull Requests with and without "testable" label to determine correctness. A manual trigger was also done.