### PR TITLE
Feature/check for missing dataType

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -47,9 +47,30 @@ jobs:
 
         echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
 
-  style:
+  consistency:
     runs-on: ubuntu-24.04
     needs: [precheck]
+    if: needs.precheck.outputs.should_run == 'true'
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: Install consistency check dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install ripgrep
+
+    - name: Run datatype enum consistency check
+      run: bash ci/check_datatype_enum_consistency.sh
+
+    - name: Run protobuf consistency check
+      run: bash ci/check_protobuf_consistency.sh
+
+  style:
+    runs-on: ubuntu-24.04
+    needs: [precheck, consistency]
     if: needs.precheck.outputs.should_run == 'true'
 
     steps:
@@ -71,7 +92,7 @@ jobs:
 
   tidy:
     runs-on: ubuntu-24.04
-    needs: [precheck]
+    needs: [precheck, consistency]
     if: needs.precheck.outputs.should_run == 'true'
 
     steps:
@@ -92,7 +113,7 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
-    needs: [precheck]
+    needs: [precheck, consistency]
     if: needs.precheck.outputs.should_run == 'true'
     strategy:
       matrix:
@@ -133,7 +154,7 @@ jobs:
 
   integration:
     runs-on: ${{ matrix.os }}
-    needs: [precheck]
+    needs: [precheck, consistency]
     if: needs.precheck.outputs.should_run == 'true'
     strategy:
       matrix:

--- a/bindings/python/src/CalibrationHandlerBindings.cpp
+++ b/bindings/python/src/CalibrationHandlerBindings.cpp
@@ -141,7 +141,7 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("getStereoLeftCameraId", &CalibrationHandler::getStereoLeftCameraId, DOC(dai, CalibrationHandler, getStereoLeftCameraId))
         .def("getStereoRightCameraId", &CalibrationHandler::getStereoRightCameraId, DOC(dai, CalibrationHandler, getStereoRightCameraId))
         .def("getAccelerometerCalibParams", &CalibrationHandler::getAccelerometerCalibParams, DOC(dai, CalibrationHandler, getAccelerometerCalibParams))
-        .def("getGyroscopeCalibParams", &CalibrationHandler::getGyroscopeCalibParams, DOC(dai,CalibrationHandler, getGyroscopeCalibParams))
+        .def("getGyroscopeCalibParams", &CalibrationHandler::getGyroscopeCalibParams, DOC(dai, CalibrationHandler, getGyroscopeCalibParams))
         .def("getImuModelParams", &CalibrationHandler::getImuModelParams, DOC(dai, CalibrationHandler, getImuModelParams))
 
         .def("eepromToJsonFile", &CalibrationHandler::eepromToJsonFile, py::arg("destPath"), DOC(dai, CalibrationHandler, eepromToJsonFile))
@@ -240,11 +240,11 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack) {
              py::arg("cameraId"),
              py::arg("rectifiedRotation"),
              DOC(dai, CalibrationHandler, setStereoRight))
