### PR TITLE
Update visualizer to version 1.5.40

### DIFF
--- a/cmake/Depthai/DepthaiVisualizerConfig.cmake
+++ b/cmake/Depthai/DepthaiVisualizerConfig.cmake
@@ -1,2 +1,2 @@
 # "full commit hash of depthai visualizer static files"
-set(DEPTHAI_VISUALIZER_COMMIT "1.5.37")
+set(DEPTHAI_VISUALIZER_COMMIT "1.5.40")


### PR DESCRIPTION
## Purpose
Update visualizer to version 1.5.40 - this update is good to go, I've run our examples and there are no regressions. Everything works as expected.