### PR TITLE
Fix: Rare ThreadedHostNode race condition

### DIFF
--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -726,7 +726,7 @@ size_t Node::ConnectionInternal::Hash::operator()(const dai::Node::ConnectionInt
 
 void Node::stopPipeline() {
     // FIXME - Not the best solution as the node now owns the pipeline. If it is the last reference to the pipeline, destructor will be called from the same
-    // thread.
+    // thread and the pipeline will crash.
     try {
         auto pipeline = getParentPipeline();
         pipeline.stop();

--- a/src/pipeline/ThreadedNode.cpp
+++ b/src/pipeline/ThreadedNode.cpp
@@ -62,7 +62,7 @@ void ThreadedNode::start() {
 }
 
 void ThreadedNode::wait() {
-    if(thread.joinable() && thread.get_id() != std::this_thread::get_id()) thread.join();
+    if(thread.joinable()) thread.join();
 }
 
 void ThreadedNode::stop() {

--- a/src/pipeline/node/host/Replay.cpp
+++ b/src/pipeline/node/host/Replay.cpp
@@ -247,6 +247,7 @@ void ReplayVideo::run() {
                     }
                     continue;
                 }
+                // This will stop even if there is still frames in the pipeline
                 stopPipeline();
                 break;
             } else {
@@ -266,6 +267,8 @@ void ReplayVideo::run() {
                     videoPlayer.restart();
                     continue;
                 }
+                // This will stop even if there is still frames in the pipeline
+                stopPipeline();
                 break;
             } else {
                 hasVideo = false;
@@ -366,6 +369,7 @@ void ReplayMetadataOnly::run() {
                 bytePlayer.restart();
                 continue;
             }
+            // This will stop even if there is still frames in the pipeline
             stopPipeline();
             break;
         } else {


### PR DESCRIPTION

## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`detection_parser_test` was failing on develop with ASAN / UBSAN enabled. The issue was a race condition in Replay node. What would happen is: 
-> test would finish 
-> pipeline would send stop to all nodes, ReplayNode `while(mainLoop())` would exit 
-> stopPipeline() called
-> new shared_ptr to the Pipeline 
-> While stopPipeline() is running, the other shared_ptr to Pipeline would be dropped making this the only one
-> stopPipeline() would finish, shared_ptr would go out of scope
-> ~PipelineImpl() called from the ReplayNode thread
-> wait() would try to join its own thread.

Without ASAN / UBSAN enabled and without DEPTHAI_PIPELINE_DEBUGGING=1 CTEST_PARALLEL_LEVEL=1 this race has not been hit (yet).

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Fixes:
1) ReplayNode `stopPipeline()`  should only run if 'video file == EOF' and 'loop==False'. 
2) Guard against joining own thread.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
test should pass