### PR TITLE
Fix DEPTHAI_VCPKG_INTERNAL_ONLY option

### DIFF
--- a/cmake/depthaiOptions.cmake
+++ b/cmake/depthaiOptions.cmake
@@ -42,11 +42,11 @@ option(DEPTHAI_INSTALL "Enable install target for depthai-core targets" ON)
 
 # ---------- Dependency Management -------------
 option(DEPTHAI_BOOTSTRAP_VCPKG "Automatically bootstrap VCPKG" ON)
-option(DEPTHAI_VCPKG_INTERNAL_ONLY "Use VCPKG internally, but not for interface libraries" ON)
+option(DEPTHAI_VCPKG_INTERNAL_ONLY "Use VCPKG internally, but not for interface libraries" OFF)
 
-set(USE_EXTERNAL_INTERFACE_LIBS_DEFAULT ON)
+set(USE_EXTERNAL_INTERFACE_LIBS_DEFAULT OFF)
 if(DEPTHAI_VCPKG_INTERNAL_ONLY)
-    set(USE_EXTERNAL_INTERFACE_LIBS_DEFAULT OFF)
+  set(USE_EXTERNAL_INTERFACE_LIBS_DEFAULT ON)
 endif()
 
 option(DEPTHAI_JSON_EXTERNAL "Use external nlohmann_json library" ${USE_EXTERNAL_INTERFACE_LIBS_DEFAULT})


### PR DESCRIPTION
## Purpose
The `DEPTHAI_VCPKG_INTERNAL_ONLY` option had behaviour opposite to its description. I have corrected this behaviour and changed the default value to `OFF`.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted default build configuration: changed how internal-only package handling and automatic selection of external interface libraries are determined, affecting which external libraries are used by default during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->