### PR TITLE
humble(v3): bump depthai_v3 ROS package version to 3.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 
 # Create depthai project
-project(depthai_v3 VERSION "3.2.2" LANGUAGES CXX C)
+project(depthai_v3 VERSION "3.5.0" LANGUAGES CXX C)
 set(DEPTHAI_PRE_RELEASE_TYPE "") # Valid options are "alpha", "beta", "rc", ""
 set(DEPTHAI_PRE_RELEASE_VERSION "0") # Valid options are "0", "1", "2", ...
 

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
     <name>depthai_v3</name>
-    <version>3.2.2</version>
+    <version>3.5.0</version>
     <description>DepthAI core is a C++ library which comes with firmware and an API to interact with
         OAK Platform</description>
 


### PR DESCRIPTION
Bump the ROS v3 package version to `3.5.0` on the Humble release line.

Changes:
- update `depthai_v3` version in `CMakeLists.txt`
- update `package.xml` version
