### PR TITLE
kilted: bump depthai ROS package version to 3.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 
 # Create depthai project
-project(depthai VERSION "3.2.1" LANGUAGES CXX C)
+project(depthai VERSION "3.5.0" LANGUAGES CXX C)
 set(DEPTHAI_PRE_RELEASE_TYPE "") # Valid options are "alpha", "beta", "rc", ""
 set(DEPTHAI_PRE_RELEASE_VERSION "0") # Valid options are "0", "1", "2", ...
 


### PR DESCRIPTION
Bump the ROS package version to `3.5.0` on the Kilted release line.

Changes:
- update `depthai` version in `CMakeLists.txt`
