### PR TITLE
Fix: Add configurable rpc timeouts

### DIFF
--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -52,9 +52,11 @@
 #include "utility/spdlog-fmt.hpp"
 
 namespace {
-thread_local std::optional<std::chrono::milliseconds> tlRpcTimeout;
 
 struct ScopedRpcTimeout {
+   public:
+    static thread_local std::optional<std::chrono::milliseconds> tlRpcTimeout;
+
     explicit ScopedRpcTimeout(std::optional<std::chrono::milliseconds> timeout) : prev(tlRpcTimeout) {
         tlRpcTimeout = timeout;
     }
@@ -68,8 +70,10 @@ struct ScopedRpcTimeout {
     std::optional<std::chrono::milliseconds> prev;
 };
 
+thread_local std::optional<std::chrono::milliseconds> ScopedRpcTimeout::tlRpcTimeout;
+
 std::optional<std::chrono::milliseconds> currentRpcTimeout() {
-    return tlRpcTimeout;
+    return ScopedRpcTimeout::tlRpcTimeout;
 }
 }  // namespace
 namespace dai {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
This PR adds two overload functions that allow the configuration of RPC timeouts with the use of a scoped timeout guard. If no timeout is specified the previous default `RPC_READ_TIMEOUT` is used. Set timeout to 0 to allow infinate wait per RPC call.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable