### PR TITLE
Fix: Update Rectification to properly set source size

### DIFF
--- a/cmake/Depthai/DepthaiDeviceRVC4Config.cmake
+++ b/cmake/Depthai/DepthaiDeviceRVC4Config.cmake
@@ -3,4 +3,4 @@
 set(DEPTHAI_DEVICE_RVC4_MATURITY "snapshot")
 
 # "version if applicable"
-set(DEPTHAI_DEVICE_RVC4_VERSION "0.0.1+168da6449ba65c1855700c85bbcac6f4bd0fa6dd")
+set(DEPTHAI_DEVICE_RVC4_VERSION "0.0.1+ace14f51454f5a2ca73d45d8ee39ff9d8c55c4ff")

--- a/cmake/Depthai/DepthaiDeviceRVC4Config.cmake
+++ b/cmake/Depthai/DepthaiDeviceRVC4Config.cmake
@@ -3,4 +3,4 @@
 set(DEPTHAI_DEVICE_RVC4_MATURITY "snapshot")
 
 # "version if applicable"
-set(DEPTHAI_DEVICE_RVC4_VERSION "0.0.1+db3b29df4b1418e6e7ae1ffb12c406a597df86dc")
+set(DEPTHAI_DEVICE_RVC4_VERSION "0.0.1+168da6449ba65c1855700c85bbcac6f4bd0fa6dd")

--- a/src/pipeline/node/Rectification.cpp
+++ b/src/pipeline/node/Rectification.cpp
@@ -118,7 +118,7 @@ dai::ImgTransformation createRectifiedImgTransformation(const dai::Extrinsics& e
                                                         uint32_t outputWidth,
                                                         uint32_t outputHeight) {
     dai::ImgTransformation outputImgTransformation;
-
+    // Rectified frame is treated as a brand new camera, so source size is set to output size
     outputImgTransformation.setSourceSize(outputWidth, outputHeight);
     outputImgTransformation.setSize(outputWidth, outputHeight);
     outputImgTransformation.setIntrinsicMatrix(dai::matrix::cvMatToMatrix3x3(cvIntrinsicMatrix));
@@ -272,6 +272,8 @@ void Rectification::run() {
         rectifiedFrame1->setMetadata(*input1Frame);
         rectifiedFrame1->setWidth(output1FrameWidth);
         rectifiedFrame1->setHeight(output1FrameHeight);
+        rectifiedFrame1->sourceFb.width = output1FrameWidth;
+        rectifiedFrame1->sourceFb.height = output1FrameHeight;
         rectifiedFrame1->setType(dai::ImgFrame::Type::RAW8);
         rectifiedFrame1->fb.stride = rectifiedFrame1->fb.width * rectifiedFrame1->getBytesPerPixel();
 
@@ -283,6 +285,8 @@ void Rectification::run() {
         rectifiedFrame2->setMetadata(*input2Frame);
         rectifiedFrame2->setWidth(output2FrameWidth);
         rectifiedFrame2->setHeight(output2FrameHeight);
+        rectifiedFrame2->sourceFb.width = output2FrameWidth;
+        rectifiedFrame2->sourceFb.height = output2FrameHeight;
         rectifiedFrame2->setType(dai::ImgFrame::Type::RAW8);
         rectifiedFrame2->fb.stride = rectifiedFrame2->fb.width * rectifiedFrame2->getBytesPerPixel();
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration version identifier

* **Updates**
  * Modified how source frame buffer dimensions are assigned in the rectification pipeline to align with output frame dimensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->