### PR TITLE
Exposed library version service in RemoteConnection, added testing of remote services in custom_services.py

### DIFF
--- a/examples/python/Visualizer/custom_services.py
+++ b/examples/python/Visualizer/custom_services.py
@@ -3,6 +3,46 @@ import depthai as dai
 import signal
 import sys
 import time
+import asyncio
+import json
+import websockets
+import struct
+
+uri = "ws://localhost:8765"
+async def call_service(ws, service_name, service_id):
+    # Call a service and return the response payload
+    msg = bytearray([0x02])  # opcode
+    msg.extend(struct.pack('<I', service_id))
+    msg.extend(struct.pack('<I', 1))  # call_id
+    msg.extend(struct.pack('<I', 4))  # encoding length
+    msg.extend(b"json")
+    msg.extend(b"{}")
+    await ws.send(bytes(msg))
+    
+    response = await asyncio.wait_for(ws.recv(), timeout=5.0)
+    if isinstance(response, bytes) and response[0] == 0x03:
+        encoding_len = struct.unpack('<I', response[9:13])[0]
+        payload = response[13 + encoding_len:]
+        return payload.decode('utf-8')
+    return None
+
+async def test_available_services():
+    async with websockets.connect(uri, subprotocols=["foxglove.websocket.v1"]) as ws:
+        while True:
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=5.0))
+            if msg.get("op") == "advertiseServices":
+                services = {s['name']: s['id'] for s in msg.get("services", [])}
+                print(f"Available services: {list(services.keys())}")
+                break
+        
+        # Test each service
+        for service_name in services:
+            try:
+                result = await call_service(ws, service_name, services[service_name])
+                print(f"{service_name}: {result}")
+            except Exception as e:
+                print(f"{service_name}: ERROR - {e}")
+
 
 isRunning = True
 def stop():
@@ -25,3 +65,4 @@ def testService(input):
 remoteConnection.registerService("myService", testService)
 while isRunning:
     time.sleep(1)
+    asyncio.run(test_available_services())

--- a/src/remote_connection/RemoteConnectionImpl.cpp
+++ b/src/remote_connection/RemoteConnectionImpl.cpp
@@ -50,6 +50,7 @@ RemoteConnectionImpl::RemoteConnectionImpl(const std::string& address, uint16_t 
     // Expose services
     exposeKeyPressedService();
     exposeTopicGroupsService();
+    exposeLibraryVersionService();
 }
 
 RemoteConnectionImpl::~RemoteConnectionImpl() {
@@ -430,6 +431,35 @@ void RemoteConnectionImpl::exposePipelineService(const Pipeline& pipeline) {
         auto response = foxglove::ServiceResponse();
         response.data = std::vector<uint8_t>(serializedPipelineStr.begin(), serializedPipelineStr.end());
         return response;
+    };
+}
+
+void RemoteConnectionImpl::exposeLibraryVersionService() {
+    std::string serviceName = "libraryVersion";
+    foxglove::ServiceWithoutId service;
+    service.name = serviceName;
+    service.type = "json";
+
+    foxglove::ServiceRequestDefinition requestDef;
+    requestDef.schemaName = serviceName + "Request";
+    requestDef.encoding = "json";
+    service.request = requestDef;
+
+    foxglove::ServiceRequestDefinition responseDef;
+    responseDef.schemaName = serviceName + "Response";
+    responseDef.encoding = "json";
+    service.response = responseDef;
+
+    auto ids = server->addServices({service});
+    assert(ids.size() == 1);
+    auto id = ids[0];
+
+    serviceMap[id] = [this](foxglove::ServiceResponse request) {
+        nlohmann::json jsonRequest = nlohmann::json::parse(request.data);
+        std::string responseMsg = std::string(build::VERSION);
+        foxglove::ServiceResponse ret;
+        ret.data = std::vector<uint8_t>(responseMsg.begin(), responseMsg.end());
+        return ret;
     };
 }
 

--- a/src/remote_connection/RemoteConnectionImpl.hpp
+++ b/src/remote_connection/RemoteConnectionImpl.hpp
@@ -57,6 +57,7 @@ class RemoteConnectionImpl {
     void exposeTopicGroupsService();
     void exposeKeyPressedService();
     void exposePipelineService(const Pipeline& pipeline);
+    void exposeLibraryVersionService();
     void keyPressedCallback(int key);
 
     std::mutex keyMutex;


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Library version service is now exposed in remote connection. custom_services.py now tests available services by calling them and printing the returned response

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
RemoteConnectionImpl now has exposed library version. custom_services.py is updated.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
This was tested with the updated custom_services.py. This first checks if the newly added libraryVersion service is successfully added in available services. It also tests it by calling it and printing the results.