### PR TITLE
Uploading of wheels update

### DIFF
--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -415,7 +415,7 @@ jobs:
 
           EXPECTED_VERSION="$ver" python bindings/python/ci/smoke_depthai.py
       - name: Upload combined wheels to artifactory
-        if: success()
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
         run: cd bindings/python && bash ./ci/upload-artifactory.sh
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
@@ -542,7 +542,7 @@ jobs:
           # Smoke test: fail hard on any exception or version mismatch
           EXPECTED_VERSION="$ver" "$PYBIN" bindings/python/ci/smoke_depthai.py
       - name: Upload combined wheels to artifactory
-        if: success()
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
         run: cd bindings/python && bash ./ci/upload-artifactory.sh
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
@@ -673,7 +673,7 @@ jobs:
 
           EXPECTED_VERSION="$ver" "$PYBIN" bindings/python/ci/smoke_depthai.py
       - name: Upload combined wheels to artifactory
-        if: success()
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
         run: cd bindings/python && bash ./ci/upload-artifactory.sh
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
@@ -735,12 +735,13 @@ jobs:
           $env:EXPECTED_VERSION = $ver
           python bindings/python/ci/smoke_depthai.py
       - name: Upload combined wheels to artifactory
-        if: success()
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
         run: cd bindings/python && bash ./ci/upload-artifactory.sh
         env:
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_PASS: ${{ secrets.ARTIFACTORY_PASS }}
+
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     # needs: [pytest, build-linux-armhf, build-windows-x86_64, build-macos-x86_64, build-macos-arm64, build-linux-x86_64, build-linux-arm64]


### PR DESCRIPTION
## Purpose
Uploading of combined wheels to the artifactory is now restricted to manual triggers and tags (releases)

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Updated python-main workflow

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
This was tested by running the Depthai Python CI/CD manually (correctly uploaded artifacts) & with a PR label (correctly did not upload the artifacts to the artifactory)