### PR TITLE
Setting ON_START as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The following environment variables can be set to alter default behavior of the 
 | DEPTHAI_REPLAY | Replays holistic replay from the specified file or directory. |
 | DEPTHAI_PROFILING | Enables runtime profiling of data transfer between the host and connected devices. Set to 1 to enable. Requires DEPTHAI_LEVEL=debug or lower to print. |
 | DEPTHAI_PIPELINE_DEBUGGING | Enables pipeline debugging with state dumps. DEPTHAI_LEVEL=trace is required to print the state dumps. |
-| DEPTHAI_AUTOCALIBRATION | Runs recalibration of the stereo pair and, by default, flashes successful calibration to non-volatile memory (EEPROM). DEPTHAI_AUTOCALIBRATION=CONTINUOUS: runs check repetitively; DEPTHAI_AUTOCALIBRATION=ON_START: runs calibration only at the start of the pipeline; DEPTHAI_AUTOCALIBRATION=OFF: no recalibration. |
+| DEPTHAI_AUTOCALIBRATION | Runs recalibration of the stereo pair and, by default, flashes successful calibration to non-volatile memory (EEPROM). DEPTHAI_AUTOCALIBRATION=CONTINUOUS: runs check repetitively; DEPTHAI_AUTOCALIBRATION=ON_START: runs calibration only at the start of the pipeline; DEPTHAI_AUTOCALIBRATION=OFF: no recalibration. AutoCalibration currently initializes only for stereo inputs at 1280x800. |
 
 ## Running tests
 

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -659,9 +659,9 @@ void PipelineImpl::build() {
     std::unique_lock<std::mutex> lock(pipelineBuildMutex);
     if(isBuild) return;
     // start ---Add AutoCalibration block---
-    auto autoCalibtationString = utility::getEnvAs<std::string>("DEPTHAI_AUTOCALIBRATION", "");
+    auto autoCalibrationString = utility::getEnvAs<std::string>("DEPTHAI_AUTOCALIBRATION", "ON_START");
 #ifndef DEPTHAI_INTERNAL_DEVICE_BUILD_RVC4
-    if(autoCalibtationString == "CONTINUOUS" || autoCalibtationString == "ON_START") {
+    if(autoCalibrationString == "CONTINUOUS" || autoCalibrationString == "ON_START") {
         if(defaultDevice && defaultDevice->tryGetCalibration()) {
             auto stereoPair = getStereoPair();
 
@@ -688,7 +688,7 @@ void PipelineImpl::build() {
             if(stereoPair.first && stereoPair.second && !hasDynamicCalibration() && hasStereoPairValidCalibration(defaultDevice->tryGetCalibration())) {
                 auto autoCalibrationNode = create<dai::node::AutoCalibration>(shared_from_this())->build(stereoPair.first, stereoPair.second);
                 Logging::getInstance().logger.info("AutoCalibration is initialized");
-                if(autoCalibtationString == "CONTINUOUS") {
+                if(autoCalibrationString == "CONTINUOUS") {
                     autoCalibrationNode->initialConfig->mode = dai::AutoCalibrationConfig::Mode::CONTINUOUS;
                 } else {
                     autoCalibrationNode->initialConfig->mode = dai::AutoCalibrationConfig::Mode::ON_START;
@@ -697,13 +697,13 @@ void PipelineImpl::build() {
         } else {
             if(isHostOnly()) {
                 Logging::getInstance().logger.info("DEPTHAI_AUTOCALIBRATION='{}' set on host-only pipeline. Skipping AutoCalibration node creation.",
-                                                   autoCalibtationString);
+                                                   autoCalibrationString);
             } else {
                 Logging::getInstance().logger.warn("Device has no valid initial calibration. Skipping autocalibration.");
             }
         }
-    } else if(autoCalibtationString != "OFF" && autoCalibtationString != "") {
-        Logging::getInstance().logger.warn("DEPTHAI_AUTOCALIBRATION can be CONTINUOUS, ON_START or OFF not {}", autoCalibtationString);
+    } else if(autoCalibrationString != "OFF" && autoCalibrationString != "") {
+        Logging::getInstance().logger.warn("DEPTHAI_AUTOCALIBRATION can be CONTINUOUS, ON_START or OFF not {}", autoCalibrationString);
     }
 #endif
     // end of ---Add AutoCalibration block---

--- a/src/pipeline/node/AutoCalibration.cpp
+++ b/src/pipeline/node/AutoCalibration.cpp
@@ -339,7 +339,7 @@ bool AutoCalibration::validateIncomingData() {
                 return false;
             }
             if(leftImgFrame->getHeight() != 800 || leftImgFrame->getWidth() != 1280) {
-                logger->warn("AutoCalibration: Not initialized - currently supports only sensors with 1280x800 resolution.");
+                logger->info("AutoCalibration: Not initialized - currently supports only sensors with 1280x800 resolution.");
                 return false;
             }
             return true;


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default auto-calibration now runs at startup when the configuration is unset (acts as "on start").
  * Preserves existing "continuous" vs "on start" modes and invalid-value warning behavior.
  * Resolution-mismatch message severity reduced from warning to informational.

* **Documentation**
  * Notes that auto-calibration currently initializes only for stereo inputs at 1280×800.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->