### PR TITLE
Fix plane offsets for YUV420p

### DIFF
--- a/src/opencv/ImgFrame.cpp
+++ b/src/opencv/ImgFrame.cpp
@@ -373,7 +373,7 @@ ImgFrame& ImgFrame::setCvFrame(cv::Mat mat, Type type) {
             fb.stride = mat.cols;
             fb.p1Offset = 0;
             fb.p2Offset = size;
-            fb.p3Offset = size / 4;
+            fb.p3Offset = fb.p2Offset + size / 4;
             cv::cvtColor(mat, output, cv::ColorConversionCodes::COLOR_BGR2YUV_I420);
             setFrame(output);
         } break;


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fix plane offsets for YUV420p in `setCvFrame`. This fixes an issue with replaying on RVC2 when isp scalers kick in.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable