### PR TITLE
Add get- and setTransformation to C++

### DIFF
--- a/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
@@ -212,7 +212,7 @@ void bind_imgframe(pybind11::module& m, void* pCallstack) {
         .def("getSourceDFov", &ImgFrame::getSourceDFov, DOC(dai, ImgFrame, getSourceDFov))
         .def("getSourceWidth", &ImgFrame::getSourceWidth, DOC(dai, ImgFrame, getSourceWidth))
         .def("getSourceHeight", &ImgFrame::getSourceHeight, DOC(dai, ImgFrame, getSourceHeight))
-        .def("getTransformation", [](ImgFrame& msg) { return msg.transformation; })
+        .def("getTransformation", &ImgFrame::getTransformation, DOC(dai, ImgFrame, getTransformation))
         .def("validateTransformations", &ImgFrame::validateTransformations, DOC(dai, ImgFrame, validateTransformations))
 
 #ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
@@ -265,7 +265,7 @@ void bind_imgframe(pybind11::module& m, void* pCallstack) {
              py::arg("sizer"),
              DOC(dai, ImgFrame, setSize, 2))
         .def("setType", &ImgFrame::setType, py::arg("type"), DOC(dai, ImgFrame, setType))
-        .def("setTransformation", [](ImgFrame& msg, const ImgTransformation& transformation) { msg.transformation = transformation; })
+        .def("setTransformation", &ImgFrame::setTransformation, py::arg("transformation"), DOC(dai, ImgFrame, setTransformation))
         // .def("set", &ImgFrame::set, py::arg("type"), DOC(dai, ImgFrame, set))
         ;
     // add aliases dai.ImgFrame.Type and dai.ImgFrame.Specs

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -194,6 +194,11 @@ class ImgFrame : public Buffer, public ProtoSerializable {
     float getLensPositionRaw() const;
 
     /**
+     * Retrieves image transformation data
+     */
+    ImgTransformation& getTransformation();
+
+    /**
      * Instance number relates to the origin of the frame (which camera)
      *
      * @param instance Instance number
@@ -262,6 +267,13 @@ class ImgFrame : public Buffer, public ProtoSerializable {
      * @param type Type of image
      */
     ImgFrame& setType(Type type);
+
+    /**
+     * Specifies image transformation data
+     *
+     * @param transformation transformation data
+     */
+    ImgFrame& setTransformation(const ImgTransformation& transformation);
 
     /**
      * Remap a point from the current frame to the source frame

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -131,6 +131,10 @@ unsigned int ImgFrame::getSourceHeight() const {
     return sourceFb.height;
 }
 
+ImgTransformation& ImgFrame::getTransformation() {
+    return transformation;
+}
+
 ImgFrame& ImgFrame::setInstanceNum(unsigned int instanceNum) {
     this->instanceNum = instanceNum;
     return *this;
@@ -177,6 +181,11 @@ ImgFrame& ImgFrame::setSourceSize(std::tuple<unsigned int, unsigned int> size) {
 ImgFrame& ImgFrame::setType(Type type) {
     fb.type = type;
     fb.bytesPP = ImgFrame::typeToBpp(fb.type);
+    return *this;
+}
+
+ImgFrame& ImgFrame::setTransformation(const ImgTransformation& transformation) {
+    this->transformation = transformation;
     return *this;
 }
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Add `getTransformation` and `setTransformation` to C++ and fix python bindings to include docs

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable