### PR TITLE
Add missing Recording binding

### DIFF
--- a/bindings/python/src/pipeline/node/RecordBindings.cpp
+++ b/bindings/python/src/pipeline/node/RecordBindings.cpp
@@ -24,6 +24,7 @@ void bind_record(pybind11::module& m, void* pCallstack) {
     ///////////////////////////////////////////////////////////////////////
     // Node
     recordVideo.def_readonly("input", &RecordVideo::input, DOC(dai, node, RecordVideo, input))
+        .def("setFps", &RecordVideo::setFps, py::arg("fps"), DOC(dai, node, RecordVideo, setFps))
         .def("setRecordMetadataFile", &RecordVideo::setRecordMetadataFile, py::arg("recordFile"), DOC(dai, node, RecordVideo, setRecordMetadataFile))
         .def("setRecordVideoFile", &RecordVideo::setRecordVideoFile, py::arg("recordFile"), DOC(dai, node, RecordVideo, setRecordVideoFile))
         .def("setCompressionLevel", &RecordVideo::setCompressionLevel, py::arg("compressionLevel"), DOC(dai, node, RecordVideo, setCompressionLevel))


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
A pybinding for "setFPS" was missing.
 
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to set frames per second (FPS) for video recording in the Python API. This allows developers to customize video output quality and performance characteristics when recording video content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->