### PR TITLE
Fix/ptp test change test cases

### DIFF
--- a/tests/include/fsync_ptp_test_utils.hpp
+++ b/tests/include/fsync_ptp_test_utils.hpp
@@ -56,7 +56,8 @@ void setUpCameraSocket(std::shared_ptr<dai::Pipeline>& pipeline,
                        std::optional<dai::ExternalFrameSyncRole> role,
                        std::optional<std::map<std::string, dai::Node::Output*>>& masterNode,
                        std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>>& slaveQueues,
-                       std::vector<std::string>& camSockets);
+                       std::vector<std::string>& camSockets,
+                       std::string &ptpMasterDeviceName);
 
 void setUpIrLeds(std::shared_ptr<dai::Device> device);
 
@@ -68,6 +69,7 @@ void setupDevice(dai::DeviceInfo& deviceInfo,
                  std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>>& slaveQueues,
                  std::vector<std::string>& camSockets,
                  float targetFps,
-                 SyncType syncType);
+                 SyncType syncType,
+                 std::string &ptpMasterDeviceName);
 
 int testFsync(float targetFps, struct FsyncTestParameters parameters);

--- a/tests/src/onhost_tests/multi_device_ptp_test.cpp
+++ b/tests/src/onhost_tests/multi_device_ptp_test.cpp
@@ -6,7 +6,7 @@
 TEST_CASE("Test Multi-device PTP frame sync with different FPS values", "[ptp]") {
     // auto fps = GENERATE(10.0f, 13.0f, 18.5f, 30.0f, 60.0f, 120.0f, 240.0f, 300.0f, 600.0f);
     // 60 FPS does not work as of 1.30.1
-    auto fps = GENERATE(10.0f, 13.0f, 18.5f, 30.0f, 45.0f);
+    auto fps = GENERATE(10.0f, 15.0f, 18.5f, 30.0f, 45.0f);
     CAPTURE(fps);
     struct FsyncTestParameters parameters {};
     parameters.syncThresholdSec = 1 / (2 * fps);  // lower this limit when we have better accuracy for timestamps

--- a/tests/src/onhost_tests/utility/fsync_ptp_test_utils.cpp
+++ b/tests/src/onhost_tests/utility/fsync_ptp_test_utils.cpp
@@ -183,7 +183,8 @@ void setUpCameraSocket(std::shared_ptr<dai::Pipeline>& pipeline,
                        std::optional<dai::ExternalFrameSyncRole> role,
                        std::optional<std::map<std::string, dai::Node::Output*>>& masterNode,
                        std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>>& slaveQueues,
-                       std::vector<std::string>& camSockets) {
+                       std::vector<std::string>& camSockets,
+                       std::string &ptpMasterDeviceName) {
     auto outNode = createPipeline(pipeline, socket, targetFps, syncType, role);
 
     if(syncType == SyncType::EXTERNAL) {
@@ -207,6 +208,9 @@ void setUpCameraSocket(std::shared_ptr<dai::Pipeline>& pipeline,
         // Actual PTP master might be different, but it doesn't matter for this test.
         if(!masterNode.has_value()) {
             masterNode.emplace();
+            ptpMasterDeviceName = name;
+        }
+        if (ptpMasterDeviceName == name) {
             masterNode.value().emplace(dai::toString(socket), outNode);
         } else {
             if(slaveQueues.find(name) == slaveQueues.end()) {
@@ -255,7 +259,8 @@ void setupDevice(dai::DeviceInfo& deviceInfo,
                  std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>>& slaveQueues,
                  std::vector<std::string>& camSockets,
                  float targetFps,
-                 SyncType syncType) {
+                 SyncType syncType,
+                 std::string &ptpMasterDeviceName) {
     auto pipeline = std::make_shared<dai::Pipeline>(std::make_shared<dai::Device>(deviceInfo));
     auto device = pipeline->getDefaultDevice();
 
@@ -274,7 +279,7 @@ void setupDevice(dai::DeviceInfo& deviceInfo,
     std::cout << "    Num of cameras: " << device->getConnectedCameras().size() << std::endl;
 
     for(auto socket : device->getConnectedCameras()) {
-        setUpCameraSocket(pipeline, socket, name, targetFps, syncType, role, masterNode, slaveQueues, camSockets);
+        setUpCameraSocket(pipeline, socket, name, targetFps, syncType, role, masterNode, slaveQueues, camSockets, ptpMasterDeviceName);
     }
 
     setUpIrLeds(device);
@@ -330,8 +335,10 @@ int testFsync(float targetFps, struct FsyncTestParameters parameters) {
     std::vector<std::string> outputNames;
     std::vector<std::string> camSockets;
 
+    std::string ptpMasterDeviceName = "";
+
     for(auto deviceInfo : deviceInfos) {
-        setupDevice(deviceInfo, masterPipeline, masterNode, masterName, slavePipelines, slaveQueues, camSockets, targetFps, parameters.syncType);
+        setupDevice(deviceInfo, masterPipeline, masterNode, masterName, slavePipelines, slaveQueues, camSockets, targetFps, parameters.syncType, ptpMasterDeviceName);
     }
 
     if(masterPipeline == nullptr || !masterNode.has_value() || !masterName.has_value()) {


### PR DESCRIPTION
Remove 13 FPS due to consistent failing.
Add 15 FPS

Fix a logic error in PTP tests when using multiple sensors per device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved multi-device synchronization testing with enhanced PTP master device selection
  * Updated test parameters to better validate timing thresholds in synchronization scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->