### PR TITLE
Lower the tolerance

### DIFF
--- a/tests/src/ondevice_tests/pipeline/node/detection_parser_test.cpp
+++ b/tests/src/ondevice_tests/pipeline/node/detection_parser_test.cpp
@@ -61,7 +61,7 @@ void validateDetections(const std::shared_ptr<dai::ImgDetections>& detections, c
     REQUIRE(detections != nullptr);
     REQUIRE(detections->detections.size() == gtDetections.size());
 
-    constexpr float tolerance = 1e-4F;
+    constexpr float tolerance = 1e-3F;
 
     struct GroundTruthDetection {
         struct KeypointCoord {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
With SNPE 2.41 the outputs of YOLO-P model changed on the third decimal making the test to fail. This PR lowers the tolerance to 1e-3F to make the test pass. 
 
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable