### PR TITLE
Fix stereo_depth_remap example

### DIFF
--- a/examples/cpp/StereoDepth/stereo_depth_remap.cpp
+++ b/examples/cpp/StereoDepth/stereo_depth_remap.cpp
@@ -29,12 +29,12 @@ cv::Mat processDepthFrame(const cv::Mat& depthFrame) {
 
     double min_depth = 0;
     if(!cv::countNonZero(depth_downscaled == 0)) {
-        std::vector<float> nonZeroDepth;
+        std::vector<uint16_t> nonZeroDepth;
         nonZeroDepth.reserve(depth_downscaled.rows * depth_downscaled.cols);
 
         for(int i = 0; i < depth_downscaled.rows; i++) {
             for(int j = 0; j < depth_downscaled.cols; j++) {
-                float depth = depth_downscaled.at<float>(i, j);
+                uint16_t depth = depth_downscaled.at<uint16_t>(i, j);
                 if(depth > 0) nonZeroDepth.push_back(depth);
             }
         }
@@ -45,11 +45,11 @@ cv::Mat processDepthFrame(const cv::Mat& depthFrame) {
         }
     }
 
-    std::vector<float> allDepth;
+    std::vector<uint16_t> allDepth;
     allDepth.reserve(depth_downscaled.rows * depth_downscaled.cols);
     for(int i = 0; i < depth_downscaled.rows; i++) {
         for(int j = 0; j < depth_downscaled.cols; j++) {
-            allDepth.push_back(depth_downscaled.at<float>(i, j));
+            allDepth.push_back(depth_downscaled.at<uint16_t>(i, j));
         }
     }
     std::sort(allDepth.begin(), allDepth.end());


### PR DESCRIPTION
## Purpose
Fix the following assertion error (caught by OpenCV when used in debug mode)
```
[ INFO:0@1.863] global plugin_loader.impl.hpp:67 cv::plugin::impl::DynamicLib::libraryLoad load opencv_core_parallel_openmp4100_64d.dll => FAILED
OpenCV(4.10.0) Error: Assertion failed (((0x28442211 >> ((traits::Depth<_Tp>::value) & ((1 << 3) - 1))*4) & 15) == elemSize1()) in cv::Mat::at, file C:\Users\kubjo\Documents\opencv\build\include\opencv2/core/mat.inl.hpp, line 900
OpenCV: terminate handler is called! The last OpenCV error is:
OpenCV(4.10.0) Error: Assertion failed (((0x28442211 >> ((traits::Depth<_Tp>::value) & ((1 << 3) - 1))*4) & 15) == elemSize1()) in cv::Mat::at, file C:\Users\kubjo\Documents\opencv\build\include\opencv2/core/mat.inl.hpp, line 900
```

CU task: https://app.clickup.com/t/86c6w3uhv