### PR TITLE
Terminate examples if NeuralDepth is not supported

### DIFF
--- a/examples/cpp/Vpp/virtual_patern_projection.cpp
+++ b/examples/cpp/Vpp/virtual_patern_projection.cpp
@@ -49,6 +49,11 @@ void showDepth(const cv::Mat& depthFrameIn,
 int main() {
     int fps = 20;
     dai::Pipeline pipeline;
+    auto device = pipeline.getDefaultDevice();
+    if(!device->isNeuralDepthSupported()) {
+        std::cout << "Exiting Vpp example: device doesn't support NeuralDepth.\n";
+        return 0;
+    }
 
     // Left / Right cameras
     auto monoLeft = pipeline.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_B, std::nullopt, fps);

--- a/examples/python/Vpp/virtual_patern_projection.py
+++ b/examples/python/Vpp/virtual_patern_projection.py
@@ -46,7 +46,12 @@ def showDepth(depthFrame, windowName="Depth", minDistance=500, maxDistance=5000,
 if __name__ == "__main__":
     fps = 20
 
-    pipeline = dai.Pipeline()
+    device = dai.Device()
+    pipeline = dai.Pipeline(device)
+
+    if not device.isNeuralDepthSupported():
+        print("Exiting Vpp example: device doesn't support NeuralDepth.")
+        exit()
 
     # Left Right cameras
     monoLeft = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_B, sensorFps=fps)


### PR DESCRIPTION
Terminate Vpp examples if the NeuralDepth is not supported.