-        .def("setAccelerometerCalibParams", 
+        .def("setAccelerometerCalibParams",
              &CalibrationHandler::setAccelerometerCalibParams,
              py::arg("accelerometerCalibParams"),
              DOC(dai, CalibrationHandler, setAccelerometerCalibParams))
-        .def("setGyroscopeCalibParams", 
+        .def("setGyroscopeCalibParams",
              &CalibrationHandler::setGyroscopeCalibParams,
              py::arg("gyroscopeCalibParams"),
              DOC(dai, CalibrationHandler, setGyroscopeCalibParams))

--- a/ci/check_datatype_enum_consistency.sh
+++ b/ci/check_datatype_enum_consistency.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ENUM_HPP="${REPO_ROOT}/include/depthai/pipeline/datatype/DatatypeEnum.hpp"
+ENUM_CPP="${REPO_ROOT}/src/pipeline/datatype/DatatypeEnum.cpp"
+PARSER_CPP="${REPO_ROOT}/src/pipeline/datatype/StreamMessageParser.cpp"
+DATATYPE_INCLUDE_DIR="${REPO_ROOT}/include/depthai/pipeline/datatype"
+DATATYPE_SRC_DIR="${REPO_ROOT}/src/pipeline/datatype"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+    rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+ENUM_VALUES="${TMP_DIR}/enum_values.txt"
+HIERARCHY_KEYS="${TMP_DIR}/hierarchy_keys.txt"
+HIERARCHY_CHILDREN="${TMP_DIR}/hierarchy_children.txt"
+PARSER_CASES="${TMP_DIR}/parser_cases.txt"
+RETURNED_ENUMS="${TMP_DIR}/returned_enums.txt"
+ENUM_VALUES_NO_ADATATYPE="${TMP_DIR}/enum_values_no_adatype.txt"
+
+extract_enum_values() {
+    awk '
+        /enum class DatatypeEnum/ { in_enum = 1; next }
+        in_enum && /^[[:space:]]*};/ { in_enum = 0 }
+        in_enum {
+            sub(/\/\/.*/, "", $0)
+            gsub(/[[:space:]]/, "", $0)
+            if($0 == "") next
+            sub(/,.*/, "", $0)
+            if($0 != "") print $0
+        }
+    ' "${ENUM_HPP}" | sort -u > "${ENUM_VALUES}"
+}
+
+extract_hierarchy_keys() {
+    sed -n 's/^[[:space:]]*{DatatypeEnum::\([A-Za-z0-9_]*\),.*/\1/p' "${ENUM_CPP}" | sort -u > "${HIERARCHY_KEYS}"
+}
+
+extract_hierarchy_children() {
+    sed -n 's/^[[:space:]]*DatatypeEnum::\([A-Za-z0-9_]*\),.*/\1/p' "${ENUM_CPP}" | sort -u > "${HIERARCHY_CHILDREN}"
+}
+
+extract_parser_cases() {
+    sed -n 's/^[[:space:]]*case DatatypeEnum::\([A-Za-z0-9_]*\):.*/\1/p' "${PARSER_CPP}" | sort -u > "${PARSER_CASES}"
+}
+
+extract_returned_datatype_enums() {
+    rg -NoI --replace '$1' 'return DatatypeEnum::([A-Za-z0-9_]+);' \
+        "${DATATYPE_INCLUDE_DIR}" "${DATATYPE_SRC_DIR}" -g '*.hpp' -g '*.cpp' \
+        | sort -u > "${RETURNED_ENUMS}"
+}
+
+check_subset() {
+    local subset="$1"
+    local superset="$2"
+    local description="$3"
+    local missing
+    missing="$(comm -23 "${subset}" "${superset}")"
+    if [[ -n "${missing}" ]]; then
+        echo "ERROR: ${description}"
+        echo "${missing}" | sed 's/^/  - /'
+        return 1
+    fi
+    return 0
+}
+
+main() {
+    extract_enum_values
+    extract_hierarchy_keys
+    extract_hierarchy_children
+    extract_parser_cases
+    extract_returned_datatype_enums
+
+    grep -vx 'ADatatype' "${ENUM_VALUES}" > "${ENUM_VALUES_NO_ADATATYPE}"
+
+    local failed=0
+
+    check_subset "${ENUM_VALUES}" "${HIERARCHY_KEYS}" \
+        "DatatypeEnum values missing as keys in DatatypeEnum.cpp hierarchy map." || failed=1
+
+    check_subset "${ENUM_VALUES_NO_ADATATYPE}" "${HIERARCHY_CHILDREN}" \
+        "DatatypeEnum values missing from DatatypeEnum.cpp hierarchy child entries." || failed=1
+
+    check_subset "${ENUM_VALUES}" "${PARSER_CASES}" \
+        "DatatypeEnum values missing from StreamMessageParser switch cases." || failed=1
+
+    check_subset "${RETURNED_ENUMS}" "${ENUM_VALUES}" \
+        "DatatypeEnum values returned by datatype classes are missing from DatatypeEnum.hpp." || failed=1
+
+    if [[ "${failed}" -ne 0 ]]; then
+        echo
+        echo "Datatype enum consistency check FAILED."
+        return 1
+    fi
+
+    echo "Datatype enum consistency check PASSED."
+}
+
+main "$@"

--- a/ci/check_datatype_enum_consistency.sh
+++ b/ci/check_datatype_enum_consistency.sh
@@ -21,6 +21,8 @@ HIERARCHY_CHILDREN="${TMP_DIR}/hierarchy_children.txt"
 PARSER_CASES="${TMP_DIR}/parser_cases.txt"
 RETURNED_ENUMS="${TMP_DIR}/returned_enums.txt"
 ENUM_VALUES_NO_ADATATYPE="${TMP_DIR}/enum_values_no_adatype.txt"
+ENUM_VALUES_NO_COUNT="${TMP_DIR}/enum_values_no_count.txt"
+ENUM_VALUES_NO_ADATATYPE_OR_COUNT="${TMP_DIR}/enum_values_no_adatype_or_count.txt"
 
 extract_enum_values() {
     awk '
@@ -75,14 +77,15 @@ main() {
     extract_parser_cases
     extract_returned_datatype_enums
 
-    grep -vx 'ADatatype' "${ENUM_VALUES}" > "${ENUM_VALUES_NO_ADATATYPE}"
+    grep -vx 'COUNT' "${ENUM_VALUES}" > "${ENUM_VALUES_NO_COUNT}"
+    grep -vxE 'ADatatype|COUNT' "${ENUM_VALUES}" > "${ENUM_VALUES_NO_ADATATYPE_OR_COUNT}"
 
     local failed=0
 
-    check_subset "${ENUM_VALUES}" "${HIERARCHY_KEYS}" \
+    check_subset "${ENUM_VALUES_NO_COUNT}" "${HIERARCHY_KEYS}" \
         "DatatypeEnum values missing as keys in DatatypeEnum.cpp hierarchy map." || failed=1
 
-    check_subset "${ENUM_VALUES_NO_ADATATYPE}" "${HIERARCHY_CHILDREN}" \
+    check_subset "${ENUM_VALUES_NO_ADATATYPE_OR_COUNT}" "${HIERARCHY_CHILDREN}" \
         "DatatypeEnum values missing from DatatypeEnum.cpp hierarchy child entries." || failed=1
 
     check_subset "${ENUM_VALUES}" "${PARSER_CASES}" \

--- a/ci/check_protobuf_consistency.sh
+++ b/ci/check_protobuf_consistency.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PROTO_HPP="${REPO_ROOT}/src/utility/ProtoSerialize.hpp"
+PROTO_CPP="${REPO_ROOT}/src/utility/ProtoSerialize.cpp"
+DATATYPE_SRC_DIR="${REPO_ROOT}/src/pipeline/datatype"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+    rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+GET_DECLS="${TMP_DIR}/get_decls.txt"
+GET_DEFS="${TMP_DIR}/get_defs.txt"
+SET_DECLS="${TMP_DIR}/set_decls.txt"
+SET_DEFS="${TMP_DIR}/set_defs.txt"
+PROTO_DATATYPES="${TMP_DIR}/proto_datatypes.txt"
+SCHEMA_ENUMS="${TMP_DIR}/schema_enums.txt"
+DESER_TRUE_ENUMS="${TMP_DIR}/deser_true_enums.txt"
+
+extract_get_specializations_declared() {
+    rg -NoI --replace '$1' '^[[:space:]]*std::unique_ptr<google::protobuf::Message>[[:space:]]+getProtoMessage\(const ([A-Za-z0-9_]+)\*' "${PROTO_HPP}" \
+        | grep -vx 'T' | sort -u > "${GET_DECLS}"
+}
+
+extract_get_specializations_defined() {
+    rg -NoI --replace '$1' '^[[:space:]]*std::unique_ptr<google::protobuf::Message>[[:space:]]+getProtoMessage\(const ([A-Za-z0-9_]+)\*' "${PROTO_CPP}" \
+        | grep -vx 'T' | sort -u > "${GET_DEFS}"
+}
+
+extract_set_specializations_declared() {
+    rg -NoI --replace '$1' '^[[:space:]]*void[[:space:]]+setProtoMessage\(([A-Za-z0-9_]+)&' "${PROTO_HPP}" \
+        | grep -vx 'T' | sort -u > "${SET_DECLS}"
+}
+
+extract_set_specializations_defined() {
+    rg -NoI --replace '$1' '^[[:space:]]*void[[:space:]]+setProtoMessage\(([A-Za-z0-9_]+)&' "${PROTO_CPP}" \
+        | grep -vx 'T' | sort -u > "${SET_DEFS}"
+}
+
+extract_proto_datatype_classes() {
+    rg -NoI --replace '$1' '^[[:space:]]*std::vector<std::uint8_t>[[:space:]]+([A-Za-z0-9_]+)::serializeProto\([^)]*\)[[:space:]]+const[[:space:]]+\{' "${DATATYPE_SRC_DIR}" -g '*.cpp' \
+        | sort -u > "${PROTO_DATATYPES}"
+}
+
+extract_schema_name_to_datatype_enums() {
+    awk '
+        /DatatypeEnum schemaNameToDatatype\(const std::string& schemaName\)/ { in_func = 1; next }
+        in_func && /^\}/ { in_func = 0 }
+        in_func {
+            while(match($0, /DatatypeEnum::[A-Za-z0-9_]+/)) {
+                print substr($0, RSTART + 14, RLENGTH - 14)
+                $0 = substr($0, RSTART + RLENGTH)
+            }
+        }
+    ' "${PROTO_CPP}" | sort -u > "${SCHEMA_ENUMS}"
+}
+
+extract_deserialization_supported_true_enums() {
+    awk '
+        /bool deserializationSupported\(DatatypeEnum datatype\)/ { in_func = 1; before_true = 1; next }
+        in_func && /^\}/ { in_func = 0 }
+        in_func {
+            if($0 ~ /return true;/) before_true = 0
+            if(before_true) {
+                while(match($0, /case DatatypeEnum::[A-Za-z0-9_]+:/)) {
+                    print substr($0, RSTART + 19, RLENGTH - 20)
+                    $0 = substr($0, RSTART + RLENGTH)
+                }
+            }
+        }
+    ' "${PROTO_CPP}" | sort -u > "${DESER_TRUE_ENUMS}"
+}
+
+check_subset() {
+    local subset="$1"
+    local superset="$2"
+    local description="$3"
+    local missing
+    missing="$(comm -23 "${subset}" "${superset}")"
+    if [[ -n "${missing}" ]]; then
+        echo "ERROR: ${description}"
+        echo "${missing}" | sed 's/^/  - /'
+        return 1
+    fi
+    return 0
+}
+
+check_equal_sets() {
+    local left="$1"
+    local right="$2"
+    local description="$3"
+
+    local only_left only_right
+    only_left="$(comm -23 "${left}" "${right}")"
+    only_right="$(comm -13 "${left}" "${right}")"
+
+    if [[ -n "${only_left}" || -n "${only_right}" ]]; then
+        echo "ERROR: ${description}"
+        if [[ -n "${only_left}" ]]; then
+            echo "  Present only in first set:"
+            echo "${only_left}" | sed 's/^/    - /'
+        fi
+        if [[ -n "${only_right}" ]]; then
+            echo "  Present only in second set:"
+            echo "${only_right}" | sed 's/^/    - /'
+        fi
+        return 1
+    fi
+    return 0
+}
+
+main() {
+    extract_get_specializations_declared
+    extract_get_specializations_defined
+    extract_set_specializations_declared
+    extract_set_specializations_defined
+    extract_proto_datatype_classes
+    extract_schema_name_to_datatype_enums
+    extract_deserialization_supported_true_enums
+
+    local failed=0
+
+    check_equal_sets "${GET_DECLS}" "${GET_DEFS}" \
+        "Mismatch between declared and defined getProtoMessage specializations." || failed=1
+
+    check_equal_sets "${SET_DECLS}" "${SET_DEFS}" \
+        "Mismatch between declared and defined setProtoMessage specializations." || failed=1
+
+    check_subset "${PROTO_DATATYPES}" "${GET_DECLS}" \
+        "Datatypes implementing serializeProto are missing getProtoMessage specializations." || failed=1
+
+    check_subset "${SCHEMA_ENUMS}" "${GET_DECLS}" \
+        "schemaNameToDatatype maps to enums without matching getProtoMessage specializations." || failed=1
+
+    check_subset "${DESER_TRUE_ENUMS}" "${SET_DECLS}" \
+        "deserializationSupported(true) enums are missing setProtoMessage specializations." || failed=1
+
+    check_subset "${DESER_TRUE_ENUMS}" "${SCHEMA_ENUMS}" \
+        "deserializationSupported(true) enums are missing schemaNameToDatatype mappings." || failed=1
+
+    if [[ "${failed}" -ne 0 ]]; then
+        echo
+        echo "Protobuf consistency check FAILED."
+        return 1
+    fi
+
+    echo "Protobuf consistency check PASSED."
+}
+
+main "$@"

--- a/include/depthai/common/EepromData.hpp
+++ b/include/depthai/common/EepromData.hpp
@@ -6,9 +6,9 @@
 #include "depthai/common/CameraBoardSocket.hpp"
 #include "depthai/common/CameraInfo.hpp"
 #include "depthai/common/Extrinsics.hpp"
+#include "depthai/common/ImuModelParams.hpp"
 #include "depthai/common/Point3f.hpp"
 #include "depthai/common/StereoRectification.hpp"
-#include "depthai/common/ImuModelParams.hpp"
 #include "depthai/utility/Serialization.hpp"
 
 namespace dai {

--- a/include/depthai/common/ImuModelParams.hpp
+++ b/include/depthai/common/ImuModelParams.hpp
@@ -7,17 +7,17 @@
 namespace dai {
 
 struct AccelAxisNoiseParams {
-    double vrw = 0.0; // velocity random walk
-    double rrw = 0.0; // rate random walk
-    double bi = 0.0;  // bias instability
+    double vrw = 0.0;  // velocity random walk
+    double rrw = 0.0;  // rate random walk
+    double bi = 0.0;   // bias instability
 
     DEPTHAI_SERIALIZE(AccelAxisNoiseParams, vrw, rrw, bi);
 };
 
 struct GyroAxisNoiseParams {
-    double arw = 0.0; // angle random walk
-    double rrw = 0.0; // rate random walk
-    double bi = 0.0;  // bias instability
+    double arw = 0.0;  // angle random walk
+    double rrw = 0.0;  // rate random walk
+    double bi = 0.0;   // bias instability
 
     DEPTHAI_SERIALIZE(GyroAxisNoiseParams, arw, rrw, bi);
 };
@@ -45,7 +45,7 @@ struct ImuModelParams {
 
     // Accelerometer parameters
     AccelerometerNoiseParams accelerometer;
-    
+
     // Gyroscope parameters
     GyroscopeNoiseParams gyroscope;
 

--- a/include/depthai/pipeline/datatype/DatatypeEnum.hpp
+++ b/include/depthai/pipeline/datatype/DatatypeEnum.hpp
@@ -55,7 +55,8 @@ enum class DatatypeEnum : std::int32_t {
     PipelineState,
     PipelineEventAggregationConfig,
     VppConfig,
-    PacketizedData
+    PacketizedData,
+    COUNT
 };
 bool isDatatypeSubclassOf(DatatypeEnum parent, DatatypeEnum children);
 

--- a/include/depthai/pipeline/datatype/DatatypeEnum.hpp
+++ b/include/depthai/pipeline/datatype/DatatypeEnum.hpp
@@ -56,7 +56,7 @@ enum class DatatypeEnum : std::int32_t {
     PipelineEventAggregationConfig,
     VppConfig,
     PacketizedData,
-    COUNT
+    COUNT  // Sentinel used by consistency checks; must remain the last enum entry.
 };
 bool isDatatypeSubclassOf(DatatypeEnum parent, DatatypeEnum children);
 

--- a/src/pipeline/datatype/StreamMessageParser.cpp
+++ b/src/pipeline/datatype/StreamMessageParser.cpp
@@ -355,6 +355,8 @@ std::shared_ptr<ADatatype> StreamMessageParser::parseMessage(streamPacketDesc_t*
         case DatatypeEnum::CoverageData:
             break;
 #endif  // DEPTHAI_HAVE_DYNAMIC_CALIBRATION_SUPPORT
+        case DatatypeEnum::COUNT:
+            break;
         default:
             break;
     }

--- a/src/pipeline/node/host/Replay.cpp
+++ b/src/pipeline/node/host/Replay.cpp
@@ -110,6 +110,7 @@ inline std::shared_ptr<Buffer> getMessage(const std::shared_ptr<google::protobuf
         case DatatypeEnum::SegmentationMask:
         case DatatypeEnum::VppConfig:
         case DatatypeEnum::PacketizedData:
+        case DatatypeEnum::COUNT:
             break;
     }
     throw std::runtime_error("Cannot replay message type: " + std::to_string((int)datatype));
@@ -192,6 +193,7 @@ inline std::shared_ptr<google::protobuf::Message> getProtoMessage(utility::ByteP
         case DatatypeEnum::SegmentationMask:
         case DatatypeEnum::VppConfig:
         case DatatypeEnum::PacketizedData:
+        case DatatypeEnum::COUNT:
             throw std::runtime_error("Cannot replay message type: " + std::to_string((int)datatype));
     }
     return {};

--- a/src/utility/ProtoSerialize.cpp
+++ b/src/utility/ProtoSerialize.cpp
@@ -195,6 +195,7 @@ bool deserializationSupported(DatatypeEnum datatype) {
         case DatatypeEnum::PipelineState:
         case DatatypeEnum::PipelineEventAggregationConfig:
         case DatatypeEnum::PacketizedData:
+        case DatatypeEnum::COUNT:
             return false;
     }
     return false;

--- a/tests/src/onhost_tests/calibration_handler_test.cpp
+++ b/tests/src/onhost_tests/calibration_handler_test.cpp
@@ -963,9 +963,12 @@ TEST_CASE("JSON round-trip preserves IMU calibration params", "[imuCalibration][
     REQUIRE(serialized.at("accelerometerCalibParams").get<std::vector<float>>() == expectedAccelerometer);
     REQUIRE(serialized.at("gyroscopeCalibParams").get<std::vector<float>>() == expectedGyroscope);
     REQUIRE(serialized.at("imuModelParams").at("name").get<std::string>() == expectedImuModel.name);
-    REQUIRE(serialized.at("imuModelParams").at("accelerometer").at("x").at("vrw").get<double>() == Catch::Approx(expectedImuModel.accelerometer.x.vrw).margin(1e-6));
-    REQUIRE(serialized.at("imuModelParams").at("accelerometer").at("y").at("rrw").get<double>() == Catch::Approx(expectedImuModel.accelerometer.y.rrw).margin(1e-6));
-    REQUIRE(serialized.at("imuModelParams").at("accelerometer").at("z").at("bi").get<double>() == Catch::Approx(expectedImuModel.accelerometer.z.bi).margin(1e-6));
+    REQUIRE(serialized.at("imuModelParams").at("accelerometer").at("x").at("vrw").get<double>()
+            == Catch::Approx(expectedImuModel.accelerometer.x.vrw).margin(1e-6));
+    REQUIRE(serialized.at("imuModelParams").at("accelerometer").at("y").at("rrw").get<double>()
+            == Catch::Approx(expectedImuModel.accelerometer.y.rrw).margin(1e-6));
+    REQUIRE(serialized.at("imuModelParams").at("accelerometer").at("z").at("bi").get<double>()
+            == Catch::Approx(expectedImuModel.accelerometer.z.bi).margin(1e-6));
     REQUIRE(serialized.at("imuModelParams").at("gyroscope").at("x").at("arw").get<double>() == Catch::Approx(expectedImuModel.gyroscope.x.arw).margin(1e-6));
     REQUIRE(serialized.at("imuModelParams").at("gyroscope").at("y").at("rrw").get<double>() == Catch::Approx(expectedImuModel.gyroscope.y.rrw).margin(1e-6));
     REQUIRE(serialized.at("imuModelParams").at("gyroscope").at("z").at("bi").get<double>() == Catch::Approx(expectedImuModel.gyroscope.z.bi).margin(1e-6));

--- a/tests/src/onhost_tests/pipeline/datatype/datatype_enum_test.cpp
+++ b/tests/src/onhost_tests/pipeline/datatype/datatype_enum_test.cpp
@@ -1,0 +1,27 @@
+#include <catch2/catch_all.hpp>
+
+#include "depthai/pipeline/datatype/DatatypeEnum.hpp"
+
+TEST_CASE("DatatypeEnum hierarchy is complete for all enum values", "[datatype][hierarchy]") {
+    using dai::DatatypeEnum;
+    const auto lastValue = static_cast<int>(DatatypeEnum::PacketizedData);
+
+    for(int i = 0; i <= lastValue; ++i) {
+        const auto dt = static_cast<DatatypeEnum>(i);
+
+        INFO("DatatypeEnum raw value: " << i);
+
+        // Ensures every enum value has an entry as a parent in hierarchy map.
+        REQUIRE_NOTHROW((void)dai::isDatatypeSubclassOf(dt, DatatypeEnum::ADatatype));
+
+        // Every datatype except ADatatype itself must be a descendant of ADatatype.
+        if(dt != DatatypeEnum::ADatatype) {
+            REQUIRE(dai::isDatatypeSubclassOf(DatatypeEnum::ADatatype, dt));
+        }
+
+        // In current design, all concrete datatypes are Buffer descendants.
+        if(dt != DatatypeEnum::ADatatype && dt != DatatypeEnum::Buffer) {
+            REQUIRE(dai::isDatatypeSubclassOf(DatatypeEnum::Buffer, dt));
+        }
+    }
+}

--- a/tests/src/onhost_tests/pipeline/datatype/datatype_enum_test.cpp
+++ b/tests/src/onhost_tests/pipeline/datatype/datatype_enum_test.cpp
@@ -4,9 +4,8 @@
 
 TEST_CASE("DatatypeEnum hierarchy is complete for all enum values", "[datatype][hierarchy]") {
     using dai::DatatypeEnum;
-    const auto lastValue = static_cast<int>(DatatypeEnum::PacketizedData);
-
-    for(int i = 0; i <= lastValue; ++i) {
+    const auto enumCount = static_cast<int>(DatatypeEnum::COUNT);
+    for(int i = 0; i < enumCount; ++i) {
         const auto dt = static_cast<DatatypeEnum>(i);
 
         INFO("DatatypeEnum raw value: " << i);


### PR DESCRIPTION
Idea is that every time in CI / CD we run the shell script and they should even before build starts, signalize if you have any undefined dataTypes, while they actually exsists in the node itself.

https://github.com/luxonis/depthai-core/actions/runs/23077185821/job/67039673343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI consistency stage that runs automated datatype and protobuf validation checks.

* **Tests**
  * New unit test for datatype-enum hierarchy; minor test formatting updates.

* **Style**
  * Small formatting and include-order adjustments across bindings and headers.

* **Other**
  * Introduced a new internal Datatype enum value (COUNT) and ensured it is safely handled and non-deserializable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->