### PR TITLE
Fix: SSD parser regression

### DIFF
--- a/include/depthai/pipeline/node/DetectionParser.hpp
+++ b/include/depthai/pipeline/node/DetectionParser.hpp
@@ -19,8 +19,8 @@ namespace dai {
 namespace node {
 
 /**
- * @brief DetectionParser node. Parses detection results from different neural networks and is being used internally by MobileNetDetectionNetwork and
- * YoloDetectionNetwork.
+ * @brief DetectionParser node. Parses detection results from Mobilenet-SSD or YOLO neural networks.
+ * @note If multiple detection heads are present in the NNArchive, only one type is supported (either YOLO or Mobilenet-SSD) and the last one will be used.
  */
 class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, DetectionParserProperties>, public HostRunnable {
    public:

--- a/tests/src/ondevice_tests/pipeline/node/detection_parser_test.cpp
+++ b/tests/src/ondevice_tests/pipeline/node/detection_parser_test.cpp
@@ -280,6 +280,28 @@ TEST_CASE("DetectionParser can set properties") {
         REQUIRE(properties.anchorsV2.empty());
         REQUIRE(properties.nKeypoints.has_value());
     }
+
+    SECTION("Mobilenet SSD") {
+        auto description = dai::NNModelDescription{"luxonis/mobilenet-ssd:300x300", "RVC2"};
+        auto archivePath = dai::getModelFromZoo(description);
+        dai::NNArchive nnArchive{archivePath};
+        REQUIRE_NOTHROW(parser.setNNArchive(nnArchive));
+
+        dai::DetectionParserOptions properties = parser.properties.parser;
+
+        REQUIRE(properties.nnFamily == DetectionNetworkType::MOBILENET);
+        REQUIRE_FALSE(properties.decodeSegmentation);
+        REQUIRE_FALSE(properties.decodeKeypoints);
+        REQUIRE_FALSE(properties.nKeypoints.has_value());
+    }
+
+    SECTION("Unsupported non-detection archive") {
+        auto description = dai::NNModelDescription{"luxonis/paddle-text-recognition:320x48", "RVC4"};
+        auto archivePath = dai::getModelFromZoo(description);
+        dai::NNArchive nnArchive{archivePath};
+
+        REQUIRE_THROWS(parser.setNNArchive(nnArchive));
+    }
 }
 
 TEST_CASE("DetectionParser replay test") {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
There was a bug in DetectionParser where the validation of NNArchive was too stringent for the type of neural network, causing the pipeline to throw error when an SSD network is used.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Expanded test to cover SSD type network.