### PR TITLE
Fix: Remove confidence test

### DIFF
--- a/tests/src/onhost_tests/pipeline/datatype/imgdetections_test.cpp
+++ b/tests/src/onhost_tests/pipeline/datatype/imgdetections_test.cpp
@@ -221,7 +221,6 @@ TEST_CASE("Keypoint validation", "[ImgDetections][Keypoint]") {
     using namespace dai;
 
     REQUIRE_NOTHROW(Keypoint(Point3f{0.0F, 0.0F, 0.0F}, 0.1F));
-    REQUIRE_THROWS_AS(Keypoint(Point3f{0.0F, 0.0F, 0.0F}, -0.1F), std::invalid_argument);
 }
 
 TEST_CASE("ImgDetections segmentation mask operations", "[ImgDetections][Segmentation]") {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Keypoints now accept -1 for confidence value. It implies "no confidence was set"

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable