### PR TITLE
fix reading calibration in raw form

### DIFF
--- a/bindings/python/src/DeviceBindings.cpp
+++ b/bindings/python/src/DeviceBindings.cpp
@@ -797,15 +797,23 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
         .def(
             "readCalibrationRaw",
             [](DeviceBase& d) {
-                py::gil_scoped_release release;
-                return d.readCalibrationRaw();
+                std::vector<uint8_t> data;
+                {
+                    py::gil_scoped_release release;
+                    data = d.readCalibrationRaw();
+                }
+                return py::bytes(reinterpret_cast<const char*>(data.data()), data.size());
             },
             DOC(dai, DeviceBase, readCalibrationRaw))
         .def(
             "readFactoryCalibrationRaw",
             [](DeviceBase& d) {
-                py::gil_scoped_release release;
-                return d.readFactoryCalibrationRaw();
+                std::vector<uint8_t> data;
+                {
+                    py::gil_scoped_release release;
+                    data = d.readFactoryCalibrationRaw();
+                }
+                return py::bytes(reinterpret_cast<const char*>(data.data()), data.size());
             },
             DOC(dai, DeviceBase, readFactoryCalibrationRaw))
         .def(


### PR DESCRIPTION
## Purpose
Fix the following errors:

```
>>> device.readCalibrationRaw()
TypeError: Unregistered type : std::vector<unsigned char, std::allocator<unsigned char> >

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Unable to convert function return value to a Python type! The signature was
        (self: depthai.DeviceBase) -> std::vector<unsigned char, std::allocator<unsigned char> >

Did you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,
<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic
conversions are optional and require extra headers to be included
when compiling your pybind11 module.
```

```
>>> device.readFactoryCalibrationRaw()
TypeError: Unregistered type : std::vector<unsigned char, std::allocator<unsigned char> >

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Unable to convert function return value to a Python type! The signature was
        (self: depthai.DeviceBase) -> std::vector<unsigned char, std::allocator<unsigned char> >

Did you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,
<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic
conversions are optional and require extra headers to be included
when compiling your pybind11 module.
```