### PR TITLE
Remove setAutoCalibration and getAutoCalibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The following environment variables can be set to alter default behavior of the 
 | DEPTHAI_REPLAY | Replays holistic replay from the specified file or directory. |
 | DEPTHAI_PROFILING | Enables runtime profiling of data transfer between the host and connected devices. Set to 1 to enable. Requires DEPTHAI_LEVEL=debug or lower to print. |
 | DEPTHAI_PIPELINE_DEBUGGING | Enables pipeline debugging with state dumps. DEPTHAI_LEVEL=trace is required to print the state dumps. |
-| DEPTHAI_AUTOCALIBRATION | Runs recalibration of the stereo pair and, by default, flashes successful calibration to non-volatile memory (EEPROM). `CONTINUOUS`: runs check repetitively; `ON_START`: runs calibration only at the start of the pipeline; `OFF`: no recalibration. The same mode can be configured from code with `pipeline.setAutoCalibrationMode(...)` (or `setAutoCalibration(...)` alias). If this environment variable is set, it overrides the pipeline-set value. AutoCalibration currently initializes only for stereo inputs at 1280x800. |
+| DEPTHAI_AUTOCALIBRATION | Runs recalibration of the stereo pair and, by default, flashes successful calibration to non-volatile memory (EEPROM). `CONTINUOUS`: runs check repetitively; `ON_START`: runs calibration only at the start of the pipeline; `OFF`: no recalibration. The same mode can be configured from code with `pipeline.setAutoCalibrationMode(...)`. If this environment variable is set, it overrides the pipeline-set value. AutoCalibration currently initializes only for stereo inputs at 1280x800. |
 
 ## Running tests
 

--- a/bindings/python/src/pipeline/PipelineBindings.cpp
+++ b/bindings/python/src/pipeline/PipelineBindings.cpp
@@ -251,8 +251,6 @@ void PipelineBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("serializeToJson", &Pipeline::serializeToJson, DOC(dai, Pipeline, serializeToJson))
         .def("setBoardConfig", &Pipeline::setBoardConfig, DOC(dai, Pipeline, setBoardConfig))
         .def("getBoardConfig", &Pipeline::getBoardConfig, DOC(dai, Pipeline, getBoardConfig))
-        .def("setAutoCalibration", &Pipeline::setAutoCalibration, py::arg("mode"))
-        .def("getAutoCalibration", &Pipeline::getAutoCalibration)
         .def("setAutoCalibrationMode", &Pipeline::setAutoCalibrationMode, py::arg("mode"))
         .def("getAutoCalibrationMode", &Pipeline::getAutoCalibrationMode)
         .def("getDefaultDevice", &Pipeline::getDefaultDevice, DOC(dai, Pipeline, getDefaultDevice))

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -534,16 +534,6 @@ class Pipeline {
     }
 
     /// Sets implicit automatic calibration policy for this pipeline.
-    void setAutoCalibration(AutoCalibrationMode mode) {
-        impl()->setAutoCalibrationMode(mode);
-    }
-
-    /// Gets implicit automatic calibration policy for this pipeline.
-    AutoCalibrationMode getAutoCalibration() const {
-        return impl()->getAutoCalibrationMode();
-    }
-
-    /// Sets implicit automatic calibration policy for this pipeline.
     void setAutoCalibrationMode(AutoCalibrationMode mode) {
         impl()->setAutoCalibrationMode(mode);
     }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Auto-calibration API methods renamed in C++ and Python: `setAutoCalibration()` → `setAutoCalibrationMode()` and `getAutoCalibration()` → `getAutoCalibrationMode()`. Update your code accordingly.

* **Documentation**
  * Enhanced environment variable documentation with clarified auto-calibration mode descriptions and updated method references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->