### PR TITLE
Remove gperf download step from Dockerfile

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -98,11 +98,6 @@ RUN python3 -m venv venv && \
 ENV PATH="/workspace/venv/bin:$PATH"
 
 RUN --mount=type=cache,target=/opt/vcpkg-downloads \
-    curl -fL --retry 5 --retry-delay 2 \
-      https://mirrors.kernel.org/gnu/gperf/gperf-3.1.tar.gz \
-      -o /opt/vcpkg-downloads/gperf-3.1.tar.gz
-
-RUN --mount=type=cache,target=/opt/vcpkg-downloads \
     --mount=type=cache,target=/opt/vcpkg-bincache \
     if [ "$FLAVOR" != "vanilla" ] && [ "$FLAVOR" != "tsan" ]; then \
         export CMAKE_TOOLCHAIN_FILE=/workspace/cmake/toolchain/${FLAVOR}.cmake && \


### PR DESCRIPTION
Removed the download step for gperf from the Dockerfile.

## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable