### PR TITLE
Improve `dai.ImgDetection`

### DIFF
--- a/bindings/python/src/pipeline/datatype/ImgDetectionsBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgDetectionsBindings.cpp
@@ -66,6 +66,7 @@ void bind_imgdetections(pybind11::module& m, void* pCallstack) {
         .def("setBoundingBox", &ImgDetection::setBoundingBox, py::arg("boundingBox"))
         .def("getBoundingBox", &ImgDetection::getBoundingBox)
         .def("setOuterBoundingBox", &ImgDetection::setOuterBoundingBox, py::arg("xmin"), py::arg("ymin"), py::arg("xmax"), py::arg("ymax"))
+        .def("getOuterBoundingBox", &ImgDetection::getOuterBoundingBox, DOC(dai, ImgDetection, getOuterBoundingBox))
         .def("setKeypoints", py::overload_cast<const KeypointsList>(&ImgDetection::setKeypoints), py::arg("keypoints"))
         .def("setKeypoints", py::overload_cast<const std::vector<Keypoint>>(&ImgDetection::setKeypoints), py::arg("keypoints"))
         .def("setKeypoints",

--- a/include/depthai/pipeline/datatype/ImgDetections.hpp
+++ b/include/depthai/pipeline/datatype/ImgDetections.hpp
@@ -40,10 +40,10 @@ struct ImgDetection {
     std::optional<KeypointsList> keypoints;
 
     ImgDetection() = default;
-    ImgDetection(const RotatedRect& boundingBox, float confidence, uint32_t label);
-    ImgDetection(const RotatedRect& boundingBox, std::string labelName, float confidence, uint32_t label);
-    ImgDetection(const RotatedRect& boundingBox, const KeypointsList& keypoints, float confidence, uint32_t label);
-    ImgDetection(const RotatedRect& boundingBox, const KeypointsList& keypoints, std::string labelName, float confidence, uint32_t label);
+    ImgDetection(const RotatedRect& boundingBox, float confidence = 0.f, uint32_t label = 0);
+    ImgDetection(const RotatedRect& boundingBox, std::string labelName, float confidence = 0.f, uint32_t label = 0);
+    ImgDetection(const RotatedRect& boundingBox, const KeypointsList& keypoints, float confidence = 0.f, uint32_t label = 0);
+    ImgDetection(const RotatedRect& boundingBox, const KeypointsList& keypoints, std::string labelName, float confidence = 0.f, uint32_t label = 0);
 
     /**
      * Sets the bounding box and the legacy coordinates of the detection.
@@ -59,6 +59,11 @@ struct ImgDetection {
      * Sets the bounding box and the legacy coordinates of the detection from the top-left and bottom-right points.
      */
     void setOuterBoundingBox(const float xmin, const float ymin, const float xmax, const float ymax);
+
+    /**
+     * Returns the outer bounding box as [minx, miny, maxx, maxy].
+     */
+    std::array<float, 4> getOuterBoundingBox() const;
 
     /**
      * Sets the keypoints of the detection.
@@ -123,27 +128,27 @@ struct ImgDetection {
     /**
      * Returns the X coordinate of the center of the bounding box.
      */
-    float getCenterX() const noexcept;
+    float getCenterX() const;
 
     /**
      * Returns the Y coordinate of the center of the bounding box.
      */
-    float getCenterY() const noexcept;
+    float getCenterY() const;
 
     /**
      * Returns the width of the (rotated) bounding box.
      */
-    float getWidth() const noexcept;
+    float getWidth() const;
 
     /**
      * Returns the height of the (rotated) bounding box.
      */
-    float getHeight() const noexcept;
+    float getHeight() const;
 
     /**
      * Returns the angle of the bounding box.
      */
-    float getAngle() const noexcept;
+    float getAngle() const;
 
     DEPTHAI_SERIALIZE(ImgDetection, label, labelName, confidence, xmin, ymin, xmax, ymax, boundingBox, keypoints);
 };

--- a/src/pipeline/datatype/ImgDetections.cpp
+++ b/src/pipeline/datatype/ImgDetections.cpp
@@ -19,23 +19,21 @@ namespace dai {
 
 // ImgDetection functions
 
-ImgDetection::ImgDetection(const dai::RotatedRect& boundingBox, float conf = 0.f, uint32_t label = 0) {
+ImgDetection::ImgDetection(const dai::RotatedRect& boundingBox, float conf, uint32_t label) {
     setBoundingBox(boundingBox);
     this->confidence = conf;
     this->label = label;
 }
-ImgDetection::ImgDetection(const dai::RotatedRect& boundingBox, std::string labelName, float conf = 0.f, uint32_t label = 0)
-    : ImgDetection(boundingBox, conf, label) {
+ImgDetection::ImgDetection(const dai::RotatedRect& boundingBox, std::string labelName, float conf, uint32_t label) : ImgDetection(boundingBox, conf, label) {
     this->labelName = std::move(labelName);
 }
 
-ImgDetection::ImgDetection(const dai::RotatedRect& boundingBox, const dai::KeypointsList& keypoints, float conf = 0.f, uint32_t label = 0)
+ImgDetection::ImgDetection(const dai::RotatedRect& boundingBox, const dai::KeypointsList& keypoints, float conf, uint32_t label)
     : ImgDetection(boundingBox, conf, label) {
     this->keypoints = keypoints;
 }
 
-ImgDetection::ImgDetection(
-    const dai::RotatedRect& boundingBox, const dai::KeypointsList& keypoints, std::string labelName, float conf = 0.f, uint32_t label = 0)
+ImgDetection::ImgDetection(const dai::RotatedRect& boundingBox, const dai::KeypointsList& keypoints, std::string labelName, float conf, uint32_t label)
     : ImgDetection(boundingBox, conf, label) {
     this->keypoints = keypoints;
     this->labelName = std::move(labelName);
@@ -54,7 +52,8 @@ void ImgDetection::setBoundingBox(const RotatedRect boundingBox) {
 RotatedRect ImgDetection::getBoundingBox() const {
     if(boundingBox.has_value()) {
         return boundingBox.value();
-    } else if(xmin == 0.f && xmax == 0.f && ymin == 0.f && ymax == 0.f) {
+    }
+    if(xmin == 0.f && xmax == 0.f && ymin == 0.f && ymax == 0.f) {
         throw std::runtime_error("All bounding box values are zero, no bounding box can be built.");
     }
 
@@ -73,6 +72,16 @@ void ImgDetection::setOuterBoundingBox(const float xmin, const float ymin, const
     Point2f bottomRight{xmax, ymax};
 
     this->boundingBox = RotatedRect{Rect{topLeft, bottomRight}};
+}
+
+std::array<float, 4> ImgDetection::getOuterBoundingBox() const {
+    if(boundingBox.has_value()) {
+        return boundingBox->getOuterRect();
+    }
+    if(xmin == 0.f && xmax == 0.f && ymin == 0.f && ymax == 0.f) {
+        throw std::runtime_error("All bounding box values are zero, no bounding box can be built.");
+    }
+    return {xmin, ymin, xmax, ymax};
 }
 
 void ImgDetection::setKeypoints(const KeypointsList kp) {
@@ -100,25 +109,22 @@ void ImgDetection::setKeypoints(const std::vector<Point2f> kps2) {
 std::vector<Keypoint> ImgDetection::getKeypoints() const {
     if(keypoints.has_value()) {
         return keypoints->getKeypoints();
-    } else {
-        return {};
     }
+    return {};
 }
 
 std::vector<Point2f> ImgDetection::getKeypoints2f() const {
     if(keypoints.has_value()) {
         return keypoints->getPoints2f();
-    } else {
-        return {};
     }
+    return {};
 }
 
 std::vector<Point3f> ImgDetection::getKeypoints3f() const {
     if(keypoints.has_value()) {
         return keypoints->getPoints3f();
-    } else {
-        return {};
     }
+    return {};
 }
 
 void ImgDetection::setEdges(const std::vector<Edge> edges) {
@@ -131,28 +137,27 @@ void ImgDetection::setEdges(const std::vector<Edge> edges) {
 std::vector<Edge> ImgDetection::getEdges() const {
     if(keypoints.has_value()) {
         return keypoints->getEdges();
-    } else {
-        return {};
     }
+    return {};
 }
 
-float ImgDetection::getCenterX() const noexcept {
+float ImgDetection::getCenterX() const {
     return getBoundingBox().center.x;
 }
 
-float ImgDetection::getCenterY() const noexcept {
+float ImgDetection::getCenterY() const {
     return getBoundingBox().center.y;
 }
 
-float ImgDetection::getWidth() const noexcept {
+float ImgDetection::getWidth() const {
     return getBoundingBox().size.width;
 }
 
-float ImgDetection::getHeight() const noexcept {
+float ImgDetection::getHeight() const {
     return getBoundingBox().size.height;
 }
 
-float ImgDetection::getAngle() const noexcept {
+float ImgDetection::getAngle() const {
     return getBoundingBox().angle;
 }
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
This PR improves the following  in `dai.ImgDetection`:
1.  Defualt values should be in hpp function signatures and not the cpp implementations
2. Missing `getOuterBoundingBox` function & binding
3. clang-tidy wranings ( else statement should not follow a return statement)

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable