### PR TITLE
Fix numpy 2.4.1 issues on tests

### DIFF
--- a/examples/python/ImageAlign/depth_align.py
+++ b/examples/python/ImageAlign/depth_align.py
@@ -65,7 +65,8 @@ def colorizeDepth(frameDepth):
     try:
         minDepth = np.percentile(frameDepth[frameDepth != 0], 3)
         maxDepth = np.percentile(frameDepth[frameDepth != 0], 95)
-        logDepth = np.log(frameDepth, where=frameDepth != 0)
+        logDepth = np.zeros_like(frameDepth, dtype=np.float32)
+        np.log(frameDepth, where=frameDepth != 0, out=logDepth)
         logMinDepth = np.log(minDepth)
         logMaxDepth = np.log(maxDepth)
         np.nan_to_num(logDepth, copy=False, nan=logMinDepth)

--- a/examples/python/ObjectTracker/object_tracker_remap.py
+++ b/examples/python/ObjectTracker/object_tracker_remap.py
@@ -10,7 +10,8 @@ def colorizeDepth(frameDepth):
     try:
         minDepth = np.percentile(frameDepth[frameDepth != 0], 3)
         maxDepth = np.percentile(frameDepth[frameDepth != 0], 95)
-        logDepth = np.log(frameDepth, where=frameDepth != 0)
+        logDepth = np.zeros_like(frameDepth, dtype=np.float32)
+        np.log(frameDepth, where=frameDepth != 0, out=logDepth)
         logMinDepth = np.log(minDepth)
         logMaxDepth = np.log(maxDepth)
         np.nan_to_num(logDepth, copy=False, nan=logMinDepth)
@@ -114,4 +115,3 @@ with dai.Pipeline() as pipeline:
         if cv2.waitKey(1) == ord("q"):
             pipeline.stop()
             break
-


### PR DESCRIPTION
Due to new numpy 2.4.1 now reporting warning in log function, tests failed.

`201:   File "/workspace/examples/python/ObjectTracker/object_tracker_remap.py", line 13, in colorizeDepth
2026-01-20T12:04:18.5052302Z [RVC2 - USB] 201:     logDepth = np.log(frameDepth, where=frameDepth != 0)
2026-01-20T12:04:18.5052534Z [RVC2 - USB] 201:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-01-20T12:04:18.5052909Z [RVC2 - USB] 201: UserWarning: 'where' used without 'out', expect unitialized memory in output. If this is intentional, use out=None.`

Before fix:
https://github.com/luxonis/depthai-core/actions/runs/21165569407
After fix:
https://github.com/luxonis/depthai-core/actions/runs/21193525865