### PR TITLE
Remote connection now handles binary services as well

### DIFF
--- a/bindings/python/tests/remote_connection_service_test.py
+++ b/bindings/python/tests/remote_connection_service_test.py
@@ -6,7 +6,7 @@ import websockets
 import struct
 
 uri = "ws://localhost:8765"
-async def call_service(ws, service_name, service_id):
+async def call_service(ws, service_id):
     # Call a service and return the response payload
     msg = bytearray([0x02])  # opcode
     msg.extend(struct.pack('<I', service_id))
@@ -24,24 +24,46 @@ async def call_service(ws, service_name, service_id):
     return None
 
 
+async def call_binary_service(ws, service_id):
+    # Call a service and return the response payload
+    msg = bytearray([0x02])  # opcode
+    msg.extend(struct.pack('<I', service_id))
+    msg.extend(struct.pack('<I', 1))  # call_id
+    encoding = b"binary"
+    msg.extend(struct.pack('<I', len(encoding)))  # encoding length
+    msg.extend(encoding)
+    payload = b"\x01\x02\x03\x04"
+    msg.extend(payload)
+    await ws.send(bytes(msg))
+    
+    response = await asyncio.wait_for(ws.recv(), timeout=5.0)
+    if isinstance(response, bytes) and response[0] == 0x03:
+        # Format: [opcode(1)][serviceId(4)][callId(4)][encodingLength(4)][encoding][data]
+        encoding_len = struct.unpack('<I', response[9:13])[0]
+        payload = response[13 + encoding_len:]
+        return payload
+    return None
+
+
 async def get_available_services():
     async with websockets.connect(uri, subprotocols=["foxglove.websocket.v1"]) as ws:
         while True:
             msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=5.0))
             if msg.get("op") == "advertiseServices":
-                services = {s['name']: s['id'] for s in msg.get("services", [])}
-                print(f"Available services: {list(services.keys())}")
+                services = msg.get("services", [])
+                print(f"Available services: {[s['name'] for s in services]}")
                 break
         
         # Test each service
         results = {}
-        for service_name in services:
+        for service in services:
             try:
-                result = await call_service(ws, service_name, services[service_name])
-                results[service_name] = result
-                print(f"{service_name}: {result}")
+                encoding = service['type']
+                result = await call_service(ws, service['id']) if encoding == 'json' else await call_binary_service(ws, service['id'])
+                results[service['name']] = result
+                print(f"{service['name']}: {result}")
             except Exception as e:
-                print(f"{service_name}: ERROR - {e}")
+                print(f"{service['name']}: ERROR - {e}")
 
         return results
 
@@ -49,16 +71,22 @@ async def get_available_services():
 def custom_service(input):
     return {"result": "custom_service_result"}
 
+def custom_binary_service(input_data):
+    # Input data is in bytes
+    return input_data[::-1]
+
 
 def test_remote_connection_services():
     remoteConnection = dai.RemoteConnection()
     remoteConnection.registerService("custom_service", custom_service)
+    remoteConnection.registerBinaryService("custom_binary_service", custom_binary_service)
 
     results = asyncio.run(get_available_services())
     assert(json.loads(results["custom_service"]) == {"result": "custom_service_result"})
     assert(results["libraryVersion"] in dai.__version__)
     assert(results["topicGroups"] == "{}")
     assert(results["keyPressed"] == None)
+    assert(results["custom_binary_service"] == b"\x04\x03\x02\x01")
 
 
 if __name__ == '__main__':

--- a/include/depthai/remote_connection/RemoteConnection.hpp
+++ b/include/depthai/remote_connection/RemoteConnection.hpp
@@ -95,6 +95,14 @@ class RemoteConnection {
      */
     void registerService(const std::string& serviceName, std::function<nlohmann::json(const nlohmann::json&)> callback);
 
+    /**
+     * @brief Registers a binary service with a callback function.
+     *
+     * @param serviceName The name of the service.
+     * @param callback The callback function to handle requests.
+     */
+    void registerBinaryService(const std::string& serviceName, std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)> callback);
+
    private:
     Pimpl<RemoteConnectionImpl> impl;  ///< PIMPL idiom for implementation hiding.
 };

--- a/src/remote_connection/RemoteConnection.cpp
+++ b/src/remote_connection/RemoteConnection.cpp
@@ -34,4 +34,8 @@ void RemoteConnection::registerService(const std::string& serviceName, std::func
     impl->registerService(serviceName, std::move(callback));
 }
 
+void RemoteConnection::registerBinaryService(const std::string& serviceName, std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)> callback) {
+    impl->registerBinaryService(serviceName, std::move(callback));
+}
+
 }  // namespace dai

--- a/src/remote_connection/RemoteConnectionImpl.hpp
+++ b/src/remote_connection/RemoteConnectionImpl.hpp
@@ -30,6 +30,7 @@ class RemoteConnectionImpl {
     bool removeTopic(const std::string& topicName);
     void registerPipeline(const Pipeline& pipeline);
     void registerService(const std::string& serviceName, std::function<nlohmann::json(const nlohmann::json&)> callback);
+    void registerBinaryService(const std::string& serviceName, std::function<std::vector<uint8_t>(const std::vector<uint8_t>&)> callback);
     int waitKey(int delayMs);
 
    private:


### PR DESCRIPTION
## Purpose
Handling of services using binary data is missing. It should be added by registering a service which handles binary data.

## Specification
Remote connection now handles registering of the binary services.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
This was tested by updating the remote connection service test to handle binary services as well.