### PR TITLE
Pointcloud example failing Windows Build

### DIFF
--- a/examples/cpp/RGBD/rgbd_pcl_processing.cpp
+++ b/examples/cpp/RGBD/rgbd_pcl_processing.cpp
@@ -12,8 +12,8 @@ class CustomPCLProcessingNode : public dai::NodeCRTP<dai::node::ThreadedHostNode
     constexpr static const float thresholdDistance = 3000.0f;
 
    public:
-    Input  inputPCL{*this, {"inPCL",  {{dai::DatatypeEnum::PointCloudData, true}}}};
-    Output outputPCL{*this, {"outPCL", {{dai::DatatypeEnum::PointCloudData, true}}}};
+    Input  inputPCL{*this, {"inPCL", DEFAULT_GROUP, DEFAULT_BLOCKING, DEFAULT_QUEUE_SIZE, {{{dai::DatatypeEnum::PointCloudData, true}}}}};
+    Output outputPCL{*this, {"outPCL", DEFAULT_GROUP, {{{dai::DatatypeEnum::PointCloudData, true}}}}};
 
     void run() override {
         while(isRunning()) {


### PR DESCRIPTION
One of the RGBD examples was failing Windows build, due to designated initializers being added (notation for Cmake 20). 

See error here:
https://github.com/luxonis/depthai-core/pull/1461/checks

This was solved in this PR as seen here:
https://github.com/luxonis/depthai-core/actions/runs/18210124854