### PR TITLE
Release 3.6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
 endif()
 
 # Create depthai project
-project(depthai VERSION "3.6.0" LANGUAGES CXX C)
+project(depthai VERSION "3.6.1" LANGUAGES CXX C)
 set(DEPTHAI_PRE_RELEASE_TYPE "") # Valid options are "alpha", "beta", "rc", ""
 set(DEPTHAI_PRE_RELEASE_VERSION "0") # Valid options are "0", "1", "2", ...
 

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -328,13 +328,30 @@ function(vcpkg_set_version_checkout)
     execute_process(COMMAND git for-each-ref refs/tags/ --count=1 --sort=-creatordate --format=%\(refname:short\) WORKING_DIRECTORY "${VCPKG_DIRECTORY_EXPLICIT}" OUTPUT_VARIABLE VCPKG_GIT_TAG_LATEST)
     string(REGEX REPLACE "\n$" "" VCPKG_GIT_TAG_LATEST "${VCPKG_GIT_TAG_LATEST}")
 
-    # resolve versions
-    if(EXISTS "./vcpkg.json")
+    # Resolve versions. Use absolute manifest paths because relative paths here
+    # depend on the current CMake working directory, which may be a build dir.
+    set(VCPKG_MANIFEST_PATH "")
+    foreach(VCPKG_MANIFEST_CANDIDATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg.json"
+        "${CMAKE_SOURCE_DIR}/vcpkg.json"
+        "${CMAKE_CURRENT_BINARY_DIR}/vcpkg.json"
+        "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../vcpkg.json"
+    )
+        if(EXISTS "${VCPKG_MANIFEST_CANDIDATE}")
+            get_filename_component(VCPKG_MANIFEST_PATH "${VCPKG_MANIFEST_CANDIDATE}" ABSOLUTE)
+            break()
+        endif()
+    endforeach()
+
+    if(VCPKG_MANIFEST_PATH)
         # set hash from vcpkg.json manifest
-        file(READ "./vcpkg.json" VCPKG_MANIFEST_CONTENTS)
+        file(READ "${VCPKG_MANIFEST_PATH}" VCPKG_MANIFEST_CONTENTS)
 
         if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
-            string(JSON VCPKG_BASELINE GET "${VCPKG_MANIFEST_CONTENTS}" "builtin-baseline")
+            string(JSON VCPKG_BASELINE ERROR_VARIABLE VCPKG_BASELINE_ERROR GET "${VCPKG_MANIFEST_CONTENTS}" "builtin-baseline")
+            if(VCPKG_BASELINE_ERROR)
+                set(VCPKG_BASELINE "")
+            endif()
         else()
             string(REGEX REPLACE "[\n ]" "" VCPKG_MANIFEST_CONTENTS "${VCPKG_MANIFEST_CONTENTS}")
             string(REGEX MATCH "\"builtin-baseline\":\"[0-9a-f]+\"" VCPKG_BASELINE "${VCPKG_MANIFEST_CONTENTS}")
@@ -347,7 +364,7 @@ function(vcpkg_set_version_checkout)
                 message(WARNING "VCPKG_VERSION was specified, but vcpkg.json manifest is used and specifies a builtin-baseline; using builtin-baseline: ${VCPKG_BASELINE}")
             endif()
             set(VCPKG_VERSION_EXPLICIT "${VCPKG_BASELINE}")
-            message(STATUS "Using VCPKG Version: <manifest builtin-baseline>")
+            message(STATUS "Using VCPKG Version: <manifest builtin-baseline> (${VCPKG_MANIFEST_PATH})")
         endif()
     endif()
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes the build of v3.6.0 which always picked up the latest vcpkg tool.
This pins down a sepcific version of the tool more robustly.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 3.6.1
  * Enhanced build system reliability and package version resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->