### PR TITLE
Downgrade OS for fsync

### DIFF
--- a/.github/workflows/test.workflow.yml
+++ b/.github/workflows/test.workflow.yml
@@ -57,7 +57,7 @@ jobs:
       luxonis_os_versions_to_test: "['1.20.5','1.27.1','1.30.1']"
       luxonis_os_versions_to_test_rgb: "['1.30.1']"
       luxonis_os_versions_to_test_usb: "['1.30.1']"
-      luxonis_os_versions_to_test_fsync: "['1.30.1']"
+      luxonis_os_versions_to_test_fsync: "['1.27.1']"
       luxonis_os_versions_to_test_ptp: "['1.30.1']"
     secrets:
       CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}


### PR DESCRIPTION
Downgrade the OS for multi device fsync tests due to a bug.
The bug is due to M8 gpio detect pin on fsync splitter and agentconfd interaction.
The bug causes the usb to be constantly muxed from USB to M8 and back.