### PR TITLE
V3 dcl adding factories; Change in API

### DIFF
--- a/bindings/python/src/pipeline/datatype/DynamicCalibrationControlBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/DynamicCalibrationControlBindings.cpp
@@ -74,6 +74,47 @@ void bind_dynamic_calibration_control(py::module& m, void* pCallstack) {
         .def(py::init<const ApplyCalibration&>())
         .def(py::init<const ResetData&>())
         .def(py::init<const SetPerformanceMode&>());
+    // Pythonic names + docstrings; defaults match C++.
+    // clang-format off
+    cls.def_static(
+           "calibrate",
+           &DCC::calibrate,
+           py::arg("force") = false,
+           "Create a DynamicCalibrationControl with a Calibrate command.");
+    cls.def_static(
+           "calibrationQuality",
+           &DCC::calibrationQuality,
+           py::arg("force") = false,
+           "Create a DynamicCalibrationControl with a CalibrationQuality command.");
+    cls.def_static(
+           "startCalibration",
+           &DCC::startCalibration,
+           py::arg("loadImagePeriod") = 0.5f,
+           py::arg("calibrationPeriod") = 5.0f,
+           "Create a DynamicCalibrationControl with a StartCalibration command.");
+    cls.def_static(
+           "stopCalibration",
+           &DCC::stopCalibration,
+           "Create a DynamicCalibrationControl with a StopCalibration command.");
+    cls.def_static(
+           "loadImage",
+           &DCC::loadImage,
+           "Create a DynamicCalibrationControl with a LoadImage command.");
+    cls.def_static(
+           "applyCalibration",
+           &DCC::applyCalibration,
+           py::arg("calibration"),
+           "Create a DynamicCalibrationControl with an ApplyCalibration command.");
+    cls.def_static(
+           "resetData",
+           &DCC::resetData,
+           "Create a DynamicCalibrationControl with a ResetData command.");
+    cls.def_static(
+           "setPerformanceMode",
+           &DCC::setPerformanceMode,
+           py::arg("mode") = dai::DynamicCalibrationControl::PerformanceMode::DEFAULT,
+           "Create a DynamicCalibrationControl with a SetPerformanceMode command.");
+    // clang-format on
     // Call remaining stack
     auto* callstack = static_cast<Callstack*>(pCallstack);
     auto cb = callstack->top();

--- a/examples/cpp/DynamicCalibration/calibration_dynamic.cpp
+++ b/examples/cpp/DynamicCalibration/calibration_dynamic.cpp
@@ -47,10 +47,10 @@ int main() {
 
     using DCC = dai::DynamicCalibrationControl;
     // Optionally set performance mode:
-    dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::SetPerformanceMode{DCC::PerformanceMode::OPTIMIZE_PERFORMANCE}));
+    dynCalibInputControl->send(DCC::setPerformanceMode(DCC::PerformanceMode::OPTIMIZE_PERFORMANCE));
 
     // Start calibration (optimize performance)
-    dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::StartCalibration{}));
+    dynCalibInputControl->send(DCC::startCalibration());
 
     double maxDisparity = 1.0;
     while(pipeline.isRunning()) {
@@ -94,7 +94,7 @@ int main() {
 
                 // Apply the produced calibration
                 const auto& newCalib = dynCalibrationResult->calibrationData->newCalibration;
-                dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::ApplyCalibration{newCalib}));
+                dynCalibInputControl->send(DCC::applyCalibration(newCalib));
 
                 // Print quality deltas
                 const auto& q = dynCalibrationResult->calibrationData->calibrationDifference;
@@ -111,8 +111,7 @@ int main() {
                           << "10m:" << q.depthErrorDifference[3] << "%\n";
 
                 // Reset and start a new round if desired
-                dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::ResetData{}));
-                dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::StartCalibration{}));
+                dynCalibInputControl->send(DCC::startCalibration());
             }
         }
 

