### PR TITLE
Updated github worklows, triggered with a new label

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - develop
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
 

--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -14,6 +14,7 @@ on:
     branches:
       - main
       - develop
+    types: [opened, synchronize, reopened, labeled]
 
 ###################################
 ###################################

--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - develop
+    types: [opened, synchronize, reopened, labeled]
 
 # Only allow latest run on same branch to be tested
 concurrency:


### PR DESCRIPTION
## Purpose
Updated github worklows, so the workflows are triggered when a new label is added to a PR

## Specification
Relevant github workflows will now be triggered when a new label is added to a PR

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable