### PR TITLE
Completely disable crashdumps with DEPTHAI_CRASHDUMP_TIMEOUT=0

### DIFF
--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -536,8 +536,9 @@ unsigned int getCrashdumpTimeout(XLinkProtocol_t protocol) {
 void DeviceBase::closeImpl() {
     using namespace std::chrono;
     auto t1 = steady_clock::now();
+    auto timeout = getCrashdumpTimeout(deviceInfo.protocol);
     bool shouldGetCrashDump = false;
-    if(!dumpOnly) {
+    if(!dumpOnly && timeout > 0) {
         pimpl->logger.debug("Device about to be closed...");
         try {
             if(hasCrashDump()) {
@@ -586,7 +587,6 @@ void DeviceBase::closeImpl() {
     pimpl->rpcClient = nullptr;
 
     if(!dumpOnly) {
-        auto timeout = getCrashdumpTimeout(deviceInfo.protocol);
         // Get crash dump if needed
         if(shouldGetCrashDump && timeout > 0) {
             pimpl->logger.debug("Getting crash dump...");


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable