### PR TITLE
Add back docker containers

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,26 +1,23 @@
 name: Publish Docker image
 on:
   workflow_dispatch:
-  # TODO(Morato) - re-enable docker upload
-  # push:
-  #   branches:
-  #   - main
-  #   - develop
-  #   tags:
-  #   - 'v2*'
+  push:
+    branches:
+    - main
+    - develop
+    tags:
+    - 'v3*'
 jobs:
 
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, [Linux, ARM], [Linux, ARM64]]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         include:
           - os: ubuntu-latest
             arch: amd64
-          - os: [Linux, ARM]
-            arch: armv7
-          - os: [Linux, ARM64]
+          - os: ubuntu-24.04-arm
             arch: armv8
     steps:
       - name: Clean the workspace
@@ -50,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          file: bindings/python/ci/Dockerfile
+          file: ci/Dockerfile
           tags: luxonis/depthai-library:${{ env.LUXONIS_IMAGE_TAG }}
 
       - name: Cleanup the created image
@@ -78,7 +75,6 @@ jobs:
           docker manifest create \
           luxonis/depthai-library:${{ github.sha}} \
           --amend luxonis/depthai-library:${{ github.sha }}-amd64 \
-          --amend luxonis/depthai-library:${{ github.sha }}-armv7 \
           --amend luxonis/depthai-library:${{ github.sha }}-armv8
           # Push
           docker manifest push luxonis/depthai-library:${{ github.sha }}
@@ -89,13 +85,11 @@ jobs:
           docker manifest create \
           luxonis/depthai-library:${{ steps.vars.outputs.short_ref }} \
           --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-amd64 \
-          --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-armv7 \
           --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-armv8
           # Push
           docker manifest push luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}
           docker manifest create \
           luxonis/depthai-library:latest \
           --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-amd64 \
-          --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-armv7 \
           --amend luxonis/depthai-library:${{ steps.vars.outputs.short_ref }}-armv8
           docker manifest push luxonis/depthai-library:latest

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,128 @@
+FROM debian:trixie-slim AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        zip \
+        unzip \
+        libopencv-dev \
+        libudev-dev \
+        libusb-1.0-0-dev \
+        ninja-build \
+        pkg-config \
+        nasm \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        patchelf && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages auditwheel
+
+WORKDIR /opt/depthai-core
+COPY . .
+
+RUN if [ -d .git ]; then git submodule update --init --recursive; fi
+
+RUN rm -rf build && \
+    cmake -S . -B build \
+        -G Ninja \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DDEPTHAI_BUILD_EXAMPLES=OFF && \
+    cmake --build build && \
+    cmake --install build
+
+WORKDIR /opt/depthai-core/bindings/python
+RUN python3 -m pip wheel . -w /opt/wheels
+
+# Repair wheel (to copy all the dependencies inside the wheel)
+RUN mkdir -p /opt/wheels_repaired && \
+    auditwheel repair /opt/wheels/*.whl -w /opt/wheels_repaired
+
+
+RUN python3 -m pip install --break-system-packages /opt/wheels_repaired/*.whl
+
+
+FROM debian:trixie-slim AS deployment
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        zip \
+        unzip \
+        libopencv-dev \
+        libudev-dev \
+        libusb-1.0-0-dev \
+        ninja-build \
+        pkg-config \
+        nasm \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages opencv-python-headless
+
+# ------------------------------------------------------------
+# Copy final installed artifacts only
+# ------------------------------------------------------------
+COPY --from=builder /usr/local /usr/local
+
+# -------------------------
+# C++ sanity check
+# -------------------------
+WORKDIR /opt/depthai-test
+RUN cat <<'EOF' > main.cpp
+#include <depthai/depthai.hpp>
+#include <depthai/build/version.hpp>
+#include <iostream>
+
+int main() {
+    std::cout << "DepthAI commit: " << dai::build::COMMIT << std::endl;
+    return 0;
+}
+EOF
+
+RUN cat <<'EOF' > CMakeLists.txt
+cmake_minimum_required(VERSION 3.20)
+project(depthai_test LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(depthai CONFIG REQUIRED)
+
+add_executable(depthai_test main.cpp)
+target_link_libraries(depthai_test PRIVATE depthai::core)
+EOF
+
+RUN cmake -S . -B build -G Ninja && \
+    cmake --build build && \
+    ./build/depthai_test
+
+# -------------------------
+# Python sanity check
+# -------------------------
+RUN python3 - <<'EOF'
+import depthai as dai
+print("DepthAI version:", dai.__version__)
+print("DepthAI module:", dai.__file__)
+EOF


### PR DESCRIPTION
## Purpose
Add a workflow to build development docker containers with preinstalled DepthAI C++ and Python libraries

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
A Docker container will get pushed to Docker hub with every push on `develop` `main` and `tags`

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested manually & added basic smoke tests to the container build itself to make sure a simple app can be compiled.
A container from the branch can be tested with:
```
docker pull luxonis/depthai-library:a1b078ba480981b9e81251bfd37799be644052b9
```