### PR TITLE
Fix bootloader submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "shared/depthai-bootloader-shared"]
 	path = shared/depthai-bootloader-shared
-	url = ../depthai-bootloader-shared.git
+	url = https://github.com/luxonis/depthai-bootloader-shared.git
 [submodule "3rdparty/xtensor"]
 	path = 3rdparty/xtensor
 	url = https://github.com/xtensor-stack/xtensor


### PR DESCRIPTION
## Purpose
Creating of fork of `depthai-core` and initializing its submodules does not work unless one also forks the bootloader repository. You can verify this claim by running the following:

```bash
git clone git@github.com:lnotspotl/depthai-core.git && cd depthai-core
git submodule update --init --recursive
```

<img width="1922" height="888" alt="image" src="https://github.com/user-attachments/assets/fa3d0aee-54b3-48ad-b146-0c0147d9788e" />


This PR changes the URL of the bootloader's submodule to point to `luxonis/depthai-bootloader-shared`.
Doing that fixes the issue. 
