### PR TITLE
Close device when present in a pipeline

### DIFF
--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -869,7 +869,8 @@ void PipelineImpl::stop() {
     // Close the task queue
     tasks.destruct();
 
-    // Close device if specified
+    // Close device if present - a pipeline might be host only and still have a device
+    // For example, one only adds host nodes
     if(defaultDevice) {
         defaultDevice->close();
     }


### PR DESCRIPTION
Reported by @dominik737, we should close a device when present, otherwise the MRE bellow does not work as intended:

```python3
import depthai as dai


device = dai.Device()
pipeline = dai.Pipeline(device)
# COMMENT IN TO GET device.isClosed() = True
# cam = pipeline.create(dai.node.Camera).build()
# _ = cam.requestFullResolutionOutput().createOutputQueue()
pipeline.start()
pipeline.stop()
pipeline.wait()
print("Device isClosed: " + str(device.isClosed()))
```