--- a/examples/cpp/DynamicCalibration/calibration_dynamic.cpp
+++ b/examples/cpp/DynamicCalibration/calibration_dynamic.cpp
@@ -104,9 +104,11 @@ int main() {
                 std::cout << "Rotation difference: " << rotDiff << " deg\n";
                 std::cout << "Mean Sampson error achievable = " << q.sampsonErrorNew << " px\n";
                 std::cout << "Mean Sampson error current    = " << q.sampsonErrorCurrent << " px\n";
-                std::cout << "Theoretical Depth Error Difference " << "@1m:" << std::fixed << std::setprecision(2) << q.depthErrorDifference[0] << "%, "
-                          << "2m:" << q.depthErrorDifference[1] << "%, " << "5m:" << q.depthErrorDifference[2] << "%, " << "10m:" << q.depthErrorDifference[3]
-                          << "%\n";
+                std::cout << "Theoretical Depth Error Difference "
+                          << "@1m:" << std::fixed << std::setprecision(2) << q.depthErrorDifference[0] << "%, "
+                          << "2m:" << q.depthErrorDifference[1] << "%, "
+                          << "5m:" << q.depthErrorDifference[2] << "%, "
+                          << "10m:" << q.depthErrorDifference[3] << "%\n";
 
                 // Reset and start a new round if desired
                 dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::ResetData{}));

--- a/examples/cpp/DynamicCalibration/calibration_integration.cpp
+++ b/examples/cpp/DynamicCalibration/calibration_integration.cpp
@@ -114,10 +114,12 @@ int main() {
 
             // --- Depth error difference ---
             // Theoretical improvement in depth accuracy at various ranges
-            std::cout << "Theoretical Depth Error Difference " << "@1m:" << std::fixed << std::setprecision(2) << q.depthErrorDifference[0] << "%, "
-                      << "2m:" << q.depthErrorDifference[1] << "%, " << "5m:" << q.depthErrorDifference[2] << "%, " << "10m:" << q.depthErrorDifference[3]
-                      << "%" << std::endl;
-            dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::ResetData{}));
+            std::cout << "Theoretical Depth Error Difference "
+                      << "@1m:" << std::fixed << std::setprecision(2) << q.depthErrorDifference[0] << "%, "
+                      << "2m:" << q.depthErrorDifference[1] << "%, "
+                      << "5m:" << q.depthErrorDifference[2] << "%, "
+                      << "10m:" << q.depthErrorDifference[3] << "%" << std::endl;
+            dynCalibInputControl->send(DCC::resetData());
             if(std::abs(q.sampsonErrorNew - q.sampsonErrorCurrent) > 0.05f) {
                 std::cout << "Start recalibration process" << std::endl;
                 dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::StartCalibration{}));
@@ -142,10 +144,12 @@ int main() {
                 std::cout << "Mean Sampson error achievable = " << q.sampsonErrorNew << " px\n";
                 std::cout << "Mean Sampson error current    = " << q.sampsonErrorCurrent << " px\n";
 
-                std::cout << "Theoretical Depth Error Difference " << "@1m:" << std::fixed << std::setprecision(2) << q.depthErrorDifference[0] << "%, "
-                          << "2m:" << q.depthErrorDifference[1] << "%, " << "5m:" << q.depthErrorDifference[2] << "%, " << "10m:" << q.depthErrorDifference[3]
-                          << "%\n";
-                dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::ResetData{}));
+                std::cout << "Theoretical Depth Error Difference "
+                          << "@1m:" << std::fixed << std::setprecision(2) << q.depthErrorDifference[0] << "%, "
+                          << "2m:" << q.depthErrorDifference[1] << "%, "
+                          << "5m:" << q.depthErrorDifference[2] << "%, "
+                          << "10m:" << q.depthErrorDifference[3] << "%\n";
+                dynCalibInputControl->send(DCC::resetData());
             }
         }
         int key = cv::waitKey(1);

--- a/examples/cpp/DynamicCalibration/calibration_integration.cpp
+++ b/examples/cpp/DynamicCalibration/calibration_integration.cpp
@@ -83,8 +83,8 @@ int main() {
         auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - lastSent);
         if(elapsed.count() >= 3) {
-            dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::LoadImage{}));
-            dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::CalibrationQuality{}));
+            dynCalibInputControl->send(DCC::loadImage());
+            dynCalibInputControl->send(DCC::calibrationQuality());
             lastSent = now;
         }
 
@@ -122,7 +122,7 @@ int main() {
             dynCalibInputControl->send(DCC::resetData());
             if(std::abs(q.sampsonErrorNew - q.sampsonErrorCurrent) > 0.05f) {
                 std::cout << "Start recalibration process" << std::endl;
-                dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::StartCalibration{}));
+                dynCalibInputControl->send(DCC::startCalibration());
             }
         }
 
@@ -133,7 +133,7 @@ int main() {
 
             if(dynCalibrationResult->calibrationData) {
                 std::cout << "Successfully calibrated." << std::endl;
-                dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::ApplyCalibration{dynCalibrationResult->calibrationData->newCalibration}));
+                dynCalibInputControl->send(DCC::applyCalibration(dynCalibrationResult->calibrationData->newCalibration));
 
                 const auto& q = dynCalibrationResult->calibrationData->calibrationDifference;
 

--- a/examples/cpp/DynamicCalibration/calibration_quality_dynamic.cpp
+++ b/examples/cpp/DynamicCalibration/calibration_quality_dynamic.cpp
@@ -85,9 +85,11 @@ int main() {
                 std::cout << "Mean Sampson error current    = " << q.sampsonErrorCurrent << " px" << std::endl;
 
                 // --- Depth error difference (%) at 1/2/5/10 m ---
-                std::cout << "Theoretical Depth Error Difference " << "@1m:" << std::fixed << std::setprecision(2) << q.depthErrorDifference[0] << "%, "
-                          << "2m:" << q.depthErrorDifference[1] << "%, " << "5m:" << q.depthErrorDifference[2] << "%, " << "10m:" << q.depthErrorDifference[3]
-                          << "%" << std::endl;
+                std::cout << "Theoretical Depth Error Difference "
+                          << "@1m:" << std::fixed << std::setprecision(2) << q.depthErrorDifference[0] << "%, "
+                          << "2m:" << q.depthErrorDifference[1] << "%, "
+                          << "5m:" << q.depthErrorDifference[2] << "%, "
+                          << "10m:" << q.depthErrorDifference[3] << "%" << std::endl;
 
                 // (Optional) Trigger a calibration step if desired:
                 // dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::Calibrate{/*force=*/true}));

--- a/examples/cpp/DynamicCalibration/calibration_quality_dynamic.cpp
+++ b/examples/cpp/DynamicCalibration/calibration_quality_dynamic.cpp
@@ -53,7 +53,7 @@ int main() {
         cv::imshow("right", rightSynced->getCvFrame());
 
         // --- Load one frame pair into the calibration pipeline
-        dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::LoadImage{}));
+        dynCalibInputControl->send(DCC::loadImage());
 
         // Wait for coverage info
         auto coverageMsg = dynCoverageOutQ->get<dai::CoverageData>();
@@ -63,7 +63,7 @@ int main() {
         }
 
         // Request a calibration quality evaluation (non-forced)
-        dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::CalibrationQuality{false}));
+        dynCalibInputControl->send(DCC::calibrationQuality(false));
 
         // Wait for calibration result
         auto dynCalibrationResult = dynQualityOutQ->get<dai::CalibrationQuality>();
@@ -92,10 +92,10 @@ int main() {
                           << "10m:" << q.depthErrorDifference[3] << "%" << std::endl;
 
                 // (Optional) Trigger a calibration step if desired:
-                // dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::Calibrate{/*force=*/true}));
+                // dynCalibInputControl->send(DCC::calibrate(true));
 
                 // Reset temporary data after reading metrics
-                dynCalibInputControl->send(std::make_shared<DCC>(DCC::Commands::ResetData{}));
+                dynCalibInputControl->send(DCC::resetData());
             }
         } else {
             std::cout << "Dynamic calibration: no result received." << std::endl;

--- a/examples/python/DynamicCalibration/calibration_dynamic.py
+++ b/examples/python/DynamicCalibration/calibration_dynamic.py
@@ -50,14 +50,14 @@ with dai.Pipeline() as pipeline:
 
     # Set performance mode
     dynCalibInputControl.send(
-        dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.SetPerformanceMode(
-            dai.DynamicCalibrationControl.OPTIMIZE_PERFORMANCE)
+        dai.DynamicCalibrationControl.setPerformanceMode(
+            dai.DynamicCalibrationControl.OPTIMIZE_PERFORMANCE
         )
     )
 
     # Start periodic calibration
     dynCalibInputControl.send(
-        dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.StartCalibration())
+        dai.DynamicCalibrationControl.startCalibration()
     )
 
     while pipeline.isRunning():
