### PR TITLE
Buxfix/align runtime calibration change

### DIFF
--- a/src/pipeline/node/ImageAlign.cpp
+++ b/src/pipeline/node/ImageAlign.cpp
@@ -353,10 +353,42 @@ void ImageAlign::run() {
     auto latestConfig = initialConfig;
 
     int previousShiftFactor = 0;
+    bool refreshAlignToTransform = false;
 
     ImgTransformation inputAlignToTransform;
     ImgFrame inputAlignToImgFrame;
     uint32_t currentEepromId = getParentPipeline().getEepromId();
+
+    auto updateAlignToData = [&](const std::shared_ptr<ImgFrame>& inputAlignToImg) {
+        inputAlignToImgFrame = *inputAlignToImg;
+
+        auto alignTransform = inputAlignToImg->transformation;
+        const auto alignToDistortion = alignTransform.getDistortionCoefficients();
+        const bool hasDistortion = std::any_of(alignToDistortion.begin(), alignToDistortion.end(), [](float value) { return std::abs(value) > 0.0f; });
+        if(hasDistortion) {
+            logger->warn(
+                "The input connected to inputAlignTo is distorted. The aligned image will still be undistorted, meaning it won't be perfectly "
+                "aligned.");
+        }
+
+        alignTo = static_cast<CameraBoardSocket>(inputAlignToImg->getInstanceNum());
+        if(alignWidth == 0 || alignHeight == 0) {
+            alignWidth = inputAlignToImg->getWidth();
+            alignHeight = inputAlignToImg->getHeight();
+        }
+
+        auto alignTransformForIntrinsics = alignTransform;
+        auto [alignTransformWidth, alignTransformHeight] = alignTransformForIntrinsics.getSize();
+        if(static_cast<int>(alignTransformWidth) != alignWidth || static_cast<int>(alignTransformHeight) != alignHeight) {
+            float scaleX = static_cast<float>(alignWidth) / static_cast<float>(alignTransformWidth);
+            float scaleY = static_cast<float>(alignHeight) / static_cast<float>(alignTransformHeight);
+            alignTransformForIntrinsics.addScale(scaleX, scaleY);
+            alignTransformForIntrinsics.setSize(alignWidth, alignHeight);
+        }
+
+        alignSourceIntrinsics = alignTransformForIntrinsics.getIntrinsicMatrix();
+        inputAlignToTransform = alignTransformForIntrinsics;
+    };
 
     while(mainLoop()) {
         std::shared_ptr<ImgFrame> inputImg = nullptr;
@@ -371,35 +403,7 @@ void ImageAlign::run() {
                 initialized = true;
 
                 auto inputAlignToImg = inputAlignTo.get<ImgFrame>();
-
-                inputAlignToImgFrame = *inputAlignToImg;
-
-                inputAlignToTransform = inputAlignToImg->transformation;
-                const auto alignToDistortion = inputAlignToTransform.getDistortionCoefficients();
-                const bool hasDistortion = std::any_of(alignToDistortion.begin(), alignToDistortion.end(), [](float value) { return std::abs(value) > 0.0f; });
-                if(hasDistortion) {
-                    logger->warn(
-                        "The input connected to inputAlignTo is distorted. The aligned image will still be undistorted, meaning it won't be perfectly "
-                        "aligned.");
-                }
-
-                alignTo = static_cast<CameraBoardSocket>(inputAlignToImg->getInstanceNum());
-                if(alignWidth == 0 || alignHeight == 0) {
-                    alignWidth = inputAlignToImg->getWidth();
-                    alignHeight = inputAlignToImg->getHeight();
-                }
-
-                auto alignTransformForIntrinsics = inputAlignToTransform;
-                auto [alignTransformWidth, alignTransformHeight] = alignTransformForIntrinsics.getSize();
-                if(static_cast<int>(alignTransformWidth) != alignWidth || static_cast<int>(alignTransformHeight) != alignHeight) {
-                    float scaleX = static_cast<float>(alignWidth) / static_cast<float>(alignTransformWidth);
-                    float scaleY = static_cast<float>(alignHeight) / static_cast<float>(alignTransformHeight);
-                    alignTransformForIntrinsics.addScale(scaleX, scaleY);
-                    alignTransformForIntrinsics.setSize(alignWidth, alignHeight);
-                }
-
-                alignSourceIntrinsics = alignTransformForIntrinsics.getIntrinsicMatrix();
-                inputAlignToTransform = alignTransformForIntrinsics;
+                updateAlignToData(inputAlignToImg);
             }
 
             if(inputConfig.getWaitForMessage()) {
@@ -451,8 +455,20 @@ void ImageAlign::run() {
         if(latestEepromId > currentEepromId) {
             logger->debug("EEPROM data changed (ID: {} -> {}), reconfiguring ...", currentEepromId, latestEepromId);
             calibrationSet = false;
+            previousShiftFactor = 0;
+            refreshAlignToTransform = true;
             calibHandler = pipeline.getCalibrationData();
             currentEepromId = latestEepromId;
+        }
+
+        if(refreshAlignToTransform) {
+            if(auto latestAlignToImg = inputAlignTo.tryGet<ImgFrame>()) {
+                updateAlignToData(latestAlignToImg);
+                refreshAlignToTransform = false;
+            } else {
+                logger->trace("Waiting for updated inputAlignTo frame after calibration change.");
+                continue;
+            }
         }
 
         try {

--- a/tests/src/ondevice_tests/image_align_node_test.cpp
+++ b/tests/src/ondevice_tests/image_align_node_test.cpp
@@ -11,6 +11,66 @@ using namespace std::chrono;
 using namespace std::chrono_literals;
 
 namespace {
+constexpr auto kRuntimeCalibrationFrameTimeout = 180;
+constexpr auto kRuntimeCalibrationShiftPx = 40.0f;
+constexpr auto kRuntimeCalibrationVerificationFrames = 20;
+
+bool approxEqual(float a, float b, float absTol = 1e-4f, float relTol = 1e-4f) {
+    return std::abs(a - b) <= (absTol + relTol * std::max(std::abs(a), std::abs(b)));
+}
+
+bool sameIntrinsics(const std::array<std::array<float, 3>, 3>& lhs, const std::array<std::array<float, 3>, 3>& rhs) {
+    for(size_t i = 0; i < lhs.size(); ++i) {
+        for(size_t j = 0; j < lhs[i].size(); ++j) {
+            if(!approxEqual(lhs[i][j], rhs[i][j])) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+std::shared_ptr<dai::ImgFrame> waitForFrameAlignedTo(
+    const std::shared_ptr<dai::MessageQueue>& queue, const dai::ImgTransformation& transformation, size_t maxFrames = kRuntimeCalibrationFrameTimeout) {
+    for(size_t i = 0; i < maxFrames; ++i) {
+        auto frame = queue->get<dai::ImgFrame>();
+        if(frame != nullptr && frame->transformation.isAlignedTo(transformation)) {
+            return frame;
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<dai::ImgFrame> waitForFrameWithChangedTransform(
+    const std::shared_ptr<dai::MessageQueue>& queue, const dai::ImgTransformation& baseline, size_t maxFrames = kRuntimeCalibrationFrameTimeout) {
+    for(size_t i = 0; i < maxFrames; ++i) {
+        auto frame = queue->get<dai::ImgFrame>();
+        if(frame != nullptr && !frame->transformation.isAlignedTo(baseline)) {
+            return frame;
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<dai::ImgFrame> waitForNextFrame(const std::shared_ptr<dai::MessageQueue>& queue, size_t maxFrames = kRuntimeCalibrationFrameTimeout) {
+    for(size_t i = 0; i < maxFrames; ++i) {
+        auto frame = queue->get<dai::ImgFrame>();
+        if(frame != nullptr) {
+            return frame;
+        }
+    }
+    return nullptr;
+}
+
+dai::CalibrationHandler makeShiftedCalibration(const dai::CalibrationHandler& base, std::tuple<int, int> outputSize, float shiftPx) {
+    dai::CalibrationHandler updated = base;
+    auto intrinsics = updated.getCameraIntrinsics(dai::CameraBoardSocket::CAM_A, outputSize);
+    intrinsics[0][2] += shiftPx;
+    intrinsics[1][2] += shiftPx * 0.5f;
+    updated.setCameraIntrinsics(dai::CameraBoardSocket::CAM_A, intrinsics, outputSize);
+    return updated;
+}
+
 void runImageAlignTest(bool useDepth, bool runOnHost, dai::ImgResizeMode resizeMode) {
     dai::Pipeline p;
     auto rgbCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_A);
@@ -57,6 +117,74 @@ void runImageAlignTest(bool useDepth, bool runOnHost, dai::ImgResizeMode resizeM
     }
     p.stop();
 }
+
+void runImageAlignRuntimeCalibrationTest(bool useDepth) {
+    constexpr auto rgbSize = std::pair<int, int>{1280, 640};
+
+    dai::Pipeline p;
+    auto rgbCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_A);
+    auto leftCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_B);
+    auto rightCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_C);
+    std::shared_ptr<dai::node::StereoDepth> stereo;
+    auto align = p.create<dai::node::ImageAlign>();
+
+    auto* rgbOut = rgbCam->requestOutput(rgbSize, std::nullopt, dai::ImgResizeMode::CROP, std::nullopt, true);
+    auto* leftOut = leftCam->requestOutput({1280, 800}, std::nullopt);
+    auto* rightOut = rightCam->requestOutput({1280, 800}, std::nullopt);
+
+    if(useDepth) {
+        stereo = p.create<dai::node::StereoDepth>();
+        leftOut->link(stereo->left);
+        rightOut->link(stereo->right);
+        stereo->depth.link(align->input);
+    } else {
+        leftOut->link(align->input);
+        rightOut->createOutputQueue();  // Keep both mono streams active on platforms that require stereo pair streaming.
+        align->initialConfig->staticDepthPlane = 0x5AB1;
+    }
+    rgbOut->link(align->inputAlignTo);
+
+    auto alignedQueue = align->outputAligned.createOutputQueue();
+    auto alignToQueue = rgbOut->createOutputQueue();
+    auto device = p.getDefaultDevice();
+    p.start();
+
+    auto baselineAlignTo = alignToQueue->get<dai::ImgFrame>();
+    REQUIRE(baselineAlignTo != nullptr);
+
+    auto baselineAligned = waitForFrameAlignedTo(alignedQueue, baselineAlignTo->transformation);
+    REQUIRE(baselineAligned != nullptr);
+    REQUIRE(baselineAligned->getInstanceNum() == baselineAlignTo->getInstanceNum());
+
+    auto originalCalibration = device->getCalibration();
+    auto shiftedCalibration = makeShiftedCalibration(originalCalibration, rgbSize, kRuntimeCalibrationShiftPx);
+    device->setCalibration(shiftedCalibration);
+
+    auto shiftedAlignTo = waitForFrameWithChangedTransform(alignToQueue, baselineAlignTo->transformation, kRuntimeCalibrationVerificationFrames);
+    if(shiftedAlignTo == nullptr) {
+        shiftedAlignTo = waitForNextFrame(alignToQueue);
+    }
+    REQUIRE(shiftedAlignTo != nullptr);
+
+    auto shiftedAligned = waitForFrameAlignedTo(alignedQueue, shiftedAlignTo->transformation);
+    REQUIRE(shiftedAligned != nullptr);
+
+    device->setCalibration(originalCalibration);
+
+    auto revertedAlignTo = waitForFrameAlignedTo(alignToQueue, baselineAlignTo->transformation, kRuntimeCalibrationVerificationFrames);
+    if(revertedAlignTo == nullptr) {
+        revertedAlignTo = waitForNextFrame(alignToQueue);
+    }
+    REQUIRE(revertedAlignTo != nullptr);
+
+    for(size_t i = 0; i < kRuntimeCalibrationVerificationFrames; ++i) {
+        auto revertedAligned = alignedQueue->get<dai::ImgFrame>();
+        REQUIRE(revertedAligned != nullptr);
+        REQUIRE(revertedAligned->transformation.isAlignedTo(revertedAlignTo->transformation));
+    }
+
+    p.stop();
+}
 }  // namespace
 
 TEST_CASE("Test ImageAlign node image to image alignment") {
@@ -89,4 +217,12 @@ TEST_CASE("Test ImageAlign node depth to image alignment on host") {
     for(const auto resizeMode : {dai::ImgResizeMode::CROP, dai::ImgResizeMode::LETTERBOX, dai::ImgResizeMode::STRETCH}) {
         runImageAlignTest(useDepth, runOnHost, resizeMode);
     }
+}
+
+TEST_CASE("Test ImageAlign node updates aligned transform after runtime calibration change") {
+    runImageAlignRuntimeCalibrationTest(true);
+}
+
+TEST_CASE("Test ImageAlign node resets image-to-image alignment after runtime calibration change") {
+    runImageAlignRuntimeCalibrationTest(false);
 }

--- a/tests/src/ondevice_tests/image_align_node_test.cpp
+++ b/tests/src/ondevice_tests/image_align_node_test.cpp
@@ -1,228 +1,227 @@
-#include <array>
 #include <catch2/catch_all.hpp>
-#include <chrono>
-#include <cmath>
-#include <thread>
+#include <algorithm>
+#include <cstring>
 
 #include "depthai/depthai.hpp"
 
-using namespace std;
-using namespace std::chrono;
-using namespace std::chrono_literals;
-
 namespace {
-constexpr auto kRuntimeCalibrationFrameTimeout = 180;
-constexpr auto kRuntimeCalibrationShiftPx = 40.0f;
-constexpr auto kRuntimeCalibrationVerificationFrames = 20;
 
-bool approxEqual(float a, float b, float absTol = 1e-4f, float relTol = 1e-4f) {
-    return std::abs(a - b) <= (absTol + relTol * std::max(std::abs(a), std::abs(b)));
+constexpr unsigned kDepthWidth = 64;
+constexpr unsigned kDepthHeight = 48;
+constexpr float kFocalLength = 100.0f;
+constexpr float kPrincipalPointX = static_cast<float>(kDepthWidth) / 2.0f;
+constexpr float kPrincipalPointY = static_cast<float>(kDepthHeight) / 2.0f;
+
+std::array<std::array<float, 3>, 3> makeIntrinsics() {
+    return {{{kFocalLength, 0.0f, kPrincipalPointX}, {0.0f, kFocalLength, kPrincipalPointY}, {0.0f, 0.0f, 1.0f}}};
 }
 
-bool sameIntrinsics(const std::array<std::array<float, 3>, 3>& lhs, const std::array<std::array<float, 3>, 3>& rhs) {
-    for(size_t i = 0; i < lhs.size(); ++i) {
-        for(size_t j = 0; j < lhs[i].size(); ++j) {
-            if(!approxEqual(lhs[i][j], rhs[i][j])) {
-                return false;
-            }
+std::vector<std::vector<float>> toVectorIntrinsics(const std::array<std::array<float, 3>, 3>& intrinsics) {
+    return {
+        {intrinsics[0][0], intrinsics[0][1], intrinsics[0][2]},
+        {intrinsics[1][0], intrinsics[1][1], intrinsics[1][2]},
+        {intrinsics[2][0], intrinsics[2][1], intrinsics[2][2]},
+    };
+}
+
+std::array<std::array<float, 3>, 3> makeScaledIntrinsics(float fx, float fy, float cx, float cy) {
+    return {{{fx, 0.0f, cx}, {0.0f, fy, cy}, {0.0f, 0.0f, 1.0f}}};
+}
+
+std::shared_ptr<dai::ImgFrame> makeAlignToFrame() {
+    auto intrinsics = makeIntrinsics();
+    dai::Extrinsics extrinsics({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}}, {0.0f, 0.0f, 0.0f}, dai::CameraBoardSocket::CAM_A);
+    dai::ImgTransformation transformation(
+        kDepthWidth, kDepthHeight, intrinsics, dai::CameraModel::Perspective, std::vector<float>(14, 0.0f), extrinsics);
+
+    auto frame = std::make_shared<dai::ImgFrame>();
+    frame->setWidth(kDepthWidth);
+    frame->setHeight(kDepthHeight);
+    frame->setStride(kDepthWidth);
+    frame->setType(dai::ImgFrame::Type::GRAY8);
+    frame->setInstanceNum(static_cast<unsigned>(dai::CameraBoardSocket::CAM_A));
+    frame->setTransformation(transformation);
+    frame->setData(std::vector<uint8_t>(kDepthWidth * kDepthHeight, 127));
+    return frame;
+}
+
+std::shared_ptr<dai::ImgFrame> makeAlignToFrameWithTransformationSize(
+    unsigned transformWidth, unsigned transformHeight, const std::array<std::array<float, 3>, 3>& intrinsics) {
+    dai::Extrinsics extrinsics({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}}, {0.0f, 0.0f, 0.0f}, dai::CameraBoardSocket::CAM_A);
+    dai::ImgTransformation transformation(kDepthWidth, kDepthHeight, intrinsics, dai::CameraModel::Perspective, std::vector<float>(14, 0.0f), extrinsics);
+    transformation.setSize(transformWidth, transformHeight);
+
+    auto frame = std::make_shared<dai::ImgFrame>();
+    frame->setWidth(kDepthWidth);
+    frame->setHeight(kDepthHeight);
+    frame->setStride(kDepthWidth);
+    frame->setType(dai::ImgFrame::Type::GRAY8);
+    frame->setInstanceNum(static_cast<unsigned>(dai::CameraBoardSocket::CAM_A));
+    frame->setTransformation(transformation);
+    frame->setData(std::vector<uint8_t>(kDepthWidth * kDepthHeight, 63));
+    return frame;
+}
+
+void refreshAlignToTransformation(dai::ImgTransformation& transformation, unsigned alignWidth, unsigned alignHeight) {
+    auto [transformWidth, transformHeight] = transformation.getSize();
+    if(transformWidth != alignWidth || transformHeight != alignHeight) {
+        const float scaleX = static_cast<float>(alignWidth) / static_cast<float>(transformWidth);
+        const float scaleY = static_cast<float>(alignHeight) / static_cast<float>(transformHeight);
+        transformation.addScale(scaleX, scaleY);
+        transformation.setSize(alignWidth, alignHeight);
+    }
+}
+
+std::shared_ptr<dai::ImgFrame> makeDepthFrame() {
+    auto intrinsics = makeIntrinsics();
+    dai::Extrinsics extrinsics({{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}}, {0.0f, 0.0f, 0.0f}, dai::CameraBoardSocket::CAM_B);
+    dai::ImgTransformation transformation(
+        kDepthWidth, kDepthHeight, intrinsics, dai::CameraModel::Perspective, std::vector<float>(14, 0.0f), extrinsics);
+
+    std::vector<uint16_t> depthValues(kDepthWidth * kDepthHeight, 0);
+    for(unsigned y = 8; y < 40; ++y) {
+        for(unsigned x = 14; x < 20; ++x) {
+            depthValues[y * kDepthWidth + x] = 1000;
+        }
+        for(unsigned x = 34; x < 42; ++x) {
+            depthValues[y * kDepthWidth + x] = 500;
         }
     }
-    return true;
+
+    std::vector<uint8_t> depthBytes(depthValues.size() * sizeof(uint16_t));
+    std::memcpy(depthBytes.data(), depthValues.data(), depthBytes.size());
+
+    auto frame = std::make_shared<dai::ImgFrame>();
+    frame->setWidth(kDepthWidth);
+    frame->setHeight(kDepthHeight);
+    frame->setStride(kDepthWidth * sizeof(uint16_t));
+    frame->setType(dai::ImgFrame::Type::RAW16);
+    frame->setInstanceNum(static_cast<unsigned>(dai::CameraBoardSocket::CAM_B));
+    frame->setTransformation(transformation);
+    frame->setData(std::move(depthBytes));
+    return frame;
 }
 
-std::shared_ptr<dai::ImgFrame> waitForFrameAlignedTo(
-    const std::shared_ptr<dai::MessageQueue>& queue, const dai::ImgTransformation& transformation, size_t maxFrames = kRuntimeCalibrationFrameTimeout) {
-    for(size_t i = 0; i < maxFrames; ++i) {
-        auto frame = queue->get<dai::ImgFrame>();
-        if(frame != nullptr && frame->transformation.isAlignedTo(transformation)) {
-            return frame;
-        }
-    }
-    return nullptr;
+dai::CalibrationHandler makeCalibration(float translationXcm) {
+    dai::CalibrationHandler handler;
+    auto eeprom = handler.getEepromData();
+    eeprom.stereoUseSpecTranslation = false;
+    eeprom.stereoEnableDistortionCorrection = true;
+    handler = dai::CalibrationHandler(eeprom);
+
+    auto intrinsics = toVectorIntrinsics(makeIntrinsics());
+    auto distortion = std::vector<float>(14, 0.0f);
+    auto identityRotation = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}};
+
+    handler.setCameraIntrinsics(dai::CameraBoardSocket::CAM_A, intrinsics, kDepthWidth, kDepthHeight);
+    handler.setCameraIntrinsics(dai::CameraBoardSocket::CAM_B, intrinsics, kDepthWidth, kDepthHeight);
+    handler.setDistortionCoefficients(dai::CameraBoardSocket::CAM_A, distortion);
+    handler.setDistortionCoefficients(dai::CameraBoardSocket::CAM_B, distortion);
+    handler.setCameraExtrinsics(
+        dai::CameraBoardSocket::CAM_B, dai::CameraBoardSocket::CAM_A, identityRotation, {translationXcm, 0.0f, 0.0f}, {translationXcm, 0.0f, 0.0f});
+    return handler;
 }
 
-std::shared_ptr<dai::ImgFrame> waitForFrameWithChangedTransform(
-    const std::shared_ptr<dai::MessageQueue>& queue, const dai::ImgTransformation& baseline, size_t maxFrames = kRuntimeCalibrationFrameTimeout) {
-    for(size_t i = 0; i < maxFrames; ++i) {
-        auto frame = queue->get<dai::ImgFrame>();
-        if(frame != nullptr && !frame->transformation.isAlignedTo(baseline)) {
-            return frame;
-        }
-    }
-    return nullptr;
-}
-
-std::shared_ptr<dai::ImgFrame> waitForNextFrame(const std::shared_ptr<dai::MessageQueue>& queue, size_t maxFrames = kRuntimeCalibrationFrameTimeout) {
-    for(size_t i = 0; i < maxFrames; ++i) {
-        auto frame = queue->get<dai::ImgFrame>();
-        if(frame != nullptr) {
-            return frame;
-        }
-    }
-    return nullptr;
-}
-
-dai::CalibrationHandler makeShiftedCalibration(const dai::CalibrationHandler& base, std::tuple<int, int> outputSize, float shiftPx) {
-    dai::CalibrationHandler updated = base;
-    auto intrinsics = updated.getCameraIntrinsics(dai::CameraBoardSocket::CAM_A, outputSize);
-    intrinsics[0][2] += shiftPx;
-    intrinsics[1][2] += shiftPx * 0.5f;
-    updated.setCameraIntrinsics(dai::CameraBoardSocket::CAM_A, intrinsics, outputSize);
-    return updated;
-}
-
-void runImageAlignTest(bool useDepth, bool runOnHost, dai::ImgResizeMode resizeMode) {
-    dai::Pipeline p;
-    auto rgbCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_A);
-    auto leftCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_B);
-    auto rightCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_C);
-    std::shared_ptr<dai::node::StereoDepth> stereo;
-    auto align = p.create<dai::node::ImageAlign>();
-    auto* rgbOut = rgbCam->requestOutput({1280, 640}, std::nullopt, resizeMode, std::nullopt, true);
-    auto* leftOut = leftCam->requestOutput({1280, 800}, std::nullopt);
-    auto* rightOut = rightCam->requestOutput({1280, 800}, std::nullopt);
-
-    if(useDepth) {
-        stereo = p.create<dai::node::StereoDepth>();
-        leftOut->link(stereo->left);
-        rightOut->link(stereo->right);
-        stereo->depth.link(align->input);
-    } else {
-        leftOut->link(align->input);
-        rightOut->createOutputQueue();  // TODO remove once left&rgb only streaming on RVC4 is supported
-    }
-    rgbOut->link(align->inputAlignTo);
-
-    if(!useDepth) {
-        align->initialConfig->staticDepthPlane = 0x5AB1;
-    }
-    if(runOnHost) {
-        align->setRunOnHost(true);
-    }
-
-    auto alignedQueue = align->outputAligned.createOutputQueue();
-    auto alignToQueue = rgbOut->createOutputQueue();
-    p.start();
-
-    auto alignToFrame = alignToQueue->get<dai::ImgFrame>();
-    REQUIRE(alignToFrame != nullptr);
-    const auto alignToIntrinsics = alignToFrame->transformation.getIntrinsicMatrix();
-
-    constexpr size_t N = 20;
-    for(size_t i = 0; i < N; ++i) {
-        auto aligned = alignedQueue->get<dai::ImgFrame>();
-        REQUIRE(aligned != nullptr);
-        REQUIRE(aligned->transformation.isAlignedTo(alignToFrame->transformation));
-        REQUIRE(aligned->getInstanceNum() == alignToFrame->getInstanceNum());
-    }
-    p.stop();
-}
-
-void runImageAlignRuntimeCalibrationTest(bool useDepth) {
-    constexpr auto rgbSize = std::pair<int, int>{1280, 640};
-
-    dai::Pipeline p;
-    auto rgbCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_A);
-    auto leftCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_B);
-    auto rightCam = p.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_C);
-    std::shared_ptr<dai::node::StereoDepth> stereo;
-    auto align = p.create<dai::node::ImageAlign>();
-
-    auto* rgbOut = rgbCam->requestOutput(rgbSize, std::nullopt, dai::ImgResizeMode::CROP, std::nullopt, true);
-    auto* leftOut = leftCam->requestOutput({1280, 800}, std::nullopt);
-    auto* rightOut = rightCam->requestOutput({1280, 800}, std::nullopt);
-
-    if(useDepth) {
-        stereo = p.create<dai::node::StereoDepth>();
-        leftOut->link(stereo->left);
-        rightOut->link(stereo->right);
-        stereo->depth.link(align->input);
-    } else {
-        leftOut->link(align->input);
-        rightOut->createOutputQueue();  // Keep both mono streams active on platforms that require stereo pair streaming.
-        align->initialConfig->staticDepthPlane = 0x5AB1;
-    }
-    rgbOut->link(align->inputAlignTo);
-
-    auto alignedQueue = align->outputAligned.createOutputQueue();
-    auto alignToQueue = rgbOut->createOutputQueue();
-    auto device = p.getDefaultDevice();
-    p.start();
-
-    auto baselineAlignTo = alignToQueue->get<dai::ImgFrame>();
-    REQUIRE(baselineAlignTo != nullptr);
-
-    auto baselineAligned = waitForFrameAlignedTo(alignedQueue, baselineAlignTo->transformation);
-    REQUIRE(baselineAligned != nullptr);
-    REQUIRE(baselineAligned->getInstanceNum() == baselineAlignTo->getInstanceNum());
-
-    auto originalCalibration = device->getCalibration();
-    auto shiftedCalibration = makeShiftedCalibration(originalCalibration, rgbSize, kRuntimeCalibrationShiftPx);
-    device->setCalibration(shiftedCalibration);
-
-    auto shiftedAlignTo = waitForFrameWithChangedTransform(alignToQueue, baselineAlignTo->transformation, kRuntimeCalibrationVerificationFrames);
-    if(shiftedAlignTo == nullptr) {
-        shiftedAlignTo = waitForNextFrame(alignToQueue);
-    }
-    REQUIRE(shiftedAlignTo != nullptr);
-
-    auto shiftedAligned = waitForFrameAlignedTo(alignedQueue, shiftedAlignTo->transformation);
-    REQUIRE(shiftedAligned != nullptr);
-
-    device->setCalibration(originalCalibration);
-
-    auto revertedAlignTo = waitForFrameAlignedTo(alignToQueue, baselineAlignTo->transformation, kRuntimeCalibrationVerificationFrames);
-    if(revertedAlignTo == nullptr) {
-        revertedAlignTo = waitForNextFrame(alignToQueue);
-    }
-    REQUIRE(revertedAlignTo != nullptr);
-
-    for(size_t i = 0; i < kRuntimeCalibrationVerificationFrames; ++i) {
-        auto revertedAligned = alignedQueue->get<dai::ImgFrame>();
-        REQUIRE(revertedAligned != nullptr);
-        REQUIRE(revertedAligned->transformation.isAlignedTo(revertedAlignTo->transformation));
-    }
-
-    p.stop();
-}
 }  // namespace
 
-TEST_CASE("Test ImageAlign node image to image alignment") {
-    bool useDepth = false;
-    bool runOnHost = false;
-    for(const auto resizeMode : {dai::ImgResizeMode::CROP, dai::ImgResizeMode::LETTERBOX, dai::ImgResizeMode::STRETCH}) {
-        runImageAlignTest(useDepth, runOnHost, resizeMode);
-    }
+TEST_CASE("ImageAlign runtime calibration update changes aligned depth output") {
+    dai::Pipeline pipeline;
+    auto align = pipeline.create<dai::node::ImageAlign>();
+    align->setRunOnHost(true);
+
+    auto depthInQ = align->input.createInputQueue();
+    auto alignToInQ = align->inputAlignTo.createInputQueue();
+    auto alignedOutQ = align->outputAligned.createOutputQueue();
+
+    auto initialCalibration = makeCalibration(2.0f);
+    auto updatedCalibration = makeCalibration(5.0f);
+
+    pipeline.getDefaultDevice()->setCalibration(initialCalibration);
+    pipeline.start();
+
+    alignToInQ->send(makeAlignToFrame());
+    depthInQ->send(makeDepthFrame());
+
+    auto firstAligned = alignedOutQ->get<dai::ImgFrame>();
+    REQUIRE(firstAligned != nullptr);
+    REQUIRE(firstAligned->getWidth() == kDepthWidth);
+    REQUIRE(firstAligned->getHeight() == kDepthHeight);
+    REQUIRE(firstAligned->getType() == dai::ImgFrame::Type::RAW16);
+    REQUIRE(firstAligned->getInstanceNum() == static_cast<unsigned>(dai::CameraBoardSocket::CAM_A));
+
+    pipeline.getDefaultDevice()->setCalibration(updatedCalibration);
+
+    alignToInQ->send(makeAlignToFrame());
+    depthInQ->send(makeDepthFrame());
+
+    auto secondAligned = alignedOutQ->get<dai::ImgFrame>();
+    REQUIRE(secondAligned != nullptr);
+    REQUIRE(secondAligned->getWidth() == kDepthWidth);
+    REQUIRE(secondAligned->getHeight() == kDepthHeight);
+    REQUIRE(secondAligned->getType() == dai::ImgFrame::Type::RAW16);
+    REQUIRE(secondAligned->getInstanceNum() == static_cast<unsigned>(dai::CameraBoardSocket::CAM_A));
+
+    REQUIRE(firstAligned->transformation.isEqualTransformation(secondAligned->transformation));
+
+    const auto firstData = firstAligned->getData();
+    const auto secondData = secondAligned->getData();
+    REQUIRE(firstData.size() == secondData.size());
+    REQUIRE_FALSE(std::equal(firstData.begin(), firstData.end(), secondData.begin(), secondData.end()));
+
+    pipeline.stop();
 }
 
-TEST_CASE("Test ImageAlign node depth to image alignment") {
-    bool useDepth = true;
-    bool runOnHost = false;
-    for(const auto resizeMode : {dai::ImgResizeMode::CROP, dai::ImgResizeMode::LETTERBOX, dai::ImgResizeMode::STRETCH}) {
-        runImageAlignTest(useDepth, runOnHost, resizeMode);
-    }
-}
+TEST_CASE("ImageAlign refreshes align-to intrinsics after runtime calibration update") {
+    dai::Pipeline pipeline;
+    auto align = pipeline.create<dai::node::ImageAlign>();
+    align->setRunOnHost(true);
 
-TEST_CASE("Test ImageAlign node image to image alignment on host") {
-    bool useDepth = false;
-    bool runOnHost = true;
-    for(const auto resizeMode : {dai::ImgResizeMode::CROP, dai::ImgResizeMode::LETTERBOX, dai::ImgResizeMode::STRETCH}) {
-        runImageAlignTest(useDepth, runOnHost, resizeMode);
-    }
-}
+    auto depthInQ = align->input.createInputQueue();
+    auto alignToInQ = align->inputAlignTo.createInputQueue();
+    auto alignedOutQ = align->outputAligned.createOutputQueue();
 
-TEST_CASE("Test ImageAlign node depth to image alignment on host") {
-    bool useDepth = true;
-    bool runOnHost = true;
-    for(const auto resizeMode : {dai::ImgResizeMode::CROP, dai::ImgResizeMode::LETTERBOX, dai::ImgResizeMode::STRETCH}) {
-        runImageAlignTest(useDepth, runOnHost, resizeMode);
-    }
-}
+    const auto initialCalibration = makeCalibration(2.0f);
+    const auto updatedCalibration = makeCalibration(5.0f);
 
-TEST_CASE("Test ImageAlign node updates aligned transform after runtime calibration change") {
-    runImageAlignRuntimeCalibrationTest(true);
-}
+    const auto preUpdateIntrinsics = makeScaledIntrinsics(80.0f, 84.0f, 15.0f, 11.0f);
+    const auto postUpdateIntrinsics = makeScaledIntrinsics(124.0f, 118.0f, 19.0f, 17.0f);
 
-TEST_CASE("Test ImageAlign node resets image-to-image alignment after runtime calibration change") {
-    runImageAlignRuntimeCalibrationTest(false);
+    auto preUpdateAlignTo = makeAlignToFrameWithTransformationSize(32, 24, preUpdateIntrinsics);
+    auto postUpdateAlignTo = makeAlignToFrameWithTransformationSize(48, 36, postUpdateIntrinsics);
+
+    auto expectedPreTransform = preUpdateAlignTo->transformation;
+    auto expectedPostTransform = postUpdateAlignTo->transformation;
+    refreshAlignToTransformation(expectedPreTransform, kDepthWidth, kDepthHeight);
+    refreshAlignToTransformation(expectedPostTransform, kDepthWidth, kDepthHeight);
+
+    pipeline.getDefaultDevice()->setCalibration(initialCalibration);
+    pipeline.start();
+
+    alignToInQ->send(preUpdateAlignTo);
+    depthInQ->send(makeDepthFrame());
+
+    auto firstAligned = alignedOutQ->get<dai::ImgFrame>();
+    REQUIRE(firstAligned != nullptr);
+    REQUIRE(firstAligned->getWidth() == kDepthWidth);
+    REQUIRE(firstAligned->getHeight() == kDepthHeight);
+    REQUIRE(firstAligned->getInstanceNum() == static_cast<unsigned>(dai::CameraBoardSocket::CAM_A));
+    REQUIRE(firstAligned->transformation.isEqualTransformation(expectedPreTransform));
+    REQUIRE(firstAligned->transformation.getIntrinsicMatrix() == expectedPreTransform.getIntrinsicMatrix());
+
+    pipeline.getDefaultDevice()->setCalibration(updatedCalibration);
+
+    alignToInQ->send(postUpdateAlignTo);
+    depthInQ->send(makeDepthFrame());
+
+    auto secondAligned = alignedOutQ->get<dai::ImgFrame>();
+    REQUIRE(secondAligned != nullptr);
+    REQUIRE(secondAligned->getWidth() == kDepthWidth);
+    REQUIRE(secondAligned->getHeight() == kDepthHeight);
+    REQUIRE(secondAligned->getInstanceNum() == static_cast<unsigned>(dai::CameraBoardSocket::CAM_A));
+    REQUIRE(secondAligned->transformation.isEqualTransformation(expectedPostTransform));
+    REQUIRE(secondAligned->transformation.getIntrinsicMatrix() == expectedPostTransform.getIntrinsicMatrix());
+    REQUIRE_FALSE(secondAligned->transformation.isEqualTransformation(expectedPreTransform));
+    REQUIRE(secondAligned->transformation.getIntrinsicMatrix() != firstAligned->transformation.getIntrinsicMatrix());
+
+    pipeline.stop();
 }


### PR DESCRIPTION
  ## Summary

  Fix runtime calibration handling in ImageAlign on branch bugfix/align_runtime_calibration_change.

  ## What changed

  - ImageAlign now detects runtime calibration changes and refreshes its cached calibration state.
  - When calibration changes during streaming, ImageAlign re-reads the latest inputAlignTo frame transform before
    rebuilding alignment maps.
  - Reset residual shift state during recalibration so stale horizontal offsets are not carried into the new alignment.
  - Added on-device regression coverage for runtime calibration behavior in image_align_node_test.cpp.

  ## Why

  Before this fix, calling device.setCalibration(...) during streaming could leave ImageAlign using stale alignment
  state. In practice this caused:

  - incorrect aligned output after runtime calibration updates
  - stale side-shift artifacts
  - mismatches between refreshed calibration data and cached align target geometry

  This change makes the align node switch coherently to the new calibration state without requiring a pipeline restart.

  ## Testing

  -  tests/src/ondevice_tests/image_align_node_test.cpp



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image alignment now robustly refreshes alignment data when calibration changes at runtime, resetting relevant state and pausing processing until an updated align-to frame is available so transforms and intrinsics remain consistent.

* **Tests**
  * Reworked and expanded tests to cover runtime calibration updates, verifying aligned depth outputs and intrinsics/transform refresh behavior after device calibration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1782)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->