### PR TITLE
Add a -Wweak-tables clang compiler flag, resolve all warnings, 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,7 @@ set(TARGET_CORE_SOURCES
     src/pipeline/Node.cpp
     src/pipeline/InputQueue.cpp
     src/pipeline/ThreadedNode.cpp
+    src/pipeline/ThreadedHostNode.cpp
     src/pipeline/DeviceNode.cpp
     src/pipeline/DeviceNodeGroup.cpp
     src/pipeline/node/internal/XLinkIn.cpp
@@ -317,6 +318,7 @@ set(TARGET_CORE_SOURCES
     src/pipeline/node/host/HostNode.cpp
     src/pipeline/node/host/RGBD.cpp
     src/pipeline/datatype/DatatypeEnum.cpp
+    src/pipeline/datatype/ADataType.cpp
     src/pipeline/node/PointCloud.cpp
     src/pipeline/datatype/Buffer.cpp
     src/pipeline/datatype/ImgFrame.cpp
@@ -325,6 +327,7 @@ set(TARGET_CORE_SOURCES
     src/pipeline/datatype/ImgAnnotations.cpp
     src/pipeline/datatype/ImageManipConfig.cpp
     src/pipeline/datatype/ImageFiltersConfig.cpp
+    src/pipeline/datatype/ImageAlignConfig.cpp
     src/pipeline/datatype/CameraControl.cpp
     src/pipeline/datatype/NNData.cpp
     src/pipeline/datatype/ImgDetections.cpp
@@ -349,10 +352,17 @@ set(TARGET_CORE_SOURCES
     src/pipeline/datatype/PointCloudData.cpp
     src/pipeline/datatype/RGBDData.cpp
     src/pipeline/datatype/MessageGroup.cpp
+    src/pipeline/datatype/ThermalConfig.cpp
     src/pipeline/datatype/TransformData.cpp
+    src/properties/Properties.cpp
+    src/capabilities/Capabilities.cpp
     src/utility/H26xParsers.cpp
     src/utility/ImageManipImpl.cpp
     src/utility/ObjectTrackerImpl.cpp
+    src/utility/Memory.cpp
+    src/utility/VectorMemory.cpp
+    src/utility/SharedMemory.cpp
+    src/utility/ProtoSerializable.cpp
     src/utility/Initialization.cpp
     src/utility/Resources.cpp
     src/utility/Platform.cpp
@@ -402,6 +412,8 @@ endif()
 if(DEPTHAI_DYNAMIC_CALIBRATION_SUPPORT)
     list(APPEND TARGET_CORE_SOURCES
         src/pipeline/node/DynamicCalibrationNode.cpp
+        src/pipeline/datatype/DynamicCalibrationConfig.cpp
+        src/pipeline/datatype/DynamicCalibrationResults.cpp
     )
 endif()
 

--- a/cmake/Flags.cmake
+++ b/cmake/Flags.cmake
@@ -26,6 +26,7 @@ function(add_default_flags target)
             add_flag(${target} -Wdouble-promotion)       # (GCC >= 4.6, Clang >= 3.8) warn if float is implicit promoted to double
             add_flag(${target} -Wsign-compare)
             add_flag(${target} -Wtype-limits)            # size_t - size_t >= 0 -> always true
+            add_flag(${target} -Wweak-vtables)           # warn if class has a weak vtables (https://stackoverflow.com/questions/23746941/what-is-the-meaning-of-clangs-wweak-vtables)
 
             # disable those flags
             # add_flag(${target} -Wno-unused-command-line-argument)    # clang: warning: argument unused during compilation: '--coverage' [-Wunused-command-line-argument]

--- a/cmake/ports/libusb/portfile.cmake
+++ b/cmake/ports/libusb/portfile.cmake
@@ -14,9 +14,9 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        WITH_UDEV=OFF
+        -DWITH_UDEV=OFF
         # Build shared libs by default to not cause licensing issues
-        BUILD_SHARED_LIBS=ON
+        -DBUILD_SHARED_LIBS=ON
         ${CMAKE_CONFIGURE_OPTIONS_DEBUG}
 )
 

--- a/include/depthai/capabilities/Capability.hpp
+++ b/include/depthai/capabilities/Capability.hpp
@@ -8,7 +8,12 @@ class Capability {
    public:
     virtual const char* getName() const = 0;
     // virtual Capability getIntersection(const Capability& other) = 0;
+
+#if defined(__clang__)
+    virtual ~Capability();
+#else
     virtual ~Capability() = default;
+#endif
 };
 
 // Capability CRTP class

--- a/include/depthai/capabilities/ImgFrameCapability.hpp
+++ b/include/depthai/capabilities/ImgFrameCapability.hpp
@@ -51,6 +51,10 @@ class ImgFrameCapability : public CapabilityCRTP<Capability, ImgFrameCapability>
 
     DEPTHAI_SERIALIZE(ImgFrameCapability, size, fps, type, resizeMode, enableUndistortion);
 
+#if defined(__clang__)
+    ~ImgFrameCapability() override;
+#endif
+
    private:
     class Impl;
     spimpl::impl_ptr<Impl> pimpl;

--- a/include/depthai/pipeline/DeviceNodeGroup.hpp
+++ b/include/depthai/pipeline/DeviceNodeGroup.hpp
@@ -19,6 +19,10 @@ class DeviceNodeGroup : public DeviceNode {
 
     void setLogLevel(dai::LogLevel level) override;
     dai::LogLevel getLogLevel() const override;
+
+#if defined(__clang__)
+    ~DeviceNodeGroup() override;
+#endif
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -331,6 +331,10 @@ class Node : public std::enable_shared_from_this<Node> {
        public:
         enum class Type { SReceiver, MReceiver };  // TODO(Morato) - refactor, make the MReceiver a separate class (shouldn't inherit from MessageQueue)
 
+#if defined(__clang__)
+        ~Input() override;
+#endif
+
        protected:
         std::vector<Output*> connectedOutputs;
 

--- a/include/depthai/pipeline/ThreadedHostNode.hpp
+++ b/include/depthai/pipeline/ThreadedHostNode.hpp
@@ -12,6 +12,10 @@ class ThreadedHostNode : public ThreadedNode {
         // Host node don't contain the necessary information to be serialized and sent to the device
         return true;
     }
+
+#if defined(__clang__)
+    ~ThreadedHostNode() override;
+#endif
 };
 
 /**

--- a/include/depthai/pipeline/ThreadedNode.hpp
+++ b/include/depthai/pipeline/ThreadedNode.hpp
@@ -16,7 +16,12 @@ class ThreadedNode : public Node {
    public:
     using Node::Node;
     ThreadedNode();
+
+#if defined(__clang__)
+    ~ThreadedNode() override;
+#else
     virtual ~ThreadedNode() = default;
+#endif
 
     /**
      * @brief Function called at the beginning of the `start` function.

--- a/include/depthai/pipeline/datatype/ADatatype.hpp
+++ b/include/depthai/pipeline/datatype/ADatatype.hpp
@@ -4,7 +4,6 @@
 
 #include "depthai/pipeline/datatype/DatatypeEnum.hpp"
 #include "depthai/utility/Memory.hpp"
-#include "depthai/utility/Serialization.hpp"
 #include "depthai/utility/VectorMemory.hpp"
 
 namespace dai {
@@ -21,7 +20,12 @@ class ADatatype {
 #else
     explicit ADatatype() : data{std::make_shared<VectorMemory>(std::vector<uint8_t>())} {};
 #endif
+
+#if defined(__clang__)
+    virtual ~ADatatype();
+#else
     virtual ~ADatatype() = default;
+#endif
 
     virtual void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const {
         (void)metadata;

--- a/include/depthai/pipeline/datatype/AprilTagConfig.hpp
+++ b/include/depthai/pipeline/datatype/AprilTagConfig.hpp
@@ -13,9 +13,14 @@ namespace dai {
 class AprilTagConfig : public Buffer {
    public:
     AprilTagConfig() = default;
-    virtual ~AprilTagConfig() = default;
 
-    virtual void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const {
+#if defined(__clang__)
+    ~AprilTagConfig() override;
+#else
+    virtual ~AprilTagConfig() = default;
+#endif
+
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         (void)metadata;
         datatype = DatatypeEnum::AprilTagConfig;
     };

--- a/include/depthai/pipeline/datatype/AprilTags.hpp
+++ b/include/depthai/pipeline/datatype/AprilTags.hpp
@@ -67,7 +67,12 @@ class AprilTags : public Buffer {
      * Construct AprilTags message.
      */
     AprilTags() = default;
+
+#if defined(__clang__)
+    ~AprilTags() override;
+#else
     virtual ~AprilTags() = default;
+#endif
 
    public:
     std::vector<AprilTag> aprilTags;

--- a/include/depthai/pipeline/datatype/BenchmarkReport.hpp
+++ b/include/depthai/pipeline/datatype/BenchmarkReport.hpp
@@ -18,6 +18,12 @@ class BenchmarkReport : public Buffer {
     // Only filled if measureIndividualLatencies is set to true
     std::vector<float> latencies;
 
+#if defined(__clang__)
+    ~BenchmarkReport() override;
+#else
+    virtual ~BenchmarkReport() = default;
+#endif
+
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);
         datatype = DatatypeEnum::BenchmarkReport;

--- a/include/depthai/pipeline/datatype/Buffer.hpp
+++ b/include/depthai/pipeline/datatype/Buffer.hpp
@@ -23,9 +23,14 @@ class Buffer : public ADatatype {
     Buffer(size_t size);
     Buffer(long fd);
     Buffer(long fd, size_t size);
-    virtual ~Buffer() = default;
 
-    virtual void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const {
+#if defined(__clang__)
+    ~Buffer() override;
+#else
+    virtual ~Buffer() = default;
+#endif
+
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);
         datatype = DatatypeEnum::Buffer;
     };

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "ImgDetections.hpp"
 #include "depthai/pipeline/datatype/Buffer.hpp"
 
 namespace dai {
@@ -32,7 +33,12 @@ namespace dai {
 class CameraControl : public Buffer {
    public:
     CameraControl() = default;
+
+#if defined(__clang__)
+    ~CameraControl() override;
+#else
     virtual ~CameraControl() = default;
+#endif
 
     enum class Command : uint8_t {
         START_STREAM = 1,

--- a/include/depthai/pipeline/datatype/DynamicCalibrationConfig.hpp
+++ b/include/depthai/pipeline/datatype/DynamicCalibrationConfig.hpp
@@ -74,6 +74,12 @@ class DynamicCalibrationControl : public Buffer {
 
     explicit DynamicCalibrationControl(Command cmd) : command(std::move(cmd)) {}
 
+#if defined(__clang__)
+    ~DynamicCalibrationControl() override;
+#else
+    virtual ~DynamicCalibrationControl() = default;
+#endif
+
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);
         datatype = DatatypeEnum::DynamicCalibrationControl;

--- a/include/depthai/pipeline/datatype/DynamicCalibrationResults.hpp
+++ b/include/depthai/pipeline/datatype/DynamicCalibrationResults.hpp
@@ -18,7 +18,12 @@ namespace dai {
  */
 struct CoverageData : public Buffer {
     CoverageData() = default;
+
+#if defined(__clang__)
+    ~CoverageData() override;
+#else
     virtual ~CoverageData() = default;
+#endif
 
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);
@@ -103,7 +108,12 @@ struct CalibrationQuality : public Buffer {
      * Construct empty CalibrationQuality message.
      */
     CalibrationQuality() = default;
+
+#if defined(__clang__)
+    ~CalibrationQuality() override;
+#else
     virtual ~CalibrationQuality() = default;
+#endif
 
     /**
      * Construct CalibrationQuality with quality metrics and info string.
@@ -168,7 +178,12 @@ struct DynamicCalibrationResult : public Buffer {
      * Construct empty DynamicCalibrationResult message.
      */
     DynamicCalibrationResult() = default;
+
+#if defined(__clang__)
+    ~DynamicCalibrationResult() override;
+#else
     virtual ~DynamicCalibrationResult() = default;
+#endif
 
     /**
      * Construct with result data and informational string.

--- a/include/depthai/pipeline/datatype/EdgeDetectorConfig.hpp
+++ b/include/depthai/pipeline/datatype/EdgeDetectorConfig.hpp
@@ -13,7 +13,12 @@ namespace dai {
 class EdgeDetectorConfig : public Buffer {
    public:
     EdgeDetectorConfig() = default;
+
+#if defined(__clang__)
+    ~EdgeDetectorConfig() override;
+#else
     virtual ~EdgeDetectorConfig() = default;
+#endif
 
     struct EdgeDetectorConfigData {
         /**

--- a/include/depthai/pipeline/datatype/EncodedFrame.hpp
+++ b/include/depthai/pipeline/datatype/EncodedFrame.hpp
@@ -33,7 +33,11 @@ class EncodedFrame : public Buffer, public ProtoSerializable {
 
     ImgTransformation transformation;
 
+#if defined(__clang__)
+    ~EncodedFrame() override;
+#else
     virtual ~EncodedFrame() = default;
+#endif
 
     // getters
     /**

--- a/include/depthai/pipeline/datatype/FeatureTrackerConfig.hpp
+++ b/include/depthai/pipeline/datatype/FeatureTrackerConfig.hpp
@@ -16,7 +16,12 @@ class FeatureTrackerConfig : public Buffer {
      * Construct FeatureTrackerConfig message.
      */
     FeatureTrackerConfig() = default;
+
+#if defined(__clang__)
+    ~FeatureTrackerConfig() override;
+#else
     virtual ~FeatureTrackerConfig() = default;
+#endif
 
     static constexpr const std::int32_t AUTO = 0;
 

--- a/include/depthai/pipeline/datatype/IMUData.hpp
+++ b/include/depthai/pipeline/datatype/IMUData.hpp
@@ -217,7 +217,11 @@ class IMUData : public Buffer, public ProtoSerializable {
    public:
     // Construct IMUData message
     IMUData() = default;
+#if defined(__clang__)
+    ~IMUData() override;
+#else
     virtual ~IMUData() = default;
+#endif
 
     /// Detections
     std::vector<IMUPacket> packets;

--- a/include/depthai/pipeline/datatype/ImageAlignConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageAlignConfig.hpp
@@ -16,7 +16,12 @@ class ImageAlignConfig : public Buffer {
     uint16_t staticDepthPlane = 0;
 
     ImageAlignConfig() = default;
+
+#if defined(__clang__)
+    ~ImageAlignConfig() override;
+#else
     virtual ~ImageAlignConfig() = default;
+#endif
 
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);

--- a/include/depthai/pipeline/datatype/ImageFiltersConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageFiltersConfig.hpp
@@ -31,7 +31,11 @@ typedef std::variant<MedianFilterParams, SpatialFilterParams, SpeckleFilterParam
 
 class ImageFiltersConfig : public Buffer {
    public:
+#if defined(__clang__)
+    ~ImageFiltersConfig() override;
+#else
     virtual ~ImageFiltersConfig() = default;
+#endif
 
     /**
      * Insert filter parameters describing how a filter at index index should be updated
@@ -67,7 +71,11 @@ class ImageFiltersConfig : public Buffer {
 
 class ToFDepthConfidenceFilterConfig : public Buffer {
    public:
+#if defined(__clang__)
+    ~ToFDepthConfidenceFilterConfig() override;
+#else
     virtual ~ToFDepthConfidenceFilterConfig() = default;
+#endif
 
     /**
      * Threshold for the confidence filter

--- a/include/depthai/pipeline/datatype/ImageManipConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfig.hpp
@@ -21,7 +21,12 @@
 namespace dai {
 
 struct OpBase {
+#if defined(__clang__)
+    virtual ~OpBase();
+#else
     virtual ~OpBase() = default;
+#endif
+
     virtual std::string toStr() const = 0;
 };
 
@@ -29,6 +34,12 @@ struct Translate : OpBase {
     float offsetX;
     float offsetY;
     bool normalized;
+
+#if defined(__clang__)
+    ~Translate() override;
+#else
+    virtual ~Translate() = default;
+#endif
 
     Translate() = default;
     Translate(float offsetX, float offsetY, bool normalized = false) : offsetX(offsetX), offsetY(offsetY), normalized(normalized) {}
@@ -50,6 +61,12 @@ struct Rotate : OpBase {
     float offsetY;
     bool normalized;
 
+#if defined(__clang__)
+    ~Rotate() override;
+#else
+    virtual ~Rotate() = default;
+#endif
+
     Rotate() = default;
     explicit Rotate(float angle, bool center = true, float offsetX = 0, float offsetY = 0, bool normalized = false)
         : angle(angle), center(center), offsetX(offsetX), offsetY(offsetY), normalized(normalized) {}
@@ -70,6 +87,12 @@ struct Resize : OpBase {
     float height;
     bool normalized;
     Mode mode = FIT;
+
+#if defined(__clang__)
+    ~Resize() override;
+#else
+    virtual ~Resize() = default;
+#endif
 
     Resize() = default;
     Resize(float width, float height, bool normalized = false) : width(width), height(height), normalized(normalized), mode(VALUE) {}
@@ -101,6 +124,12 @@ struct Flip : OpBase {
     Direction direction = HORIZONTAL;
     bool center = false;  // if true, flip is around center of image, otherwise around top-left corner
 
+#if defined(__clang__)
+    ~Flip() override;
+#else
+    virtual ~Flip() = default;
+#endif
+
     Flip() = default;
     explicit Flip(Direction direction, bool center = true) : direction(direction), center(center) {}
 
@@ -117,6 +146,12 @@ struct Flip : OpBase {
 struct Affine : OpBase {
     std::array<float, 4> matrix{1, 0, 0, 1};
 
+#if defined(__clang__)
+    ~Affine() override;
+#else
+    virtual ~Affine() = default;
+#endif
+
     Affine() = default;
     explicit Affine(std::array<float, 4> matrix) : matrix(matrix) {}
 
@@ -132,6 +167,12 @@ struct Affine : OpBase {
 
 struct Perspective : OpBase {
     std::array<float, 9> matrix{1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+#if defined(__clang__)
+    ~Perspective() override;
+#else
+    virtual ~Perspective() = default;
+#endif
 
     Perspective() = default;
     explicit Perspective(std::array<float, 9> matrix) : matrix(matrix) {}
@@ -151,6 +192,12 @@ struct FourPoints : OpBase {
     std::array<dai::Point2f, 4> src{dai::Point2f(0.0, 0.0), dai::Point2f(1.0, 0.0), dai::Point2f(1.0, 1.0), dai::Point2f(0.0, 1.0)};
     std::array<dai::Point2f, 4> dst{dai::Point2f(0.0, 0.0), dai::Point2f(1.0, 0.0), dai::Point2f(1.0, 1.0), dai::Point2f(0.0, 1.0)};
     bool normalized = false;
+
+#if defined(__clang__)
+    ~FourPoints() override;
+#else
+    virtual ~FourPoints() = default;
+#endif
 
     FourPoints() = default;
     FourPoints(std::array<dai::Point2f, 4> src, std::array<dai::Point2f, 4> dst, bool normalized = false) : src(src), dst(dst), normalized(normalized) {}
@@ -172,6 +219,12 @@ struct Crop : OpBase {
     float height;
     bool normalized;
     bool center;
+
+#if defined(__clang__)
+    ~Crop() override;
+#else
+    virtual ~Crop() = default;
+#endif
 
     Crop() : width(0), height(0), normalized(true), center(true) {}
     Crop(float width, float height, bool normalized = false, bool center = false) : width(width), height(height), normalized(normalized), center(center) {}
@@ -409,7 +462,12 @@ class ImageManipConfig : public Buffer {
 
    public:
     ImageManipConfig() = default;
+
+#if defined(__clang__)
+    ~ImageManipConfig() override;
+#else
     virtual ~ImageManipConfig() = default;
+#endif
 
     using ResizeMode = ImageManipOpsBase<Container>::ResizeMode;
 

--- a/include/depthai/pipeline/datatype/ImgAnnotations.hpp
+++ b/include/depthai/pipeline/datatype/ImgAnnotations.hpp
@@ -55,7 +55,11 @@ class ImgAnnotations : public Buffer, public ProtoSerializable {
     ImgAnnotations() = default;
     explicit ImgAnnotations(std::vector<ImgAnnotation> annotations) : annotations(std::move(annotations)) {}
 
+#if defined(__clang__)
+    ~ImgAnnotations() override;
+#else
     virtual ~ImgAnnotations() = default;
+#endif
 
     /// Transform
     std::vector<ImgAnnotation> annotations;

--- a/include/depthai/pipeline/datatype/ImgDetections.hpp
+++ b/include/depthai/pipeline/datatype/ImgDetections.hpp
@@ -30,7 +30,12 @@ class ImgDetections : public Buffer, public ProtoSerializable {
      * Construct ImgDetections message.
      */
     ImgDetections() = default;
+
+#if defined(__clang__)
+    ~ImgDetections() override;
+#else
     virtual ~ImgDetections() = default;
+#endif
 
     /// Detections
     std::vector<ImgDetection> detections;

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -75,7 +75,12 @@ class ImgFrame : public Buffer, public ProtoSerializable {
     ImgFrame(long fd);
     ImgFrame(size_t size);
     ImgFrame(long fd, size_t size);
+
+#if defined(__clang__)
+    ~ImgFrame() override;
+#else
     virtual ~ImgFrame() = default;
+#endif
 
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);

--- a/include/depthai/pipeline/datatype/MessageGroup.hpp
+++ b/include/depthai/pipeline/datatype/MessageGroup.hpp
@@ -16,7 +16,11 @@ class MessageGroup : public Buffer {
    public:
     std::map<std::string, std::shared_ptr<ADatatype>> group;
 
+#if defined(__clang__)
+    ~MessageGroup() override;
+#else
     virtual ~MessageGroup() = default;
+#endif
 
     /// Group
     std::shared_ptr<ADatatype> operator[](const std::string& name);

--- a/include/depthai/pipeline/datatype/NNData.hpp
+++ b/include/depthai/pipeline/datatype/NNData.hpp
@@ -69,7 +69,12 @@ class NNData : public Buffer {
      */
     NNData() = default;
     NNData(size_t size);
+
+#if defined(__clang__)
+    ~NNData() override;
+#else
     virtual ~NNData() = default;
+#endif
 
     // getters
     /**

--- a/include/depthai/pipeline/datatype/ObjectTrackerConfig.hpp
+++ b/include/depthai/pipeline/datatype/ObjectTrackerConfig.hpp
@@ -16,7 +16,12 @@ class ObjectTrackerConfig : public Buffer {
      * Construct ObjectTrackerConfig message.
      */
     ObjectTrackerConfig() = default;
+
+#if defined(__clang__)
+    ~ObjectTrackerConfig() override;
+#else
     virtual ~ObjectTrackerConfig() = default;
+#endif
 
     /**
      * Tracklet IDs to remove from tracking.

--- a/include/depthai/pipeline/datatype/PointCloudConfig.hpp
+++ b/include/depthai/pipeline/datatype/PointCloudConfig.hpp
@@ -20,7 +20,12 @@ class PointCloudConfig : public Buffer {
      * Construct PointCloudConfig message.
      */
     PointCloudConfig() = default;
+
+#if defined(__clang__)
+    ~PointCloudConfig() override;
+#else
     virtual ~PointCloudConfig() = default;
+#endif
 
     /**
      * Retrieve sparse point cloud calculation status.

--- a/include/depthai/pipeline/datatype/PointCloudData.hpp
+++ b/include/depthai/pipeline/datatype/PointCloudData.hpp
@@ -37,7 +37,12 @@ class PointCloudData : public Buffer, public ProtoSerializable {
      * Construct PointCloudData message.
      */
     PointCloudData() = default;
+
+#if defined(__clang__)
+    ~PointCloudData() override;
+#else
     virtual ~PointCloudData() = default;
+#endif
 
     std::vector<Point3f> getPoints();
     std::vector<Point3fRGBA> getPointsRGB();

--- a/include/depthai/pipeline/datatype/RGBDData.hpp
+++ b/include/depthai/pipeline/datatype/RGBDData.hpp
@@ -18,7 +18,11 @@ class RGBDData : public Buffer {
      */
     RGBDData() = default;
 
+#if defined(__clang__)
+    ~RGBDData() override;
+#else
     virtual ~RGBDData() = default;
+#endif
 
     std::map<std::string, std::shared_ptr<ADatatype>> frames;
     void setRGBFrame(const std::shared_ptr<ImgFrame>& frame);

--- a/include/depthai/pipeline/datatype/SpatialImgDetections.hpp
+++ b/include/depthai/pipeline/datatype/SpatialImgDetections.hpp
@@ -36,7 +36,12 @@ class SpatialImgDetections : public Buffer, public ProtoSerializable {
      * Construct SpatialImgDetections message.
      */
     SpatialImgDetections() = default;
+
+#if defined(__clang__)
+    ~SpatialImgDetections() override;
+#else
     virtual ~SpatialImgDetections() = default;
+#endif
 
     /**
      * Detection results.

--- a/include/depthai/pipeline/datatype/SpatialLocationCalculatorConfig.hpp
+++ b/include/depthai/pipeline/datatype/SpatialLocationCalculatorConfig.hpp
@@ -74,7 +74,12 @@ class SpatialLocationCalculatorConfig : public Buffer {
      * Construct SpatialLocationCalculatorConfig message.
      */
     SpatialLocationCalculatorConfig() = default;
+
+#if defined(__clang__)
+    ~SpatialLocationCalculatorConfig() override;
+#else
     virtual ~SpatialLocationCalculatorConfig() = default;
+#endif
 
     /**
      * Set a vector of ROIs as configuration data.

--- a/include/depthai/pipeline/datatype/SpatialLocationCalculatorData.hpp
+++ b/include/depthai/pipeline/datatype/SpatialLocationCalculatorData.hpp
@@ -65,7 +65,12 @@ class SpatialLocationCalculatorData : public Buffer {
      * Construct SpatialLocationCalculatorData message.
      */
     SpatialLocationCalculatorData() = default;
+
+#if defined(__clang__)
+    ~SpatialLocationCalculatorData() override;
+#else
     virtual ~SpatialLocationCalculatorData() = default;
+#endif
 
     /**
      * Retrieve configuration data for SpatialLocationCalculatorData.

--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -18,7 +18,11 @@ class StereoDepthConfig : public Buffer {
      * Construct StereoDepthConfig message.
      */
     StereoDepthConfig() = default;
+#if defined(__clang__)
+    ~StereoDepthConfig() override;
+#else
     virtual ~StereoDepthConfig() = default;
+#endif
 
     using MedianFilter = filters::params::MedianFilter;
 

--- a/include/depthai/pipeline/datatype/SystemInformation.hpp
+++ b/include/depthai/pipeline/datatype/SystemInformation.hpp
@@ -21,7 +21,11 @@ class SystemInformation : public Buffer {
      * Construct SystemInformation message.
      */
     SystemInformation() = default;
+#if defined(__clang__)
+    ~SystemInformation() override;
+#else
     virtual ~SystemInformation() = default;
+#endif
 
     MemoryInfo ddrMemoryUsage;
     MemoryInfo cmxMemoryUsage;

--- a/include/depthai/pipeline/datatype/SystemInformationS3.hpp
+++ b/include/depthai/pipeline/datatype/SystemInformationS3.hpp
@@ -20,7 +20,11 @@ class SystemInformationS3 : public Buffer {
      * Construct SystemInformation message.
      */
     SystemInformationS3() = default;
+#if defined(__clang__)
+    ~SystemInformationS3() override;
+#else
     virtual ~SystemInformationS3() = default;
+#endif
 
     MemoryInfo ddrMemoryUsage;
     CpuUsage cpuAvgUsage;

--- a/include/depthai/pipeline/datatype/ThermalConfig.hpp
+++ b/include/depthai/pipeline/datatype/ThermalConfig.hpp
@@ -123,7 +123,11 @@ class ThermalConfig : public Buffer {
      * Construct ThermalConfig message.
      */
     ThermalConfig() = default;
+#if defined(__clang__)
+    ~ThermalConfig() override;
+#else
     virtual ~ThermalConfig() = default;
+#endif
 
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);

--- a/include/depthai/pipeline/datatype/ToFConfig.hpp
+++ b/include/depthai/pipeline/datatype/ToFConfig.hpp
@@ -69,12 +69,17 @@ class ToFConfig : public Buffer {
      * Construct ToFConfig message.
      */
     ToFConfig() = default;
-    virtual ~ToFConfig() = default;
 
     /**
      * @param median Set kernel size for median filtering, or disable
      */
     ToFConfig& setMedianFilter(filters::params::MedianFilter median);
+
+#if defined(__clang__)
+    ~ToFConfig() override;
+#else
+    virtual ~ToFConfig() = default;
+#endif
 
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);

--- a/include/depthai/pipeline/datatype/TrackedFeatures.hpp
+++ b/include/depthai/pipeline/datatype/TrackedFeatures.hpp
@@ -57,7 +57,12 @@ class TrackedFeatures : public Buffer {
      * Construct TrackedFeatures message.
      */
     TrackedFeatures() = default;
+
+#if defined(__clang__)
+    ~TrackedFeatures() override;
+#else
     virtual ~TrackedFeatures() = default;
+#endif
 
     std::vector<TrackedFeature> trackedFeatures;
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {

--- a/include/depthai/pipeline/datatype/Tracklets.hpp
+++ b/include/depthai/pipeline/datatype/Tracklets.hpp
@@ -65,7 +65,11 @@ class Tracklets : public Buffer {
      * Construct Tracklets message.
      */
     Tracklets() = default;
+#if defined(__clang__)
+    ~Tracklets() override;
+#else
     virtual ~Tracklets() = default;
+#endif
 
     /**
      * Retrieve data for Tracklets.

--- a/include/depthai/pipeline/datatype/TransformData.hpp
+++ b/include/depthai/pipeline/datatype/TransformData.hpp
@@ -31,7 +31,12 @@ class TransformData : public Buffer {
     TransformData(const rtabmap::Transform& transformRTABMap);
     rtabmap::Transform getRTABMapTransform() const;
 #endif
+
+#if defined(__clang__)
+    ~TransformData() override;
+#else
     virtual ~TransformData() = default;
+#endif
 
     /// Transform
     Transform transform;

--- a/include/depthai/pipeline/node/DetectionParser.hpp
+++ b/include/depthai/pipeline/node/DetectionParser.hpp
@@ -25,6 +25,12 @@ class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, Detec
     constexpr static const char* NAME = "DetectionParser";
     using DeviceNodeCRTP::DeviceNodeCRTP;
 
+#if defined(__clang__)
+    ~DetectionParser() override;
+#else
+    virtual ~DetectionParser() = default;
+#endif
+
     /**
      * @brief Build DetectionParser node. Connect output to this node's input. Also call setNNArchive() with provided NNArchive.
      * @param nnInput: Output to link

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -26,6 +26,12 @@ class NeuralNetwork : public DeviceNodeCRTP<DeviceNode, NeuralNetwork, NeuralNet
     constexpr static const char* NAME = "NeuralNetwork";
     using DeviceNodeCRTP::DeviceNodeCRTP;
 
+#if defined(__clang__)
+    ~NeuralNetwork() override;
+#else
+    virtual ~NeuralNetwork() = default;
+#endif
+
     /**
      * @brief Build NeuralNetwork node. Connect output to this node's input. Also call setNNArchive() with provided NNArchive.
      *

--- a/include/depthai/pipeline/node/ToF.hpp
+++ b/include/depthai/pipeline/node/ToF.hpp
@@ -94,6 +94,12 @@ class ToF : public DeviceNodeGroup {
           tofDepthConfidenceFilterNode{*tofDepthConfidenceFilter},
           imageFiltersNode{*imageFilters} {}
 
+#if defined(__clang__)
+    ~ToF() override;
+#else
+    virtual ~ToF() = default;
+#endif
+
     [[nodiscard]] static std::shared_ptr<ToF> create(const std::shared_ptr<Device>& device) {
         auto tofPtr = std::make_shared<ToF>(device);
         tofPtr->buildInternal();

--- a/include/depthai/pipeline/node/UVC.hpp
+++ b/include/depthai/pipeline/node/UVC.hpp
@@ -20,6 +20,12 @@ class UVC : public DeviceNodeCRTP<DeviceNode, UVC, UVCProperties> {
     UVC() = default;
     UVC(std::unique_ptr<Properties> props);
 
+#if defined(__clang__)
+    ~UVC() override;
+#else
+    virtual ~UVC() = default;
+#endif
+
     /**
      * Input for image frames to be streamed over UVC
      * Default queue is blocking with size 8

--- a/include/depthai/pipeline/node/internal/XLinkIn.hpp
+++ b/include/depthai/pipeline/node/internal/XLinkIn.hpp
@@ -20,7 +20,11 @@ class XLinkIn : public DeviceNodeCRTP<DeviceNode, XLinkIn, XLinkInProperties> {
     using DeviceNodeCRTP::DeviceNodeCRTP;
 
    public:
+#if defined(__clang__)
+    ~XLinkIn() override;
+#else
     virtual ~XLinkIn() = default;
+#endif
 
     /**
      * Outputs message of same type as send from host.

--- a/include/depthai/properties/AprilTagProperties.hpp
+++ b/include/depthai/properties/AprilTagProperties.hpp
@@ -17,6 +17,12 @@ struct AprilTagProperties : PropertiesSerializable<Properties, AprilTagPropertie
 
     /// How many threads to use for AprilTag detection
     int numThreads = 1;
+
+#if defined(__clang__)
+    ~AprilTagProperties() override;
+#else
+    virtual ~AprilTagProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(AprilTagProperties, initialConfig, inputConfigSync);

--- a/include/depthai/properties/BenchmarkInProperties.hpp
+++ b/include/depthai/properties/BenchmarkInProperties.hpp
@@ -25,6 +25,12 @@ struct BenchmarkInProperties : PropertiesSerializable<Properties, BenchmarkInPro
      * Send the reports also as logger warnings
      */
     bool logReportsAsWarnings = true;
+
+#if defined(__clang__)
+    ~BenchmarkInProperties() override;
+#else
+    virtual ~BenchmarkInProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(BenchmarkInProperties, reportEveryNMessages, attachLatencies, logReportsAsWarnings);

--- a/include/depthai/properties/BenchmarkOutProperties.hpp
+++ b/include/depthai/properties/BenchmarkOutProperties.hpp
@@ -20,6 +20,12 @@ struct BenchmarkOutProperties : PropertiesSerializable<Properties, BenchmarkOutP
      * FPS for sending, 0 means as fast as possible
      */
     float fps = 0;
+
+#if defined(__clang__)
+    ~BenchmarkOutProperties() override;
+#else
+    virtual ~BenchmarkOutProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(BenchmarkOutProperties, numMessages, fps);

--- a/include/depthai/properties/CameraProperties.hpp
+++ b/include/depthai/properties/CameraProperties.hpp
@@ -90,6 +90,12 @@ struct CameraProperties : PropertiesSerializable<Properties, CameraProperties> {
     int numFramesPoolVideo = 4;
     int numFramesPoolPreview = 4;
     int numFramesPoolStill = 4;
+
+#if defined(__clang__)
+    ~CameraProperties() override;
+#else
+    virtual ~CameraProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(CameraProperties,

--- a/include/depthai/properties/CastProperties.hpp
+++ b/include/depthai/properties/CastProperties.hpp
@@ -16,6 +16,12 @@ struct CastProperties : PropertiesSerializable<Properties, CastProperties> {
     std::optional<float> scale;
     std::optional<float> offset;
     int numFramesPool = 4;
+
+#if defined(__clang__)
+    ~CastProperties() override;
+#else
+    virtual ~CastProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(CastProperties, numFramesPool, outputType, scale, offset);

--- a/include/depthai/properties/ColorCameraProperties.hpp
+++ b/include/depthai/properties/ColorCameraProperties.hpp
@@ -211,6 +211,12 @@ struct ColorCameraProperties : PropertiesSerializable<Properties, ColorCameraPro
      * with both packed/unpacked, but disabled for other cameras like ToF.
      */
     std::optional<bool> rawPacked;
+
+#if defined(__clang__)
+    ~ColorCameraProperties() override;
+#else
+    virtual ~ColorCameraProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ColorCameraProperties,

--- a/include/depthai/properties/DetectionParserProperties.hpp
+++ b/include/depthai/properties/DetectionParserProperties.hpp
@@ -20,6 +20,12 @@ struct DetectionParserProperties : PropertiesSerializable<Properties, DetectionP
 
     /// Options for parser
     DetectionParserOptions parser;
+
+#if defined(__clang__)
+    ~DetectionParserProperties() override;
+#else
+    virtual ~DetectionParserProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(DetectionParserProperties, numFramesPool, networkInputs, parser);

--- a/include/depthai/properties/DeviceNodeGroupProperties.hpp
+++ b/include/depthai/properties/DeviceNodeGroupProperties.hpp
@@ -11,6 +11,12 @@ namespace dai {
 struct DeviceNodeGroupProperties : PropertiesSerializable<Properties, DeviceNodeGroupProperties> {
     // Dummy property
     int dummy = 0;
+
+#if defined(__clang__)
+    ~DeviceNodeGroupProperties() override;
+#else
+    virtual ~DeviceNodeGroupProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(DeviceNodeGroupProperties, dummy);

--- a/include/depthai/properties/DynamicCalibrationProperties.hpp
+++ b/include/depthai/properties/DynamicCalibrationProperties.hpp
@@ -10,6 +10,12 @@ namespace dai {
 
 struct DynamicCalibrationProperties : PropertiesSerializable<Properties, DynamicCalibrationProperties> {
     bool emptyBool;
+
+#if defined(__clang__)
+    ~DynamicCalibrationProperties() override;
+#else
+    virtual ~DynamicCalibrationProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(DynamicCalibrationProperties, emptyBool);

--- a/include/depthai/properties/EdgeDetectorProperties.hpp
+++ b/include/depthai/properties/EdgeDetectorProperties.hpp
@@ -22,6 +22,12 @@ struct EdgeDetectorProperties : PropertiesSerializable<Properties, EdgeDetectorP
 
     /// Num frames in output pool
     int numFramesPool = 4;
+
+#if defined(__clang__)
+    ~EdgeDetectorProperties() override;
+#else
+    virtual ~EdgeDetectorProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(EdgeDetectorProperties, initialConfig, outputFrameSize, numFramesPool);

--- a/include/depthai/properties/FeatureTrackerProperties.hpp
+++ b/include/depthai/properties/FeatureTrackerProperties.hpp
@@ -33,6 +33,12 @@ struct FeatureTrackerProperties : PropertiesSerializable<Properties, FeatureTrac
      * Maximum 2, minimum 1.
      */
     std::int32_t numMemorySlices = 1;
+
+#if defined(__clang__)
+    ~FeatureTrackerProperties() override;
+#else
+    virtual ~FeatureTrackerProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(FeatureTrackerProperties, initialConfig, numShaves, numMemorySlices);

--- a/include/depthai/properties/GlobalProperties.hpp
+++ b/include/depthai/properties/GlobalProperties.hpp
@@ -68,6 +68,12 @@ struct GlobalProperties : PropertiesSerializable<Properties, GlobalProperties> {
      * Units are bytes.
      */
     uint32_t sippDmaBufferSize = SIPP_DMA_BUFFER_DEFAULT_SIZE;
+
+#if defined(__clang__)
+    ~GlobalProperties() override;
+#else
+    virtual ~GlobalProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(GlobalProperties,

--- a/include/depthai/properties/IMUProperties.hpp
+++ b/include/depthai/properties/IMUProperties.hpp
@@ -176,6 +176,12 @@ struct IMUProperties : PropertiesSerializable<Properties, IMUProperties> {
      * Default value: false.
      */
     std::optional<bool> enableFirmwareUpdate = false;
+
+#if defined(__clang__)
+    ~IMUProperties() override;
+#else
+    virtual ~IMUProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(IMUProperties, imuSensors, batchReportThreshold, maxBatchReports, enableFirmwareUpdate);

--- a/include/depthai/properties/ImageAlignProperties.hpp
+++ b/include/depthai/properties/ImageAlignProperties.hpp
@@ -41,6 +41,12 @@ struct ImageAlignProperties : PropertiesSerializable<Properties, ImageAlignPrope
      * Number of shaves reserved.
      */
     std::int32_t numShaves = 2;
+
+#if defined(__clang__)
+    ~ImageAlignProperties() override;
+#else
+    virtual ~ImageAlignProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ImageAlignProperties, initialConfig, numFramesPool, alignWidth, alignHeight, warpHwIds, interpolation, outKeepAspectRatio, numShaves);

--- a/include/depthai/properties/ImageFiltersProperties.hpp
+++ b/include/depthai/properties/ImageFiltersProperties.hpp
@@ -13,6 +13,12 @@ struct ImageFiltersProperties : PropertiesSerializable<Properties, ImageFiltersP
      * Initial config for the filter pipeline
      */
     ImageFiltersConfig initialConfig;
+
+#if defined(__clang__)
+    ~ImageFiltersProperties() override;
+#else
+    virtual ~ImageFiltersProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ImageFiltersProperties, initialConfig);
@@ -22,6 +28,12 @@ struct ToFDepthConfidenceFilterProperties : PropertiesSerializable<Properties, T
      * Initial config for the ToF depth confidence filter
      */
     ToFDepthConfidenceFilterConfig initialConfig;
+
+#if defined(__clang__)
+    ~ToFDepthConfidenceFilterProperties() override;
+#else
+    virtual ~ToFDepthConfidenceFilterProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ToFDepthConfidenceFilterProperties, initialConfig);

--- a/include/depthai/properties/ImageManipProperties.hpp
+++ b/include/depthai/properties/ImageManipProperties.hpp
@@ -38,6 +38,12 @@ struct ImageManipProperties : PropertiesSerializable<Properties, ImageManipPrope
     /// Using HW backend can cause some unexpected behavior when using multiple ImageManip nodes in series
     Backend backend = Backend::CPU;
     PerformanceMode performanceMode = PerformanceMode::PERFORMANCE;
+
+#if defined(__clang__)
+    ~ImageManipProperties() override;
+#else
+    virtual ~ImageManipProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ImageManipProperties, initialConfig, outputFrameSize, numFramesPool, backend, performanceMode);

--- a/include/depthai/properties/MessageDemuxProperties.hpp
+++ b/include/depthai/properties/MessageDemuxProperties.hpp
@@ -10,6 +10,12 @@ namespace dai {
 struct MessageDemuxProperties : PropertiesSerializable<Properties, MessageDemuxProperties> {
     // Needed for serialization
     char dummy = 0;
+
+#if defined(__clang__)
+    ~MessageDemuxProperties() override;
+#else
+    virtual ~MessageDemuxProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(MessageDemuxProperties, dummy);

--- a/include/depthai/properties/MonoCameraProperties.hpp
+++ b/include/depthai/properties/MonoCameraProperties.hpp
@@ -93,6 +93,12 @@ struct MonoCameraProperties : PropertiesSerializable<Properties, MonoCameraPrope
      * with both packed/unpacked, but disabled for other cameras like ToF.
      */
     std::optional<bool> rawPacked;
+
+#if defined(__clang__)
+    ~MonoCameraProperties() override;
+#else
+    virtual ~MonoCameraProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(MonoCameraProperties,

--- a/include/depthai/properties/NeuralNetworkProperties.hpp
+++ b/include/depthai/properties/NeuralNetworkProperties.hpp
@@ -53,6 +53,12 @@ struct NeuralNetworkProperties : PropertiesSerializable<Properties, NeuralNetwor
      * Specify backend properties
      */
     std::map<std::string, std::string> backendProperties;
+
+#if defined(__clang__)
+    ~NeuralNetworkProperties() override;
+#else
+    virtual ~NeuralNetworkProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(

--- a/include/depthai/properties/ObjectTrackerProperties.hpp
+++ b/include/depthai/properties/ObjectTrackerProperties.hpp
@@ -72,6 +72,12 @@ struct ObjectTrackerProperties : PropertiesSerializable<Properties, ObjectTracke
      * Tracklet birth threshold. Minimum consecutive tracked frames required to consider a tracklet as a new instance.
      */
     uint32_t trackletBirthThreshold = 3;
+
+#if defined(__clang__)
+    ~ObjectTrackerProperties() override;
+#else
+    virtual ~ObjectTrackerProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ObjectTrackerProperties,

--- a/include/depthai/properties/PointCloudProperties.hpp
+++ b/include/depthai/properties/PointCloudProperties.hpp
@@ -15,6 +15,12 @@ struct PointCloudProperties : PropertiesSerializable<Properties, PointCloudPrope
     PointCloudConfig initialConfig;
 
     int numFramesPool = 4;
+
+#if defined(__clang__)
+    ~PointCloudProperties() override;
+#else
+    virtual ~PointCloudProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(PointCloudProperties, initialConfig, numFramesPool);

--- a/include/depthai/properties/PoolProperties.hpp
+++ b/include/depthai/properties/PoolProperties.hpp
@@ -30,6 +30,12 @@ struct PoolProperties : PropertiesSerializable<Properties, PoolProperties> {
      * Which processor should hold the pool
      */
     std::optional<ProcessorType> processor = std::nullopt;
+
+#if defined(__clang__)
+    ~PoolProperties() override;
+#else
+    virtual ~PoolProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(PoolProperties, numMessages, maxMessageSize, datatype, processor);

--- a/include/depthai/properties/Properties.hpp
+++ b/include/depthai/properties/Properties.hpp
@@ -8,7 +8,12 @@ namespace dai {
 struct Properties {
     virtual void serialize(std::vector<std::uint8_t>& data, SerializationType type) const = 0;
     virtual std::unique_ptr<Properties> clone() const = 0;
+
+#if defined(__clang__)
+    virtual ~Properties();
+#else
     virtual ~Properties() = default;
+#endif
 };
 
 /// Serializable properties

--- a/include/depthai/properties/SPIInProperties.hpp
+++ b/include/depthai/properties/SPIInProperties.hpp
@@ -28,6 +28,12 @@ struct SPIInProperties : PropertiesSerializable<Properties, SPIInProperties> {
      * Number of frames in pool
      */
     std::uint32_t numFrames = 4;
+
+#if defined(__clang__)
+    ~SPIInProperties() override;
+#else
+    virtual ~SPIInProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(SPIInProperties, streamName, busId, maxDataSize, numFrames);

--- a/include/depthai/properties/SPIOutProperties.hpp
+++ b/include/depthai/properties/SPIOutProperties.hpp
@@ -17,6 +17,12 @@ struct SPIOutProperties : PropertiesSerializable<Properties, SPIOutProperties> {
      * SPI bus to use
      */
     int busId = 0;
+
+#if defined(__clang__)
+    ~SPIOutProperties() override;
+#else
+    virtual ~SPIOutProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(SPIOutProperties, streamName, busId);

--- a/include/depthai/properties/ScriptProperties.hpp
+++ b/include/depthai/properties/ScriptProperties.hpp
@@ -24,6 +24,12 @@ struct ScriptProperties : PropertiesSerializable<Properties, ScriptProperties> {
      * Which processor should execute the script
      */
     ProcessorType processor = ProcessorType::LEON_MSS;
+
+#if defined(__clang__)
+    ~ScriptProperties() override;
+#else
+    virtual ~ScriptProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ScriptProperties, scriptUri, scriptName, processor);

--- a/include/depthai/properties/SpatialDetectionNetworkProperties.hpp
+++ b/include/depthai/properties/SpatialDetectionNetworkProperties.hpp
@@ -21,6 +21,12 @@ struct SpatialDetectionNetworkProperties : PropertiesSerializable<Properties, Sp
     SpatialLocationCalculatorConfigThresholds depthThresholds;
     SpatialLocationCalculatorAlgorithm calculationAlgorithm = SpatialLocationCalculatorAlgorithm::MEDIAN;
     std::int32_t stepSize = SpatialLocationCalculatorConfigData::AUTO;
+
+#if defined(__clang__)
+    ~SpatialDetectionNetworkProperties() override;
+#else
+    virtual ~SpatialDetectionNetworkProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(SpatialDetectionNetworkProperties, detectedBBScaleFactor, depthThresholds, calculationAlgorithm);

--- a/include/depthai/properties/SpatialLocationCalculatorProperties.hpp
+++ b/include/depthai/properties/SpatialLocationCalculatorProperties.hpp
@@ -13,6 +13,12 @@ namespace dai {
  */
 struct SpatialLocationCalculatorProperties : PropertiesSerializable<Properties, SpatialLocationCalculatorProperties> {
     SpatialLocationCalculatorConfig roiConfig;
+
+#if defined(__clang__)
+    ~SpatialLocationCalculatorProperties() override;
+#else
+    virtual ~SpatialLocationCalculatorProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(SpatialLocationCalculatorProperties, roiConfig);

--- a/include/depthai/properties/StereoDepthProperties.hpp
+++ b/include/depthai/properties/StereoDepthProperties.hpp
@@ -187,6 +187,12 @@ struct StereoDepthProperties : PropertiesSerializable<Properties, StereoDepthPro
      * See getOptimalNewCameraMatrix from opencv for more details.
      */
     std::optional<float> alphaScaling;
+
+#if defined(__clang__)
+    ~StereoDepthProperties() override;
+#else
+    virtual ~StereoDepthProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(StereoDepthProperties,

--- a/include/depthai/properties/SyncProperties.hpp
+++ b/include/depthai/properties/SyncProperties.hpp
@@ -19,6 +19,12 @@ struct SyncProperties : PropertiesSerializable<Properties, SyncProperties> {
      * The number of syncing attempts before fail (num of replaced messages).
      */
     int32_t syncAttempts = -1;
+
+#if defined(__clang__)
+    ~SyncProperties() override;
+#else
+    virtual ~SyncProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(SyncProperties, syncThresholdNs, syncAttempts);

--- a/include/depthai/properties/SystemLoggerProperties.hpp
+++ b/include/depthai/properties/SystemLoggerProperties.hpp
@@ -14,6 +14,12 @@ struct SystemLoggerProperties : PropertiesSerializable<Properties, SystemLoggerP
      * Rate at which the messages are going to be sent in hertz
      */
     float rateHz = 1.0f;
+
+#if defined(__clang__)
+    ~SystemLoggerProperties() override;
+#else
+    virtual ~SystemLoggerProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(SystemLoggerProperties, rateHz);

--- a/include/depthai/properties/ThermalProperties.hpp
+++ b/include/depthai/properties/ThermalProperties.hpp
@@ -30,6 +30,12 @@ struct ThermalProperties : PropertiesSerializable<Properties, ThermalProperties>
      * Camera sensor FPS
      */
     float fps = 25.0;
+
+#if defined(__clang__)
+    ~ThermalProperties() override;
+#else
+    virtual ~ThermalProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ThermalProperties, initialConfig, numFramesPool, boardSocket, fps);

--- a/include/depthai/properties/ToFProperties.hpp
+++ b/include/depthai/properties/ToFProperties.hpp
@@ -55,6 +55,12 @@ struct ToFProperties : PropertiesSerializable<Properties, ToFProperties> {
      * Pool sizes
      */
     int numFramesPoolRaw = 3;
+
+#if defined(__clang__)
+    ~ToFProperties() override;
+#else
+    virtual ~ToFProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(ToFProperties, initialConfig, numFramesPool, numShaves, warpHwIds, boardSocket, cameraName, imageOrientation, fps, numFramesPoolRaw);

--- a/include/depthai/properties/UVCProperties.hpp
+++ b/include/depthai/properties/UVCProperties.hpp
@@ -16,6 +16,12 @@ struct UVCProperties : PropertiesSerializable<Properties, UVCProperties> {
 
     /// <gpio_number, value> list for GPIOs to set when streaming is disabled
     std::unordered_map<int, int> gpioStreamOff;
+
+#if defined(__clang__)
+    ~UVCProperties() override;
+#else
+    virtual ~UVCProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(UVCProperties, gpioInit, gpioStreamOn, gpioStreamOff);

--- a/include/depthai/properties/VideoEncoderProperties.hpp
+++ b/include/depthai/properties/VideoEncoderProperties.hpp
@@ -72,6 +72,12 @@ struct VideoEncoderProperties : PropertiesSerializable<Properties, VideoEncoderP
      * Frame rate
      */
     float frameRate = 30.0f;
+
+#if defined(__clang__)
+    ~VideoEncoderProperties() override;
+#else
+    virtual ~VideoEncoderProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(VideoEncoderProperties,

--- a/include/depthai/properties/WarpProperties.hpp
+++ b/include/depthai/properties/WarpProperties.hpp
@@ -34,6 +34,12 @@ struct WarpProperties : PropertiesSerializable<Properties, WarpProperties> {
     std::vector<int> warpHwIds;
 
     Interpolation interpolation = Interpolation::AUTO;
+
+#if defined(__clang__)
+    ~WarpProperties() override;
+#else
+    virtual ~WarpProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(WarpProperties, outputWidth, outputHeight, outputFrameSize, numFramesPool, meshWidth, meshHeight, meshUri, warpHwIds, interpolation);

--- a/include/depthai/properties/internal/XLinkInProperties.hpp
+++ b/include/depthai/properties/internal/XLinkInProperties.hpp
@@ -25,6 +25,12 @@ struct XLinkInProperties : PropertiesSerializable<Properties, XLinkInProperties>
      * Number of frames in pool
      */
     std::uint32_t numFrames = 8;
+
+#if defined(__clang__)
+    ~XLinkInProperties() override;
+#else
+    virtual ~XLinkInProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(XLinkInProperties, streamName, maxDataSize, numFrames);

--- a/include/depthai/properties/internal/XLinkOutProperties.hpp
+++ b/include/depthai/properties/internal/XLinkOutProperties.hpp
@@ -23,6 +23,12 @@ struct XLinkOutProperties : PropertiesSerializable<Properties, XLinkOutPropertie
      * Whether to transfer data or only object attributes
      */
     bool metadataOnly = false;
+
+#if defined(__clang__)
+    ~XLinkOutProperties() override;
+#else
+    virtual ~XLinkOutProperties() = default;
+#endif
 };
 
 DEPTHAI_SERIALIZE_EXT(XLinkOutProperties, maxFpsLimit, streamName, metadataOnly);

--- a/include/depthai/utility/Memory.hpp
+++ b/include/depthai/utility/Memory.hpp
@@ -110,7 +110,7 @@ holder(std::move(holder)) {}
 // memory as interface
 class Memory {
    public:
-    virtual ~Memory(){};
+    virtual ~Memory();
     virtual span<std::uint8_t> getData() = 0;
     virtual span<const std::uint8_t> getData() const = 0;
     virtual std::size_t getMaxSize() const = 0;

--- a/include/depthai/utility/ProtoSerializable.hpp
+++ b/include/depthai/utility/ProtoSerializable.hpp
@@ -13,7 +13,11 @@ class ProtoSerializable {
         std::string schema;
     };
 
+#if defined(__clang__)
+    virtual ~ProtoSerializable();
+#else
     virtual ~ProtoSerializable() = default;
+#endif
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
     /**

--- a/include/depthai/utility/SharedMemory.hpp
+++ b/include/depthai/utility/SharedMemory.hpp
@@ -77,14 +77,7 @@ class SharedMemory : public Memory {
         mapFd();
     }
 
-    ~SharedMemory() {
-        unmapFd();
-#if defined(__unix__) && !defined(__APPLE__)
-        if(fd > 0) {
-            close(fd);
-        }
-#endif
-    }
+    ~SharedMemory() override;
 
     SharedMemory& operator=(long argFd) {
         unmapFd();
@@ -130,6 +123,8 @@ class SharedMemory : public Memory {
         if(ftruncate(fd, size) < 0) {
             throw std::runtime_error("Failed to set shared memory size");
         }
+#else
+        (void)size;  // size is not used
 #endif
         mapFd();
     }

--- a/include/depthai/utility/VectorMemory.hpp
+++ b/include/depthai/utility/VectorMemory.hpp
@@ -36,6 +36,12 @@ class VectorMemory : public std::vector<std::uint8_t>, public Memory {
     void setSize(std::size_t size) override {
         resize(size);
     }
+
+#if defined(__clang__)
+    ~VectorMemory() override;
+#else
+    virtual ~VectorMemory() = default;
+#endif
 };
 
 }  // namespace dai

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -67,6 +67,12 @@ class StreamPacketMemory : public StreamPacketDesc, public Memory {
         }
         this->size = size;
     }
+
+#if defined(__clang__)
+    ~StreamPacketMemory() override;
+#else
+    virtual ~StreamPacketMemory() = default;
+#endif
 };
 
 class XLinkStream {
@@ -123,6 +129,11 @@ class XLinkStream {
     std::string getStreamName() const;
 };
 
+#ifdef __clang__
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 struct XLinkError : public std::runtime_error {
     const XLinkError_t status = X_LINK_ERROR;
     const std::string streamName;
@@ -140,5 +151,9 @@ struct XLinkWriteError : public XLinkError {
     using XLinkError = XLinkError;
     XLinkWriteError(XLinkError_t status, const std::string& stream);
 };
+
+#ifdef __clang__
+    #pragma clang diagnostic pop
+#endif
 
 }  // namespace dai

--- a/src/capabilities/Capabilities.cpp
+++ b/src/capabilities/Capabilities.cpp
@@ -1,0 +1,17 @@
+
+#if defined(__clang__)
+    #include "depthai/capabilities/Capability.hpp"
+    #include "depthai/capabilities/ImgFrameCapability.hpp"
+#endif
+
+namespace dai {
+
+#if defined(__clang__)
+Capability::~Capability() = default;
+#endif
+
+#if defined(__clang__)
+ImgFrameCapability::~ImgFrameCapability() = default;
+#endif
+
+}  // namespace dai

--- a/src/pipeline/DeviceNodeGroup.cpp
+++ b/src/pipeline/DeviceNodeGroup.cpp
@@ -2,6 +2,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+DeviceNodeGroup::~DeviceNodeGroup() = default;
+#endif
+
 void DeviceNodeGroup::setLogLevel(dai::LogLevel level) {
     for(auto& node : nodeRefs) {
         // Try converting to ThreadedNode

--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -24,6 +24,10 @@ Pipeline Node::getParentPipeline() {
     return Pipeline(impl);
 }
 
+#if defined(__clang__)
+Node::Input::~Input() = default;
+#endif
+
 Node::Connection::Connection(Output out, Input in) {
     outputId = out.getParent().id;
     outputName = out.getName();

--- a/src/pipeline/ThreadedHostNode.cpp
+++ b/src/pipeline/ThreadedHostNode.cpp
@@ -1,0 +1,13 @@
+#if defined(__clang__)
+    #include "depthai/pipeline/ThreadedHostNode.hpp"
+#endif
+
+namespace dai {
+namespace node {
+
+#if defined(__clang__)
+ThreadedHostNode::~ThreadedHostNode() = default;
+#endif
+
+}  // namespace node
+}  // namespace dai

--- a/src/pipeline/ThreadedNode.cpp
+++ b/src/pipeline/ThreadedNode.cpp
@@ -20,6 +20,10 @@ ThreadedNode::ThreadedNode() {
     pimpl->logger->set_level(level);
 }
 
+#if defined(__clang__)
+ThreadedNode::~ThreadedNode() = default;
+#endif
+
 void ThreadedNode::start() {
     // A node should not be started if it is already running
     // We would be creating multiple threads for the same node

--- a/src/pipeline/datatype/ADataType.cpp
+++ b/src/pipeline/datatype/ADataType.cpp
@@ -1,0 +1,9 @@
+#include "depthai/pipeline/datatype/ADatatype.hpp"
+
+namespace dai {
+
+#if defined(__clang__)
+ADatatype::~ADatatype() = default;
+#endif
+
+}  // namespace dai

--- a/src/pipeline/datatype/AprilTagConfig.cpp
+++ b/src/pipeline/datatype/AprilTagConfig.cpp
@@ -1,6 +1,11 @@
 #include "depthai/pipeline/datatype/AprilTagConfig.hpp"
 
 namespace dai {
+
+#if defined(__clang__)
+AprilTagConfig::~AprilTagConfig() = default;
+#endif
+
 AprilTagConfig& AprilTagConfig::setFamily(Family family) {
     this->family = family;
     return *this;

--- a/src/pipeline/datatype/AprilTags.cpp
+++ b/src/pipeline/datatype/AprilTags.cpp
@@ -1,5 +1,9 @@
 #include "depthai/pipeline/datatype/AprilTags.hpp"
 
 namespace dai {
-;  // TODO - no impl needed
+
+#if defined(__clang__)
+AprilTags::~AprilTags() = default;
+#endif
+
 }  // namespace dai

--- a/src/pipeline/datatype/BenchmarkReport.cpp
+++ b/src/pipeline/datatype/BenchmarkReport.cpp
@@ -1,5 +1,9 @@
 #include "depthai/pipeline/datatype/BenchmarkReport.hpp"
 
 namespace dai {
-// No implementation needed
+
+#if defined(__clang__)
+BenchmarkReport::~BenchmarkReport() = default;
+#endif
+
 }  // namespace dai

--- a/src/pipeline/datatype/Buffer.cpp
+++ b/src/pipeline/datatype/Buffer.cpp
@@ -20,6 +20,10 @@ Buffer::Buffer(long fd, size_t size) : Buffer() {
     data = mem;
 }
 
+#if defined(__clang__)
+Buffer::~Buffer() = default;
+#endif
+
 span<uint8_t> Buffer::getData() {
     return data->getData();
 }

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -250,6 +250,10 @@ int CameraControl::getLensPosition() const {
     return lensPosition;
 }
 
+#if defined(__clang__)
+CameraControl::~CameraControl() = default;
+#endif
+
 float CameraControl::getLensPositionRaw() const {
     return lensPositionRaw;
 }

--- a/src/pipeline/datatype/DynamicCalibrationConfig.cpp
+++ b/src/pipeline/datatype/DynamicCalibrationConfig.cpp
@@ -1,3 +1,9 @@
 #include "depthai/pipeline/datatype/DynamicCalibrationConfig.hpp"
 
-namespace dai {}  // namespace dai
+namespace dai {
+
+#if defined(__clang__)
+DynamicCalibrationControl::~DynamicCalibrationControl() = default;
+#endif
+
+}  // namespace dai

--- a/src/pipeline/datatype/DynamicCalibrationResults.cpp
+++ b/src/pipeline/datatype/DynamicCalibrationResults.cpp
@@ -1,0 +1,13 @@
+#include "depthai/pipeline/datatype/DynamicCalibrationResults.hpp"
+
+namespace dai {
+
+#if defined(__clang__)
+CoverageData::~CoverageData() = default;
+
+CalibrationQuality::~CalibrationQuality() = default;
+
+DynamicCalibrationResult::~DynamicCalibrationResult() = default;
+#endif
+
+}  // namespace dai

--- a/src/pipeline/datatype/EdgeDetectorConfig.cpp
+++ b/src/pipeline/datatype/EdgeDetectorConfig.cpp
@@ -1,6 +1,11 @@
 #include "depthai/pipeline/datatype/EdgeDetectorConfig.hpp"
 
 namespace dai {
+
+#if defined(__clang__)
+EdgeDetectorConfig::~EdgeDetectorConfig() = default;
+#endif
+
 void EdgeDetectorConfig::setSobelFilterKernels(const std::vector<std::vector<int>>& horizontalKernel, const std::vector<std::vector<int>>& verticalKernel) {
     config.sobelFilterHorizontalKernel = horizontalKernel;
     config.sobelFilterVerticalKernel = verticalKernel;

--- a/src/pipeline/datatype/EncodedFrame.cpp
+++ b/src/pipeline/datatype/EncodedFrame.cpp
@@ -7,6 +7,11 @@
 #include "utility/H26xParsers.hpp"
 
 namespace dai {
+
+#if defined(__clang__)
+EncodedFrame::~EncodedFrame() = default;
+#endif
+
 // getters
 unsigned int EncodedFrame::getInstanceNum() const {
     return instanceNum;

--- a/src/pipeline/datatype/FeatureTrackerConfig.cpp
+++ b/src/pipeline/datatype/FeatureTrackerConfig.cpp
@@ -2,6 +2,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+FeatureTrackerConfig::~FeatureTrackerConfig() = default;
+#endif
+
 FeatureTrackerConfig& FeatureTrackerConfig::setCornerDetector(FeatureTrackerConfig::CornerDetector::Type cornerDetector) {
     this->cornerDetector.type = cornerDetector;
     return *this;

--- a/src/pipeline/datatype/ImageAlignConfig.cpp
+++ b/src/pipeline/datatype/ImageAlignConfig.cpp
@@ -1,0 +1,9 @@
+#include "depthai/pipeline/datatype/ImageAlignConfig.hpp"
+
+namespace dai {
+
+#if defined(__clang__)
+ImageAlignConfig::~ImageAlignConfig() = default;
+#endif
+
+}  // namespace dai

--- a/src/pipeline/datatype/ImageFiltersConfig.cpp
+++ b/src/pipeline/datatype/ImageFiltersConfig.cpp
@@ -3,6 +3,15 @@
 #include "utility/ErrorMacros.hpp"
 
 namespace dai {
+
+#if defined(__clang__)
+ImageFiltersConfig::~ImageFiltersConfig() = default;
+#endif
+
+#if defined(__clang__)
+ToFDepthConfidenceFilterConfig::~ToFDepthConfidenceFilterConfig() = default;
+#endif
+
 ImageFiltersConfig& ImageFiltersConfig::updateFilterAtIndex(std::int32_t index, FilterParams params) {
     DAI_CHECK_V(this->filterIndices.size() == this->filterParams.size(),
                 "ImageFiltersConfig can either be used to create a new filter pipeline or update an existing one, not both");

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -6,6 +6,21 @@
 
 namespace dai {
 
+#if defined(__clang__)
+
+OpBase::~OpBase() = default;
+Translate::~Translate() = default;
+Rotate::~Rotate() = default;
+Resize::~Resize() = default;
+Flip::~Flip() = default;
+Affine::~Affine() = default;
+Perspective::~Perspective() = default;
+FourPoints::~FourPoints() = default;
+Crop::~Crop() = default;
+
+ImageManipConfig::~ImageManipConfig() = default;
+#endif
+
 // New API
 ImageManipConfig& ImageManipConfig::clearOps() {
     base.clear();

--- a/src/pipeline/datatype/ImgAnnotations.cpp
+++ b/src/pipeline/datatype/ImgAnnotations.cpp
@@ -7,6 +7,11 @@
 #endif
 
 namespace dai {
+
+#if defined(__clang__)
+ImgAnnotations::~ImgAnnotations() = default;
+#endif
+
 #ifdef DEPTHAI_ENABLE_PROTOBUF
 
 ProtoSerializable::SchemaPair ImgAnnotations::serializeSchema() const {

--- a/src/pipeline/datatype/ImgDetections.cpp
+++ b/src/pipeline/datatype/ImgDetections.cpp
@@ -6,6 +6,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+ImgDetections::~ImgDetections() = default;
+#endif
+
 #ifdef DEPTHAI_ENABLE_PROTOBUF
 ProtoSerializable::SchemaPair ImgDetections::serializeSchema() const {
     return utility::serializeSchema(utility::getProtoMessage(this));

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -10,6 +10,10 @@
 #endif
 namespace dai {
 
+#if defined(__clang__)
+ImgFrame::~ImgFrame() = default;
+#endif
+
 ImgFrame::ImgFrame() {
     // Set timestamp to now
     setTimestamp(std::chrono::steady_clock::now());

--- a/src/pipeline/datatype/MessageGroup.cpp
+++ b/src/pipeline/datatype/MessageGroup.cpp
@@ -8,6 +8,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+MessageGroup::~MessageGroup() = default;
+#endif
+
 std::shared_ptr<ADatatype> MessageGroup::operator[](const std::string& name) {
     return group.at(name);
 }

--- a/src/pipeline/datatype/NNData.cpp
+++ b/src/pipeline/datatype/NNData.cpp
@@ -10,6 +10,11 @@
 #include "fp16/fp16.h"
 
 namespace dai {
+
+#if defined(__clang__)
+NNData::~NNData() = default;
+#endif
+
 NNData::NNData(size_t size) : NNData() {
     auto mem = std::make_shared<VectorMemory>();
     mem->resize(size);

--- a/src/pipeline/datatype/ObjectTrackerConfig.cpp
+++ b/src/pipeline/datatype/ObjectTrackerConfig.cpp
@@ -2,6 +2,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+ObjectTrackerConfig::~ObjectTrackerConfig() = default;
+#endif
+
 ObjectTrackerConfig& ObjectTrackerConfig::forceRemoveID(int32_t id) {
     trackletIdsToRemove.push_back(id);
     return *this;

--- a/src/pipeline/datatype/PointCloudConfig.cpp
+++ b/src/pipeline/datatype/PointCloudConfig.cpp
@@ -2,6 +2,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+PointCloudConfig::~PointCloudConfig() = default;
+#endif
+
 bool PointCloudConfig::getSparse() const {
     return sparse;
 }

--- a/src/pipeline/datatype/PointCloudData.cpp
+++ b/src/pipeline/datatype/PointCloudData.cpp
@@ -7,6 +7,10 @@
 #endif
 namespace dai {
 
+#if defined(__clang__)
+PointCloudData::~PointCloudData() = default;
+#endif
+
 std::vector<Point3f> PointCloudData::getPoints() {
     if(isColor()) {
         span<const Point3fRGBA> pointData(reinterpret_cast<Point3fRGBA*>(data->getData().data()), data->getData().size() / sizeof(Point3fRGBA));

--- a/src/pipeline/datatype/RGBDData.cpp
+++ b/src/pipeline/datatype/RGBDData.cpp
@@ -1,6 +1,11 @@
 #include "depthai/pipeline/datatype/RGBDData.hpp"
 
 namespace dai {
+
+#if defined(__clang__)
+RGBDData::~RGBDData() = default;
+#endif
+
 void RGBDData::setRGBFrame(const std::shared_ptr<ImgFrame>& frame) {
     frames["rgb"] = frame;
 }

--- a/src/pipeline/datatype/SpatialImgDetections.cpp
+++ b/src/pipeline/datatype/SpatialImgDetections.cpp
@@ -5,6 +5,11 @@
 #endif
 
 namespace dai {
+
+#if defined(__clang__)
+SpatialImgDetections::~SpatialImgDetections() = default;
+#endif
+
 #ifdef DEPTHAI_ENABLE_PROTOBUF
 std::vector<std::uint8_t> SpatialImgDetections::serializeProto(bool) const {
     return utility::serializeProto(utility::getProtoMessage(this));

--- a/src/pipeline/datatype/SpatialLocationCalculatorConfig.cpp
+++ b/src/pipeline/datatype/SpatialLocationCalculatorConfig.cpp
@@ -1,6 +1,11 @@
 #include "depthai/pipeline/datatype/SpatialLocationCalculatorConfig.hpp"
 
 namespace dai {
+
+#if defined(__clang__)
+SpatialLocationCalculatorConfig::~SpatialLocationCalculatorConfig() = default;
+#endif
+
 void SpatialLocationCalculatorConfig::setROIs(std::vector<SpatialLocationCalculatorConfigData> ROIs) {
     config = ROIs;
 }

--- a/src/pipeline/datatype/SpatialLocationCalculatorData.cpp
+++ b/src/pipeline/datatype/SpatialLocationCalculatorData.cpp
@@ -1,6 +1,11 @@
 #include "depthai/pipeline/datatype/SpatialLocationCalculatorData.hpp"
 
 namespace dai {
+
+#if defined(__clang__)
+SpatialLocationCalculatorData::~SpatialLocationCalculatorData() = default;
+#endif
+
 std::vector<SpatialLocations> SpatialLocationCalculatorData::getSpatialLocations() const {
     return spatialLocations;
 }

--- a/src/pipeline/datatype/StereoDepthConfig.cpp
+++ b/src/pipeline/datatype/StereoDepthConfig.cpp
@@ -1,6 +1,11 @@
 #include "depthai/pipeline/datatype/StereoDepthConfig.hpp"
 
 namespace dai {
+
+#if defined(__clang__)
+StereoDepthConfig::~StereoDepthConfig() = default;
+#endif
+
 StereoDepthConfig& StereoDepthConfig::setDepthAlign(AlgorithmControl::DepthAlign align) {
     algorithmControl.depthAlign = align;
     return *this;

--- a/src/pipeline/datatype/SystemInformation.cpp
+++ b/src/pipeline/datatype/SystemInformation.cpp
@@ -1,5 +1,9 @@
 #include "depthai/pipeline/datatype/SystemInformation.hpp"
 
 namespace dai {
-// No implementation needed
+
+#if defined(__clang__)
+SystemInformation::~SystemInformation() = default;
+#endif
+
 }  // namespace dai

--- a/src/pipeline/datatype/SystemInformationS3.cpp
+++ b/src/pipeline/datatype/SystemInformationS3.cpp
@@ -1,5 +1,9 @@
 #include "depthai/pipeline/datatype/SystemInformationS3.hpp"
 
 namespace dai {
-// No implementation needed
+
+#if defined(__clang__)
+SystemInformationS3::~SystemInformationS3() = default;
+#endif
+
 }  // namespace dai

--- a/src/pipeline/datatype/ThermalConfig.cpp
+++ b/src/pipeline/datatype/ThermalConfig.cpp
@@ -1,0 +1,9 @@
+#include "depthai/pipeline/datatype/ThermalConfig.hpp"
+
+namespace dai {
+
+#if defined(__clang__)
+ThermalConfig::~ThermalConfig() = default;
+#endif
+
+}  // namespace dai

--- a/src/pipeline/datatype/ToFConfig.cpp
+++ b/src/pipeline/datatype/ToFConfig.cpp
@@ -2,6 +2,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+ToFConfig::~ToFConfig() = default;
+#endif
+
 ToFConfig& ToFConfig::setMedianFilter(filters::params::MedianFilter median) {
     this->median = median;
     return *this;

--- a/src/pipeline/datatype/TrackedFeatures.cpp
+++ b/src/pipeline/datatype/TrackedFeatures.cpp
@@ -1,5 +1,9 @@
 #include "depthai/pipeline/datatype/TrackedFeatures.hpp"
 
 namespace dai {
-// No implementation needed
+
+#if defined(__clang__)
+TrackedFeatures::~TrackedFeatures() = default;
+#endif
+
 }  // namespace dai

--- a/src/pipeline/datatype/Tracklets.cpp
+++ b/src/pipeline/datatype/Tracklets.cpp
@@ -1,3 +1,9 @@
 #include "depthai/pipeline/datatype/Tracklets.hpp"
 
-namespace dai {}  // namespace dai
+namespace dai {
+
+#if defined(__clang__)
+Tracklets::~Tracklets() = default;
+#endif
+
+}  // namespace dai

--- a/src/pipeline/datatype/TransformData.cpp
+++ b/src/pipeline/datatype/TransformData.cpp
@@ -8,6 +8,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+TransformData::~TransformData() = default;
+#endif
+
 TransformData::TransformData() {}
 TransformData::TransformData(const Transform& transform) : transform(transform) {}
 TransformData::TransformData(const std::array<std::array<double, 4>, 4>& data) : transform({data}) {}

--- a/src/pipeline/node/DetectionParser.cpp
+++ b/src/pipeline/node/DetectionParser.cpp
@@ -14,6 +14,10 @@
 namespace dai {
 namespace node {
 
+#if defined(__clang__)
+DetectionParser::~DetectionParser() = default;
+#endif
+
 void DetectionParser::setNNArchive(const NNArchive& nnArchive) {
     constexpr int DEFAULT_SUPERBLOB_NUM_SHAVES = 8;
     switch(nnArchive.getModelType()) {

--- a/src/pipeline/node/ImageFilters.cpp
+++ b/src/pipeline/node/ImageFilters.cpp
@@ -822,6 +822,9 @@ void ImageFilters::run() {
         // Set config
         while(inputConfig.has()) {
             auto configMsg = inputConfig.get<ImageFiltersConfig>();
+            if(configMsg == nullptr) {
+                continue;
+            }
             bool isUpdate = configMsg->filterIndices.size() > 0;
             if(isUpdate) {
                 updateExistingFilterPipeline(*configMsg);
@@ -950,7 +953,9 @@ void ToFDepthConfidenceFilter::run() {
         // Update threshold dynamically
         while(inputConfig.has()) {
             auto configMsg = inputConfig.get<ToFDepthConfidenceFilterConfig>();
-            confidenceThreshold = configMsg->confidenceThreshold;
+            if(configMsg != nullptr) {
+                confidenceThreshold = configMsg->confidenceThreshold;
+            }
         }
 
         // Get frames from input queue

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -15,6 +15,10 @@
 namespace dai {
 namespace node {
 
+#if defined(__clang__)
+NeuralNetwork::~NeuralNetwork() = default;
+#endif
+
 std::shared_ptr<NeuralNetwork> NeuralNetwork::build(Node::Output& input, const NNArchive& nnArchive) {
     setNNArchive(nnArchive);
     input.link(this->input);

--- a/src/pipeline/node/ToF.cpp
+++ b/src/pipeline/node/ToF.cpp
@@ -5,6 +5,10 @@
 namespace dai {
 namespace node {
 
+#if defined(__clang__)
+ToF::~ToF() = default;
+#endif
+
 ToFBase::ToFBase(std::unique_ptr<Properties> props)
     : DeviceNodeCRTP<DeviceNode, ToFBase, ToFProperties>(std::move(props)),
       initialConfig(std::make_shared<decltype(properties.initialConfig)>(properties.initialConfig)) {}

--- a/src/pipeline/node/UVC.cpp
+++ b/src/pipeline/node/UVC.cpp
@@ -3,6 +3,10 @@
 namespace dai {
 namespace node {
 
+#if defined(__clang__)
+UVC::~UVC() = default;
+#endif
+
 UVC::UVC(std::unique_ptr<Properties> props) : DeviceNodeCRTP<DeviceNode, UVC, UVCProperties>(std::move(props)) {}
 
 void UVC::setGpiosOnInit(std::unordered_map<int, int> list) {

--- a/src/pipeline/node/internal/XLinkIn.cpp
+++ b/src/pipeline/node/internal/XLinkIn.cpp
@@ -3,6 +3,11 @@
 namespace dai {
 namespace node {
 namespace internal {
+
+#if defined(__clang__)
+XLinkIn::~XLinkIn() = default;
+#endif
+
 void XLinkIn::setStreamName(const std::string& name) {
     properties.streamName = name;
 }

--- a/src/properties/Properties.cpp
+++ b/src/properties/Properties.cpp
@@ -1,0 +1,94 @@
+#include "depthai/properties/Properties.hpp"
+
+#if defined(__clang__)
+    #include "depthai/properties/AprilTagProperties.hpp"
+    #include "depthai/properties/BenchmarkInProperties.hpp"
+    #include "depthai/properties/BenchmarkOutProperties.hpp"
+    #include "depthai/properties/CameraProperties.hpp"
+    #include "depthai/properties/CastProperties.hpp"
+    #include "depthai/properties/ColorCameraProperties.hpp"
+    #include "depthai/properties/DetectionParserProperties.hpp"
+    #include "depthai/properties/DeviceNodeGroupProperties.hpp"
+    #include "depthai/properties/EdgeDetectorProperties.hpp"
+    #include "depthai/properties/FeatureTrackerProperties.hpp"
+    #include "depthai/properties/GlobalProperties.hpp"
+    #include "depthai/properties/IMUProperties.hpp"
+    #include "depthai/properties/ImageAlignProperties.hpp"
+    #include "depthai/properties/ImageFiltersProperties.hpp"
+    #include "depthai/properties/ImageManipProperties.hpp"
+    #include "depthai/properties/MessageDemuxProperties.hpp"
+    #include "depthai/properties/MonoCameraProperties.hpp"
+    #include "depthai/properties/NeuralNetworkProperties.hpp"
+    #include "depthai/properties/ObjectTrackerProperties.hpp"
+    #include "depthai/properties/PointCloudProperties.hpp"
+    #include "depthai/properties/SPIInProperties.hpp"
+    #include "depthai/properties/SPIOutProperties.hpp"
+    #include "depthai/properties/ScriptProperties.hpp"
+    #include "depthai/properties/SpatialDetectionNetworkProperties.hpp"
+    #include "depthai/properties/SpatialLocationCalculatorProperties.hpp"
+    #include "depthai/properties/StereoDepthProperties.hpp"
+    #include "depthai/properties/SyncProperties.hpp"
+    #include "depthai/properties/SystemLoggerProperties.hpp"
+    #include "depthai/properties/ThermalProperties.hpp"
+    #include "depthai/properties/ToFProperties.hpp"
+    #include "depthai/properties/UVCProperties.hpp"
+    #include "depthai/properties/VideoEncoderProperties.hpp"
+    #include "depthai/properties/WarpProperties.hpp"
+    #include "depthai/properties/internal/XLinkInProperties.hpp"
+    #include "depthai/properties/internal/XLinkOutProperties.hpp"
+
+    #ifdef DEPTHAI_HAVE_DYNAMIC_CALIBRATION_SUPPORT
+        #include "depthai/properties/DynamicCalibrationProperties.hpp"
+    #endif
+#endif
+
+namespace dai {
+
+#if defined(__clang__)
+Properties::~Properties() = default;
+
+namespace internal {
+XLinkInProperties::~XLinkInProperties() = default;
+XLinkOutProperties::~XLinkOutProperties() = default;
+}  // namespace internal
+
+AprilTagProperties::~AprilTagProperties() = default;
+BenchmarkInProperties::~BenchmarkInProperties() = default;
+BenchmarkOutProperties::~BenchmarkOutProperties() = default;
+CameraProperties::~CameraProperties() = default;
+ColorCameraProperties::~ColorCameraProperties() = default;
+DetectionParserProperties::~DetectionParserProperties() = default;
+EdgeDetectorProperties::~EdgeDetectorProperties() = default;
+FeatureTrackerProperties::~FeatureTrackerProperties() = default;
+IMUProperties::~IMUProperties() = default;
+ImageAlignProperties::~ImageAlignProperties() = default;
+ImageManipProperties::~ImageManipProperties() = default;
+ImageFiltersProperties::~ImageFiltersProperties() = default;
+ToFDepthConfidenceFilterProperties::~ToFDepthConfidenceFilterProperties() = default;
+DeviceNodeGroupProperties::~DeviceNodeGroupProperties() = default;
+MessageDemuxProperties::~MessageDemuxProperties() = default;
+MonoCameraProperties::~MonoCameraProperties() = default;
+NeuralNetworkProperties::~NeuralNetworkProperties() = default;
+ObjectTrackerProperties::~ObjectTrackerProperties() = default;
+PointCloudProperties::~PointCloudProperties() = default;
+SPIInProperties::~SPIInProperties() = default;
+SPIOutProperties::~SPIOutProperties() = default;
+ScriptProperties::~ScriptProperties() = default;
+SpatialDetectionNetworkProperties::~SpatialDetectionNetworkProperties() = default;
+SpatialLocationCalculatorProperties::~SpatialLocationCalculatorProperties() = default;
+StereoDepthProperties::~StereoDepthProperties() = default;
+SyncProperties::~SyncProperties() = default;
+SystemLoggerProperties::~SystemLoggerProperties() = default;
+ThermalProperties::~ThermalProperties() = default;
+ToFProperties::~ToFProperties() = default;
+UVCProperties::~UVCProperties() = default;
+VideoEncoderProperties::~VideoEncoderProperties() = default;
+WarpProperties::~WarpProperties() = default;
+GlobalProperties::~GlobalProperties() = default;
+CastProperties::~CastProperties() = default;
+    #ifdef DEPTHAI_HAVE_DYNAMIC_CALIBRATION_SUPPORT
+DynamicCalibrationProperties::~DynamicCalibrationProperties() = default;
+    #endif
+#endif
+
+}  // namespace dai

--- a/src/utility/Memory.cpp
+++ b/src/utility/Memory.cpp
@@ -1,0 +1,7 @@
+#include "depthai/utility/Memory.hpp"
+
+namespace dai {
+
+Memory::~Memory() = default;
+
+}  // namespace dai

--- a/src/utility/ObjectTrackerImpl.cpp
+++ b/src/utility/ObjectTrackerImpl.cpp
@@ -54,6 +54,10 @@ Eigen::VectorXf speed_direction(Eigen::VectorXf bbox1, Eigen::VectorXf bbox2);
 Eigen::VectorXf convert_x_to_bbox(Eigen::VectorXf x);
 Eigen::VectorXf k_previous_obs(const std::map<int, Eigen::VectorXf>& observations, int cur_age, int k);
 
+#if defined(__clang__)
+Tracker::~Tracker() = default;
+#endif
+
 class TrackletExt : public Tracklet {
    public:
     uint32_t ageSinceStatusUpdate = 1;

--- a/src/utility/ObjectTrackerImpl.hpp
+++ b/src/utility/ObjectTrackerImpl.hpp
@@ -10,7 +10,11 @@ namespace impl {
 
 class Tracker {
    public:
+#if defined(__clang__)
+    virtual ~Tracker();
+#else
     virtual ~Tracker() = default;
+#endif
 
     /**
      * Initialize the tracker with the first frame and detections.

--- a/src/utility/Platform.cpp
+++ b/src/utility/Platform.cpp
@@ -68,6 +68,9 @@ void setThreadName(JoiningThread& thread, const std::string& name) {
 #ifdef __linux__
     auto handle = thread.native_handle();
     pthread_setname_np(handle, name.c_str());
+#else
+    (void)thread;  // unused
+    (void)name;    // unused
 #endif
     return;
 }

--- a/src/utility/ProtoSerializable.cpp
+++ b/src/utility/ProtoSerializable.cpp
@@ -1,0 +1,9 @@
+#include "depthai/utility/ProtoSerializable.hpp"
+
+namespace dai {
+
+#if defined(__clang__)
+ProtoSerializable::~ProtoSerializable() = default;
+#endif
+
+}  // namespace dai

--- a/src/utility/SharedMemory.cpp
+++ b/src/utility/SharedMemory.cpp
@@ -1,0 +1,13 @@
+#include "depthai/utility/SharedMemory.hpp"
+
+namespace dai {
+
+SharedMemory::~SharedMemory() {
+    unmapFd();
+#if defined(__unix__) && !defined(__APPLE__)
+    if(fd > 0) {
+        close(fd);
+    }
+#endif
+}
+}  // namespace dai

--- a/src/utility/VectorMemory.cpp
+++ b/src/utility/VectorMemory.cpp
@@ -1,0 +1,9 @@
+#include "depthai/utility/VectorMemory.hpp"
+
+namespace dai {
+
+#if defined(__clang__)
+VectorMemory::~VectorMemory() = default;
+#endif
+
+}  // namespace dai

--- a/src/xlink/XLinkStream.cpp
+++ b/src/xlink/XLinkStream.cpp
@@ -10,6 +10,10 @@
 
 namespace dai {
 
+#if defined(__clang__)
+StreamPacketMemory::~StreamPacketMemory() = default;
+#endif
+
 // static
 constexpr std::chrono::milliseconds XLinkStream::WAIT_FOR_STREAM_RETRY;
 constexpr int XLinkStream::STREAM_OPEN_RETRIES;


### PR DESCRIPTION
Due to the fact that python wheels are linking against a single shared library depthai-core and we're making extensive use of dynamic casting in our code base, it was necessary to remove all weak vtables from our codebase (some were ignored) to ensure proper casting. Specifically, on MacOS, dynamic_casts would rather confusingly return nullptr on objects with their parent class being that class being cast to.

> This is a clang issue only and happens exclusively on MacOS.
