### PR TITLE
Fix: remove confidence validation

### DIFF
--- a/include/depthai/common/Keypoint.hpp
+++ b/include/depthai/common/Keypoint.hpp
@@ -16,21 +16,17 @@ struct Keypoint {
     Point3f imageCoordinates;
     float confidence = -1.f;  // -1.f indicates confidence is not set
     uint32_t label = 0;
-    std::string labelName = "";
+    std::string labelName;
 
     Keypoint() = default;
     explicit Keypoint(Point3f imageCoordinates, float conf = 0.f, uint32_t label = 0, std::string labelName = "")
-        : imageCoordinates(imageCoordinates), confidence(conf), label(label), labelName(labelName) {
-        if(confidence < 0.f) {
-            throw std::invalid_argument("Confidence must be non-negative.");
-        }
-    }
+        : imageCoordinates(imageCoordinates), confidence(conf), label(label), labelName(std::move(labelName)) {}
 
     explicit Keypoint(Point2f imageCoordinates, float confidence = 0.f, uint32_t label = 0, std::string labelName = "")
-        : Keypoint(Point3f{imageCoordinates.x, imageCoordinates.y, 0.f}, confidence, label, labelName) {}
+        : Keypoint(Point3f{imageCoordinates.x, imageCoordinates.y, 0.f}, confidence, label, std::move(labelName)) {}
 
     explicit Keypoint(float x, float y, float z, float confidence = 0.f, uint32_t label = 0, std::string labelName = "")
-        : Keypoint(Point3f{x, y, z}, confidence, label, labelName) {}
+        : Keypoint(Point3f{x, y, z}, confidence, label, std::move(labelName)) {}
 
     DEPTHAI_SERIALIZE(dai::Keypoint, imageCoordinates, confidence, label, labelName);
 };
@@ -53,7 +49,7 @@ struct KeypointsList : KeypointsListT<Keypoint> {
      * @param keypoints list of Point3f objects to set.
      * @note This will clear any existing keypoints and edges.
      */
-    void setKeypoints(const std::vector<Point3f> kps3) {
+    void setKeypoints(const std::vector<Point3f>& kps3) {
         edges.clear();
         keypoints.clear();
         keypoints.reserve(kps3.size());
@@ -67,7 +63,7 @@ struct KeypointsList : KeypointsListT<Keypoint> {
      * @param keypoints list of Point2f objects to set.
      * @note This will clear any existing keypoints and edges.
      */
-    void setKeypoints(const std::vector<Point2f> kps2) {
+    void setKeypoints(const std::vector<Point2f>& kps2) {
         edges.clear();
         keypoints.clear();
         keypoints.reserve(kps2.size());


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Default value of confidence is -1 and forgot to remove check in the initializer. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable