### PR TITLE
Adding the setter in pipeline for AutoCalibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,19 @@ The following environment variables can be set to alter default behavior of the 
 | DEPTHAI_REPLAY | Replays holistic replay from the specified file or directory. |
 | DEPTHAI_PROFILING | Enables runtime profiling of data transfer between the host and connected devices. Set to 1 to enable. Requires DEPTHAI_LEVEL=debug or lower to print. |
 | DEPTHAI_PIPELINE_DEBUGGING | Enables pipeline debugging with state dumps. DEPTHAI_LEVEL=trace is required to print the state dumps. |
-| DEPTHAI_AUTOCALIBRATION | Runs recalibration of the stereo pair and, by default, flashes successful calibration to non-volatile memory (EEPROM). DEPTHAI_AUTOCALIBRATION=CONTINUOUS: runs check repetitively; DEPTHAI_AUTOCALIBRATION=ON_START: runs calibration only at the start of the pipeline; DEPTHAI_AUTOCALIBRATION=OFF: no recalibration. AutoCalibration currently initializes only for stereo inputs at 1280x800. |
+| DEPTHAI_AUTOCALIBRATION | Runs recalibration of the stereo pair and, by default, flashes successful calibration to non-volatile memory (EEPROM). `CONTINUOUS`: runs check repetitively; `ON_START`: runs calibration only at the start of the pipeline; `OFF`: no recalibration. The same mode can be configured from code with `pipeline.setAutoCalibrationMode(...)` (or `setAutoCalibration(...)` alias). If this environment variable is set, it overrides the pipeline-set value. AutoCalibration currently initializes only for stereo inputs at 1280x800. |
+
+You can set the mode directly on the pipeline:
+
+```cpp
+dai::Pipeline pipeline;
+pipeline.setAutoCalibrationMode(dai::Pipeline::AutoCalibrationMode::ON_START);
+```
+
+```python
+pipeline = dai.Pipeline()
+pipeline.setAutoCalibrationMode(dai.Pipeline.AutoCalibrationMode.ON_START)
+```
 
 ## Running tests
 

--- a/bindings/python/src/pipeline/PipelineBindings.cpp
+++ b/bindings/python/src/pipeline/PipelineBindings.cpp
@@ -71,6 +71,7 @@ void PipelineBindings::bind(pybind11::module& m, void* pCallstack) {
     py::class_<NodesStateApi> nodesStateApi(m, "NodesStateApi", DOC(dai, NodesStateApi));
     py::class_<NodeStateApi> nodeStateApi(m, "NodeStateApi", DOC(dai, NodeStateApi));
     py::class_<Pipeline> pipeline(m, "Pipeline", DOC(dai, Pipeline, 2));
+    py::enum_<Pipeline::AutoCalibrationMode> pipelineAutoCalibrationMode(pipeline, "AutoCalibrationMode");
 
     ///////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////
@@ -84,6 +85,10 @@ void PipelineBindings::bind(pybind11::module& m, void* pCallstack) {
     ///////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////
+
+    pipelineAutoCalibrationMode.value("OFF", Pipeline::AutoCalibrationMode::OFF)
+        .value("ON_START", Pipeline::AutoCalibrationMode::ON_START)
+        .value("CONTINUOUS", Pipeline::AutoCalibrationMode::CONTINUOUS);
 
     // Bind global properties
     globalProperties.def_readwrite("pipelineName", &GlobalProperties::pipelineName).def_readwrite("pipelineVersion", &GlobalProperties::pipelineVersion);
@@ -246,6 +251,10 @@ void PipelineBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("serializeToJson", &Pipeline::serializeToJson, DOC(dai, Pipeline, serializeToJson))
         .def("setBoardConfig", &Pipeline::setBoardConfig, DOC(dai, Pipeline, setBoardConfig))
         .def("getBoardConfig", &Pipeline::getBoardConfig, DOC(dai, Pipeline, getBoardConfig))
+        .def("setAutoCalibration", &Pipeline::setAutoCalibration, py::arg("mode"))
+        .def("getAutoCalibration", &Pipeline::getAutoCalibration)
+        .def("setAutoCalibrationMode", &Pipeline::setAutoCalibrationMode, py::arg("mode"))
+        .def("getAutoCalibrationMode", &Pipeline::getAutoCalibrationMode)
         .def("getDefaultDevice", &Pipeline::getDefaultDevice, DOC(dai, Pipeline, getDefaultDevice))
         // 'Template' create function
         .def(

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -34,6 +34,12 @@ namespace dai {
 
 namespace fs = std::filesystem;
 
+enum class PipelineAutoCalibrationMode : int {
+    OFF = 0,
+    ON_START = 1,
+    CONTINUOUS = 2,
+};
+
 class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
     friend class Pipeline;
     friend class Node;
@@ -99,8 +105,10 @@ class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
     void setSippBufferSize(int sizeBytes);
     void setSippDmaBufferSize(int sizeBytes);
     void setBoardConfig(BoardConfig board);
+    void setAutoCalibrationMode(PipelineAutoCalibrationMode mode);
     std::pair<std::shared_ptr<dai::node::Camera>, std::shared_ptr<dai::node::Camera>> getStereoPair() const;
     bool hasDynamicCalibration() const;
+    PipelineAutoCalibrationMode getAutoCalibrationMode() const;
 
     BoardConfig getBoardConfig() const;
 
@@ -147,6 +155,10 @@ class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
 
     // Board configuration
     BoardConfig board;
+
+    // Build-time automatic calibration policy for implicit AutoCalibration node creation.
+    PipelineAutoCalibrationMode autoCalibrationMode = PipelineAutoCalibrationMode::ON_START;
+    bool autoCalibrationModeSetByApi = false;
 
     // Output queues
     std::vector<std::shared_ptr<MessageQueue>> outputQueues;
@@ -276,6 +288,8 @@ class Pipeline {
     std::shared_ptr<PipelineImpl> pimpl;
 
    public:
+    using AutoCalibrationMode = PipelineAutoCalibrationMode;
+
     PipelineImpl* impl() {
         return pimpl.get();
     }
@@ -517,6 +531,26 @@ class Pipeline {
     /// Sets board configuration
     void setBoardConfig(BoardConfig board) {
         impl()->setBoardConfig(board);
+    }
+
+    /// Sets implicit automatic calibration policy for this pipeline.
+    void setAutoCalibration(AutoCalibrationMode mode) {
+        impl()->setAutoCalibrationMode(mode);
+    }
+
+    /// Gets implicit automatic calibration policy for this pipeline.
+    AutoCalibrationMode getAutoCalibration() const {
+        return impl()->getAutoCalibrationMode();
+    }
+
+    /// Sets implicit automatic calibration policy for this pipeline.
+    void setAutoCalibrationMode(AutoCalibrationMode mode) {
+        impl()->setAutoCalibrationMode(mode);
+    }
+
+    /// Gets implicit automatic calibration policy for this pipeline.
+    AutoCalibrationMode getAutoCalibrationMode() const {
+        return impl()->getAutoCalibrationMode();
     }
 
     /// Gets board configuration

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -25,11 +25,15 @@
 #include "depthai/pipeline/NodeConnectionSchema.hpp"
 
 // std
+#include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cmath>
+#include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <string_view>
 #include <unordered_set>
 
 // libraries
@@ -58,6 +62,33 @@ struct hash<::dai::NodeConnectionSchema> {
 namespace dai {
 
 namespace {
+
+const char* autoCalibrationModeToString(PipelineAutoCalibrationMode mode) {
+    switch(mode) {
+        case PipelineAutoCalibrationMode::OFF:
+            return "OFF";
+        case PipelineAutoCalibrationMode::ON_START:
+            return "ON_START";
+        case PipelineAutoCalibrationMode::CONTINUOUS:
+            return "CONTINUOUS";
+    }
+    return "ON_START";
+}
+
+std::optional<PipelineAutoCalibrationMode> parseAutoCalibrationMode(std::string_view mode) {
+    std::string modeStr(mode);
+    std::transform(modeStr.begin(), modeStr.end(), modeStr.begin(), [](char c) { return static_cast<char>(std::toupper(static_cast<unsigned char>(c))); });
+    if(modeStr == "OFF") {
+        return PipelineAutoCalibrationMode::OFF;
+    }
+    if(modeStr == "ON_START") {
+        return PipelineAutoCalibrationMode::ON_START;
+    }
+    if(modeStr == "CONTINUOUS") {
+        return PipelineAutoCalibrationMode::CONTINUOUS;
+    }
+    return std::nullopt;
+}
 
 #ifdef DEPTHAI_HAVE_DYNAMIC_CALIBRATION_SUPPORT
 bool hasDifferentDistortion(const CalibrationHandler& lhs, const CalibrationHandler& rhs, CameraBoardSocket socket) {
@@ -522,6 +553,16 @@ void PipelineImpl::setBoardConfig(BoardConfig boardCfg) {
     board = boardCfg;
 }
 
+void PipelineImpl::setAutoCalibrationMode(PipelineAutoCalibrationMode mode) {
+    DAI_CHECK_V(!isBuilt(), "Cannot change auto calibration mode once the pipeline is built.");
+    autoCalibrationMode = mode;
+    autoCalibrationModeSetByApi = true;
+}
+
+PipelineAutoCalibrationMode PipelineImpl::getAutoCalibrationMode() const {
+    return autoCalibrationMode;
+}
+
 BoardConfig PipelineImpl::getBoardConfig() const {
     return board;
 }
@@ -740,7 +781,8 @@ bool PipelineImpl::isBuilt() const {
 bool PipelineImpl::hasDynamicCalibration() const {
     // call this only with locked pipelineBuildMutex
     for(const auto& node : getAllNodes()) {
-        if(node->getName() == dai::node::DynamicCalibration::NAME || node->getName() == dai::node::AutoCalibration::NAME) {
+        const auto nodeName = std::string_view(node->getName());
+        if(nodeName == dai::node::DynamicCalibration::NAME || nodeName == dai::node::AutoCalibration::NAME) {
             return true;
         }
     }
@@ -763,7 +805,7 @@ std::pair<std::shared_ptr<dai::node::Camera>, std::shared_ptr<dai::node::Camera>
     std::pair<std::shared_ptr<dai::node::Camera>, std::shared_ptr<dai::node::Camera>> stereoPair = std::pair(nullptr, nullptr);
     // call this only with locked pipelineBuildMutex
     for(const auto& node : getAllNodes()) {
-        if(node->getName() == dai::node::Camera::NAME) {
+        if(std::string_view(node->getName()) == dai::node::Camera::NAME) {
             auto camera = std::static_pointer_cast<dai::node::Camera>(node);
             auto boardSocket = camera->getBoardSocket();
             if(boardSocket == stereoSockets[0].left) {
@@ -785,9 +827,24 @@ void PipelineImpl::build() {
 
     // start ---Add AutoCalibration block---
 #ifdef DEPTHAI_HAVE_DYNAMIC_CALIBRATION_SUPPORT
-    auto autoCalibrationString = utility::getEnvAs<std::string>("DEPTHAI_AUTOCALIBRATION", "ON_START");
+    const auto pipelineAutoCalibrationMode = getAutoCalibrationMode();
+    const auto pipelineAutoCalibrationString = std::string(autoCalibrationModeToString(pipelineAutoCalibrationMode));
+    std::string autoCalibrationString = pipelineAutoCalibrationString;
+    std::optional<PipelineAutoCalibrationMode> autoCalibrationMode = pipelineAutoCalibrationMode;
+    if(!autoCalibrationModeSetByApi) {
+        autoCalibrationString = utility::getEnvAs<std::string>("DEPTHAI_AUTOCALIBRATION", "");
+        if(!autoCalibrationString.empty()) {
+            autoCalibrationMode = parseAutoCalibrationMode(autoCalibrationString);
+        }
+    }
     #ifndef DEPTHAI_INTERNAL_DEVICE_BUILD_RVC4
-    if(autoCalibrationString == "CONTINUOUS" || autoCalibrationString == "ON_START") {
+    if((autoCalibrationMode == PipelineAutoCalibrationMode::CONTINUOUS || autoCalibrationMode == PipelineAutoCalibrationMode::ON_START)
+       && hasDynamicCalibration()) {
+        Logging::getInstance().logger.info("Pipeline contains DynamicCalibration/AutoCalibration node. Disabling implicit AutoCalibration at startup.");
+        autoCalibrationMode = PipelineAutoCalibrationMode::OFF;
+    }
+
+    if(autoCalibrationMode == PipelineAutoCalibrationMode::CONTINUOUS || autoCalibrationMode == PipelineAutoCalibrationMode::ON_START) {
         if(defaultDevice && defaultDevice->tryGetCalibration()) {
             auto stereoPair = getStereoPair();
 
@@ -811,7 +868,7 @@ void PipelineImpl::build() {
                 }
             };
 
-            if(stereoPair.first && stereoPair.second && !hasDynamicCalibration() && hasStereoPairValidCalibration(defaultDevice->tryGetCalibration())) {
+            if(stereoPair.first && stereoPair.second && hasStereoPairValidCalibration(defaultDevice->tryGetCalibration())) {
                 auto autoCalibrationNode = create<dai::node::AutoCalibration>(shared_from_this())->build(stereoPair.first, stereoPair.second);
                 Logging::getInstance().logger.info("AutoCalibration is initialized");
 
@@ -851,7 +908,7 @@ void PipelineImpl::build() {
                 }
                 autoCalibrationNode->initialConfig->flashCalibration = allowFlashCalibration;
 
-                if(autoCalibrationString == "CONTINUOUS") {
+                if(autoCalibrationMode == PipelineAutoCalibrationMode::CONTINUOUS) {
                     autoCalibrationNode->initialConfig->mode = dai::AutoCalibrationConfig::Mode::CONTINUOUS;
                 } else {
                     autoCalibrationNode->initialConfig->mode = dai::AutoCalibrationConfig::Mode::ON_START;
@@ -865,8 +922,8 @@ void PipelineImpl::build() {
                 Logging::getInstance().logger.info("Device has no valid initial calibration. Skipping autocalibration.");
             }
         }
-    } else if(autoCalibrationString != "OFF" && autoCalibrationString != "") {
-        Logging::getInstance().logger.info("DEPTHAI_AUTOCALIBRATION can be CONTINUOUS, ON_START or OFF not {}", autoCalibrationString);
+    } else if(!autoCalibrationMode && !autoCalibrationString.empty()) {
+        Logging::getInstance().logger.warn("DEPTHAI_AUTOCALIBRATION can be CONTINUOUS, ON_START or OFF not {}", autoCalibrationString);
     }
     #endif
 #endif


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pipeline auto‑calibration modes (OFF, ON_START, CONTINUOUS) with public API and Python enum/methods to set/get the mode.

* **Documentation**
  * README updated: supported values formatted inline, C++/Python examples added, and env var precedence clarified.

* **Bug Fixes**
  * Invalid env values now warn; setting mode blocked after pipeline build; startup logic adjusted to avoid duplicate calibration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->