### PR TITLE
fix: guard memcpy against null pointer in PointCloudData

### DIFF
--- a/src/pipeline/datatype/PointCloudData.cpp
+++ b/src/pipeline/datatype/PointCloudData.cpp
@@ -58,7 +58,9 @@ std::vector<Point3fRGBA> PointCloudData::getPointsRGB() const {
 void PointCloudData::setPoints(const std::vector<Point3f>& points) {
     auto size = points.size();
     std::vector<uint8_t> data(size * sizeof(Point3f));
-    std::memcpy(data.data(), points.data(), size * sizeof(Point3f));
+    if(size > 0) {
+        std::memcpy(data.data(), points.data(), size * sizeof(Point3f));
+    }
     setData(std::move(data));
     setColor(false);
 }
@@ -66,7 +68,9 @@ void PointCloudData::setPoints(const std::vector<Point3f>& points) {
 void PointCloudData::setPointsRGB(const std::vector<Point3fRGBA>& points) {
     auto size = points.size();
     std::vector<uint8_t> data(size * sizeof(Point3fRGBA));
-    std::memcpy(data.data(), points.data(), size * sizeof(Point3fRGBA));
+    if(size > 0) {
+        std::memcpy(data.data(), points.data(), size * sizeof(Point3fRGBA));
+    }
     setData(std::move(data));
     setColor(true);
 }


### PR DESCRIPTION
`setPoints()` and `setPointsRGB()` pass a null pointer to `std::memcpy` when given an empty vector,
which is undefined behavior even when size is 0.

Caught by UBSan (`pointclouddata_test`):

runtime error: null pointer passed as argument 1, which is declared to never be null

Fix: skip `memcpy` when the vector is empty.