### PR TITLE
Fixed out of bounds vector access in spatial_location_calculator.cpp

### DIFF
--- a/examples/cpp/SpatialLocationCalculator/spatial_location_calculator.cpp
+++ b/examples/cpp/SpatialLocationCalculator/spatial_location_calculator.cpp
@@ -69,9 +69,13 @@ int main() {
                     if(val > 0) depthValues.push_back(val);
                 }
             }
-            std::sort(depthValues.begin(), depthValues.end());
-            float medianDepth = depthValues[depthValues.size() / 2];
-            std::cout << "Median depth value: " << medianDepth << std::endl;
+            if(depthValues.empty()) {
+                std::cout << "Median depth value: N/A (no valid depth pixels)" << std::endl;
+            } else {
+                std::sort(depthValues.begin(), depthValues.end());
+                float medianDepth = depthValues[depthValues.size() / 2];
+                std::cout << "Median depth value: " << medianDepth << std::endl;
+            }
 
             // Process depth frame for visualization
             cv::Mat depthFrameColor;


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential error in the spatial location calculator when no valid depth pixels are available. The tool now displays "N/A (no valid depth pixels)" in these cases instead of attempting invalid calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->