### PR TITLE
Remove implicit node instantiation in Python

### DIFF
--- a/bindings/python/src/pipeline/PipelineBindings.cpp
+++ b/bindings/python/src/pipeline/PipelineBindings.cpp
@@ -43,6 +43,7 @@
 
 // depthai/
 #include <memory>
+#include <stdexcept>
 
 #include "depthai/properties/GlobalProperties.hpp"
 #include "depthai/utility/RecordReplay.hpp"
@@ -294,10 +295,10 @@ void PipelineBindings::bind(pybind11::module& m, void* pCallstack) {
                     std::shared_ptr<Node> hostNode;
                     try {
                         hostNode = py::cast<std::shared_ptr<node::ThreadedHostNode>>(class_(*args, **kwargs));
-                    } catch(...) {
+                    } catch(std::runtime_error& e) {
                         delCreatingNodeFromPipelineCreate();
                         delImplicitPipeline();
-                        throw;
+                        throw std::runtime_error(std::string("Error creating node: ") + e.what());
                     }
                     delCreatingNodeFromPipelineCreate();
                     delImplicitPipeline();

--- a/bindings/python/src/pipeline/node/ColorCameraBindings.cpp
+++ b/bindings/python/src/pipeline/node/ColorCameraBindings.cpp
@@ -91,11 +91,7 @@ void bind_colorcamera(pybind11::module& m, void* pCallstack) {
         .def_readwrite("warpMeshStepHeight", &ColorCameraProperties::warpMeshStepHeight)
         .def_readwrite("eventFilter", &ColorCameraProperties::eventFilter);
     // ColorCamera node
-    colorCamera
-        .def(py::init([]() {
-            auto camera = getImplicitPipeline()->create<ColorCamera>();
-            return camera;
-        }))
+    colorCamera.def(py::init())
         .def_readonly("inputControl", &ColorCamera::inputControl, DOC(dai, node, ColorCamera, inputControl))
         .def_readonly("initialControl", &ColorCamera::initialControl, DOC(dai, node, ColorCamera, initialControl))
         .def_readonly("video", &ColorCamera::video, DOC(dai, node, ColorCamera, video))

--- a/bindings/python/src/pipeline/node/DetectionNetworkBindings.cpp
+++ b/bindings/python/src/pipeline/node/DetectionNetworkBindings.cpp
@@ -126,15 +126,7 @@ void bind_detectionnetwork(pybind11::module& m, void* pCallstack) {
             py::arg("fps") = std::nullopt,
             DOC(dai, node, DetectionNetwork, build, 4))
 #endif
-        .def(py::init([](DETECTION_NETWORK_BUILD_ARGS, DETECTION_NETWORK_ARGS) {
-                 auto self = getImplicitPipeline()->create<DetectionNetwork>();
-                 self->build(input, nnArchive);
-                 DETECTION_NETWORK_CODE(->)
-                 return self;
-             }),
-             DETECTION_NETWORK_BUILD_PYARGS,
-             DETECTION_NETWORK_PYARGS)
-        // Copied from NN node
+        .def(py::init<const std::shared_ptr<Device>&>(), py::arg("device"))
         .def("setBlobPath", &DetectionNetwork::setBlobPath, py::arg("path"), DOC(dai, node, DetectionNetwork, setBlobPath))
         .def("setNumPoolFrames", &DetectionNetwork::setNumPoolFrames, py::arg("numFrames"), DOC(dai, node, DetectionNetwork, setNumPoolFrames))
         .def("setNumInferenceThreads",

--- a/bindings/python/src/pipeline/node/StereoDepthBindings.cpp
+++ b/bindings/python/src/pipeline/node/StereoDepthBindings.cpp
@@ -83,22 +83,7 @@ void bind_stereodepth(pybind11::module& m, void* pCallstack) {
         .value("ACCURACY", StereoDepth::PresetMode::ACCURACY);
 
     // Node
-    stereoDepth
-        .def(py::init([](Node::Output& left, Node::Output& right, StereoDepth::PresetMode presetMode) {
-                 auto self = getImplicitPipeline()->create<StereoDepth>();
-                 self->build(left, right, presetMode);
-                 return self;
-             }),
-             py::arg("left"),
-             py::arg("right"),
-             py::arg("presetMode") = StereoDepth::PresetMode::DEFAULT)
-        .def(py::init([](bool autoCreateCameras, StereoDepth::PresetMode presetMode) {
-                 auto self = getImplicitPipeline()->create<StereoDepth>();
-                 self->build(autoCreateCameras, presetMode);
-                 return self;
-             }),
-             py::arg("autoCreateCameras"),
-             py::arg("presetMode") = StereoDepth::PresetMode::DEFAULT)
+    stereoDepth.def(py::init<>())
         .def("build",
              static_cast<std::shared_ptr<StereoDepth> (StereoDepth::*)(Node::Output&, Node::Output&, StereoDepth::PresetMode)>(&StereoDepth::build),
              py::arg("left"),

--- a/bindings/python/src/pipeline/node/VideoEncoderBindings.cpp
+++ b/bindings/python/src/pipeline/node/VideoEncoderBindings.cpp
@@ -74,14 +74,7 @@ void bind_videoencoder(pybind11::module& m, void* pCallstack) {
             },
             VIDEO_ENCODER_BUILD_PYARGS,
             VIDEO_ENCODER_PYARGS)
-        .def(py::init([](VIDEO_ENCODER_BUILD_ARGS, VIDEO_ENCODER_ARGS) {
-                 auto self = getImplicitPipeline()->create<VideoEncoder>();
-                 self->build(input);
-                 VIDEO_ENCODER_CODE(->)
-                 return self;
-             }),
-             VIDEO_ENCODER_BUILD_PYARGS,
-             VIDEO_ENCODER_PYARGS)
+        .def(py::init<>())
         .def_readonly("input", &VideoEncoder::input, DOC(dai, node, VideoEncoder, input), DOC(dai, node, VideoEncoder, input))
         .def_readonly("bitstream", &VideoEncoder::bitstream, DOC(dai, node, VideoEncoder, bitstream), DOC(dai, node, VideoEncoder, bitstream))
         .def_readonly("out", &VideoEncoder::out, DOC(dai, node, VideoEncoder, out), DOC(dai, node, VideoEncoder, out))

--- a/include/depthai/pipeline/node/DetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/DetectionNetwork.hpp
@@ -20,7 +20,7 @@ namespace node {
  */
 class DetectionNetwork : public DeviceNodeGroup {
    public:
-    DetectionNetwork(const std::shared_ptr<Device>& device);
+    explicit DetectionNetwork(const std::shared_ptr<Device>& device);
     using Model = NeuralNetwork::Model;
 
     [[nodiscard]] static std::shared_ptr<DetectionNetwork> create(const std::shared_ptr<Device>& device) {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
This PR removes the following deprecated feature:
``` 
with dai.Pipeline as pipeline:
    myNode = Node()
```
The only exception is (Threaded)HostNodes as they might require implicit pipeline in their init() methods as in the case of ParsingNeuralNetwork:
```
class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
    def __init__(self, *args, **kwargs) -> None:
        super().__init__(*args, **kwargs) # Calls ThreadedHostNode.__init__(), which adds this node to the pipeline making getParentPipeline() available
        self._pipeline = self.getParentPipeline()
        self._nn = self._pipeline.create(dai.node.NeuralNetwork)
        self._parsers: Dict[int, BaseParser] = {}
```

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested by running a couple of oak-examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in node creation with more informative error messages and improved resource cleanup.

* **API Changes**
  * Simplified constructors for ColorCamera, DetectionNetwork, StereoDepth, and VideoEncoder nodes. Users now initialize these nodes without arguments and configure them explicitly using dedicated methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->