@@ -99,9 +99,7 @@ with dai.Pipeline() as pipeline:
             print("Successfully calibrated")
             # Apply to device
             dynCalibInputControl.send(
-                dai.DynamicCalibrationControl(
-                    dai.DynamicCalibrationControl.Commands.ApplyCalibration(calibrationData.newCalibration)
-                )
+                dai.DynamicCalibrationControl.applyCalibration(calibrationData.newCalibration)
             )
 
             q = calibrationData.calibrationDifference
@@ -119,10 +117,10 @@ with dai.Pipeline() as pipeline:
 
             # Reset accumulators and continue periodic calibration
             dynCalibInputControl.send(
-                dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.ResetData())
+                dai.DynamicCalibrationControl.resetData()
             )
             dynCalibInputControl.send(
-                dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.StartCalibration())
+                dai.DynamicCalibrationControl.startCalibration()
             )
 
         key = cv2.waitKey(1)

--- a/examples/python/DynamicCalibration/calibration_integration.py
+++ b/examples/python/DynamicCalibration/calibration_integration.py
@@ -74,8 +74,8 @@ with dai.Pipeline() as pipeline:
 
         # Run quality check command every 3 seconds
         if np.abs(time.time() - start) > 3:
-            dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.LoadImage()))
-            dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.CalibrationQuality(True)))
+            dynCalibInputControl.send(dai.DynamicCalibrationControl.loadImage())
+            dynCalibInputControl.send(dai.DynamicCalibrationControl.calibrationQuality(True))
             start = time.time()
 
         # Wait for the calibration result
@@ -99,12 +99,12 @@ with dai.Pipeline() as pipeline:
             )
             print(f"Theoretical Depth Error Difference @1m:{quality.depthErrorDifference[0]:.2f}%, 2m:{quality.depthErrorDifference[1]:.2f}%, 5m:{quality.depthErrorDifference[2]:.2f}%, 10m:{quality.depthErrorDifference[3]:.2f}%")
             """
-            dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.ResetData()))
+            dynCalibInputControl.send(dai.DynamicCalibrationControl.resetData())
 
             # example of usage of sampson error as main information for when calibration is needed (higher than 0.05px difference)
             if np.abs(quality.sampsonErrorNew - quality.sampsonErrorCurrent) > 0.05:
                 print("Start recalibration process")
-                dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.StartCalibration()))
+                dynCalibInputControl.send(dai.DynamicCalibrationControl.startCalibration())
 
 
         # Wait for the calibration result
@@ -120,7 +120,7 @@ with dai.Pipeline() as pipeline:
             print("Successfully calibrated")
             print(f"New calibration: {calibrationData.newCalibration}")
 
-            dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.ApplyCalibration(calibrationData.newCalibration)))
+            dynCalibInputControl.send(dai.DynamicCalibrationControl.applyCalibration(calibrationData.newCalibration))
             quality = calibrationData.calibrationDifference
             """print(
                 "Rotation difference: || r_current - r_new || = "
@@ -133,7 +133,7 @@ with dai.Pipeline() as pipeline:
             print(f"Theoretical Depth Error Difference @1m:{quality.depthErrorDifference[0]:.2f}%, 2m:{quality.depthErrorDifference[1]:.2f}%, 5m:{quality.depthErrorDifference[2]:.2f}%, 10m:{quality.depthErrorDifference[3]:.2f}%")
             """
 
-            dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.ResetData()))
+            dynCalibInputControl.send(dai.DynamicCalibrationControl.resetData())
 
         cv2.imshow("disparity", colorizedDisparity)
         key = cv2.waitKey(1)

--- a/examples/python/DynamicCalibration/calibration_quality_dynamic.py
+++ b/examples/python/DynamicCalibration/calibration_quality_dynamic.py
@@ -66,14 +66,14 @@ with dai.Pipeline() as pipeline:
         cv2.imshow("disparity", colorizedDisparity)
 
         # --- Load one frame into calibration & read coverage
-        dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.LoadImage()))
+        dynCalibInputControl.send(dai.DynamicCalibrationControl.loadImage())
         coverage = dynCalibCoverageQueue.get()
         if coverage is not None:
             print(f"2D Spatial Coverage = {coverage.meanCoverage} / 100 [%]")
             print(f"Data Acquired       = {coverage.dataAcquired} / 100 [%]")
 
         # --- Request a quality evaluation & read result
-        dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.CalibrationQuality(False)))
+        dynCalibInputControl.send(dai.DynamicCalibrationControl.calibrationQuality(False))
         dynQualityResult = dynCalibQualityQueue.get()
         if dynQualityResult is not None:
             print(f"Dynamic calibration status: {dynQualityResult.info}")
@@ -96,7 +96,7 @@ with dai.Pipeline() as pipeline:
                     f"10m:{q.depthErrorDifference[3]:.2f}%"
                 )
                 # Reset temporary accumulators before the next cycle
-                dynCalibInputControl.send(dai.DynamicCalibrationControl(dai.DynamicCalibrationControl.Commands.ResetData()))
+                dynCalibInputControl.send(dai.DynamicCalibrationControl.resetData())
 
         key = cv2.waitKey(1)
         if key == ord('q'):

--- a/include/depthai/pipeline/datatype/DynamicCalibrationControl.hpp
+++ b/include/depthai/pipeline/datatype/DynamicCalibrationControl.hpp
@@ -74,7 +74,42 @@ class DynamicCalibrationControl : public Buffer {
     DynamicCalibrationControl() {}
 
     explicit DynamicCalibrationControl(Command cmd) : command(std::move(cmd)) {}
+
     ~DynamicCalibrationControl() override;
+
+    // ---------- Named constructors that return shared_ptr ----------
+    [[nodiscard]] static std::shared_ptr<DynamicCalibrationControl> calibrate(bool force = false) {
+        return std::make_shared<DynamicCalibrationControl>(Commands::Calibrate{force});
+    }
+
+    [[nodiscard]] static std::shared_ptr<DynamicCalibrationControl> calibrationQuality(bool force = false) {
+        return std::make_shared<DynamicCalibrationControl>(Commands::CalibrationQuality{force});
+    }
+
+    [[nodiscard]] static std::shared_ptr<DynamicCalibrationControl> startCalibration(float loadImagePeriod = 0.5f, float calibrationPeriod = 5.0f) {
+        return std::make_shared<DynamicCalibrationControl>(Commands::StartCalibration{loadImagePeriod, calibrationPeriod});
+    }
+
+    [[nodiscard]] static std::shared_ptr<DynamicCalibrationControl> stopCalibration() {
+        return std::make_shared<DynamicCalibrationControl>(Commands::StopCalibration{});
+    }
+
+    [[nodiscard]] static std::shared_ptr<DynamicCalibrationControl> loadImage() {
+        return std::make_shared<DynamicCalibrationControl>(Commands::LoadImage{});
+    }
+
+    [[nodiscard]] static std::shared_ptr<DynamicCalibrationControl> applyCalibration(const CalibrationHandler& calibration) {
+        return std::make_shared<DynamicCalibrationControl>(Commands::ApplyCalibration{calibration});
+    }
+
+    [[nodiscard]] static std::shared_ptr<DynamicCalibrationControl> resetData() {
+        return std::make_shared<DynamicCalibrationControl>(Commands::ResetData{});
+    }
+
+    [[nodiscard]] static std::shared_ptr<DynamicCalibrationControl> setPerformanceMode(PerformanceMode mode = PerformanceMode::DEFAULT) {
+        return std::make_shared<DynamicCalibrationControl>(Commands::SetPerformanceMode{mode});
+    }
+
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         metadata = utility::serialize(*this);
         datatype = DatatypeEnum::DynamicCalibrationControl;


### PR DESCRIPTION
Reason for adding factories is to clear API with hard to remember Commands.
Commands can still be used the same way as previously this is just a simplification function.