### PR TITLE
Fix: Backwards compatibility of remapPointTo

### DIFF
--- a/src/pipeline/datatype/ImgTransformations.cpp
+++ b/src/pipeline/datatype/ImgTransformations.cpp
@@ -9,6 +9,7 @@
 #include <depthai/utility/matrixOps.hpp>
 #include <vector>
 
+#include "common/CameraBoardSocket.hpp"
 #include "depthai/common/CameraModel.hpp"
 #include "depthai/common/Point2f.hpp"
 #include "depthai/common/Point3f.hpp"
@@ -55,12 +56,13 @@ dai::Point2f interSourceFrameTransform(dai::Point2f sourcePt, const ImgTransform
 
     std::array<float, 3> normalizedUndistortedRay = pixelToRay(sourcePt, from);
 
-    const std::array<std::array<float, 4>, 4> extriniscTransformation = from.getExtrinsicsTransformationMatrixTo(to);
+    std::array<std::array<float, 3>, 3> rotationMatrix = {{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}};
+    if(from.getExtrinsics().toCameraSocket != dai::CameraBoardSocket::AUTO && to.getExtrinsics().toCameraSocket != dai::CameraBoardSocket::AUTO) {
+        const std::array<std::array<float, 4>, 4> extriniscTransformation = from.getExtrinsicsTransformationMatrixTo(to);
+        rotationMatrix = matrix::getRotationMatrixFromProjection4x4(extriniscTransformation);
+    }
 
-    std::array<std::array<float, 3>, 3> rotationMatrix = matrix::getRotationMatrixFromProjection4x4(extriniscTransformation);
-
-    const std::array<float, 3> rectifiedRay = matrix::matVecMul(rotationMatrix, normalizedUndistortedRay);
-
+    std::array<float, 3> rectifiedRay = matrix::matVecMul(rotationMatrix, normalizedUndistortedRay);
     return rayToPixel(rectifiedRay, to);
 }
 

--- a/src/pipeline/datatype/ImgTransformations.cpp
+++ b/src/pipeline/datatype/ImgTransformations.cpp
@@ -9,7 +9,7 @@
 #include <depthai/utility/matrixOps.hpp>
 #include <vector>
 
-#include "common/CameraBoardSocket.hpp"
+#include "depthai/common/CameraBoardSocket.hpp"
 #include "depthai/common/CameraModel.hpp"
 #include "depthai/common/Point2f.hpp"
 #include "depthai/common/Point3f.hpp"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

In <= 3.5.0 the default behavior for `ImgTransformations::remapPointTo` was to assume the remapping was performed on the same optical frame because extrinsics were not tracked. This PR re-introduces this behavior for the cases where recording were made with depthai <= 3.5.0 or only a video (without metadata) is being replayed. In those cases fallback to indentity rotation instead of throwing:
```Node threw exception, stopping the node. Exception message: Cannot get extrinsics transformation to or from an extrinsics with AUTO camera socket. Please specify the camera socket for both extrinsics.```

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
