### PR TITLE
Update wheel symbol stripping

### DIFF
--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -386,7 +386,7 @@ jobs:
         run: |
           cd bindings/python && mv wheelhouse/audited wheelhouse/audited_pre && mkdir -p wheelhouse/audited
           echo "Combining repaired wheels into one master wheel"
-          python3 ci/combine_wheels.py --input_folder=wheelhouse/audited_pre --output_folder=wheelhouse/audited
+          python3 ci/combine_wheels.py --input_folder=wheelhouse/audited_pre --output_folder=wheelhouse/audited --strip-unneeded
       - name: Upload combined wheels as an artifact
         uses: actions/upload-artifact@v4
         with:
@@ -484,7 +484,7 @@ jobs:
         run: cd bindings/python && bash ./ci/show_vcpkg_logs.sh
 
       - name: Audit wheels
-        run: cd bindings/python && for whl in wheelhouse/*.whl; do auditwheel repair "$whl" --plat $PLAT -w wheelhouse/audited/; done
+        run: cd bindings/python && for whl in wheelhouse/*.whl; do auditwheel repair "$whl" --plat $PLAT --strip -w wheelhouse/audited/; done
       - name: Archive wheel artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -506,11 +506,14 @@ jobs:
           pattern: audited-wheels-linux-x86_64-*
           path: bindings/python/wheelhouse/audited/
           merge-multiple: true
+      - name: Install llvm-strip
+        run: |
+          yum install -y llvm # for llvm-strip, strip leads to "ELF load command address/offset not page-aligned" errors 
       - name: Combine wheels
         run: |
           cd bindings/python && mv wheelhouse/audited wheelhouse/audited_pre && mkdir -p wheelhouse/audited
           echo "Combining repaired wheels into one master wheel"
-          python3 ci/combine_wheels.py --input_folder=wheelhouse/audited_pre --output_folder=wheelhouse/audited
+          python3 ci/combine_wheels.py --input_folder=wheelhouse/audited_pre --output_folder=wheelhouse/audited --strip-unneeded
       - name: Upload combined wheels as an artifact
         uses: actions/upload-artifact@v4
         with:
@@ -614,7 +617,7 @@ jobs:
         run: cd bindings/python && bash ./ci/show_vcpkg_logs.sh
 
       - name: Auditing wheels
-        run: cd bindings/python && for whl in wheelhouse/*.whl; do auditwheel repair "$whl" --plat $PLAT -w wheelhouse/audited/; done
+        run: cd bindings/python && for whl in wheelhouse/*.whl; do auditwheel repair "$whl" --plat $PLAT --strip -w wheelhouse/audited/; done
       - name: Archive wheel artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -637,11 +640,14 @@ jobs:
           pattern: audited-wheels-linux-arm64-*
           path: bindings/python/wheelhouse/audited/
           merge-multiple: true
+      - name: Install llvm-strip
+        run: |
+          yum install -y llvm # for llvm-strip, strip leads to "ELF load command address/offset not page-aligned" errors
       - name: Combine wheels
         run: |
           cd bindings/python && mv wheelhouse/audited wheelhouse/audited_pre && mkdir -p wheelhouse/audited
           echo "Combining repaired wheels into one master wheel"
-          python3 ci/combine_wheels.py --input_folder=wheelhouse/audited_pre --output_folder=wheelhouse/audited
+          python3 ci/combine_wheels.py --input_folder=wheelhouse/audited_pre --output_folder=wheelhouse/audited --strip-unneeded
       - name: Upload combined wheels as an artifact
         uses: actions/upload-artifact@v4
         with:
@@ -702,7 +708,7 @@ jobs:
           mv wheelhouse/audited wheelhouse/audited_pre
           mkdir -p wheelhouse/audited
           echo "Combining repaired wheels into one master wheel"
-          python ci/combine_wheels.py --input_folder=wheelhouse/audited_pre --output_folder=wheelhouse/audited --log_level=debug
+          python ci/combine_wheels.py --input_folder=wheelhouse/audited_pre --output_folder=wheelhouse/audited
       - name: Upload combined wheels as an artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Purpose
Fix wheel stripping on Linux and MacOS to produce even smaller wheels.

Note: we're doing symbol stripping followed by a call to the `llvm-strip` utility function from the LLVM ecosystem of tools (inside the `combine_wheels.py` python utility script). Without this, the stripped libraries don't have their ELF sections properly aligned (some systems, including mine, expect sections to be 4KB aligned) - `llvm-strip` fixes this alignment issue. On the other hand, using `llvm-strip` alone produces a larger folder upon unpacking the wheel. We're therefore using both the `strip` and `llvm-strip` utilities to combine the best of both worlds.

Note: even with all shared libraries stripped, the section with dynamic symbols (those symbols exposed by a shared library) is retained and so `backwardcpp` still informs the user about the location of an error or an abort. Testing has not shown any regression this regard.