### PR TITLE
Raw ToF output and CBA EEPROM access

### DIFF
--- a/bindings/python/src/DeviceBindings.cpp
+++ b/bindings/python/src/DeviceBindings.cpp
@@ -618,18 +618,20 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
             DOC(dai, DeviceBase, getProfilingData))
         .def(
             "readCalibration",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.readCalibration();
+                return d.readCalibration(cameraSocket);
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, readCalibration))
         .def(
             "tryFlashCalibration",
-            [](DeviceBase& d, CalibrationHandler calibrationDataHandler) {
+            [](DeviceBase& d, CalibrationHandler calibrationDataHandler, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.tryFlashCalibration(calibrationDataHandler);
+                return d.tryFlashCalibration(calibrationDataHandler, cameraSocket);
             },
             py::arg("calibrationDataHandler"),
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, tryFlashCalibration))
         .def(
             "setXLinkChunkSize",
@@ -722,10 +724,12 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
             DOC(dai, DeviceBase, isEepromAvailable))
         .def(
             "flashCalibration",
-            [](DeviceBase& d, CalibrationHandler ch) {
+            [](DeviceBase& d, CalibrationHandler ch, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.flashCalibration(ch);
+                return d.flashCalibration(ch, cameraSocket);
             },
+            py::arg("calibrationDataHandler"),
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, flashCalibration))
         .def(
             "setCalibration",

--- a/bindings/python/src/DeviceBindings.cpp
+++ b/bindings/python/src/DeviceBindings.cpp
@@ -23,6 +23,7 @@
 // STL Bind
 #include <pybind11/pytypes.h>
 #include <pybind11/stl_bind.h>
+#include <pybind11/numpy.h>
 
 PYBIND11_MAKE_OPAQUE(std::unordered_map<std::int8_t, dai::BoardConfig::GPIO>);
 PYBIND11_MAKE_OPAQUE(std::unordered_map<std::int8_t, dai::BoardConfig::UART>);
@@ -804,6 +805,34 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
                 return py::bytes(reinterpret_cast<const char*>(data.data()), data.size());
             },
             DOC(dai, DeviceBase, readFactoryCalibrationRaw))
+        .def(
+            "readCcmEepromRaw",
+            [](DeviceBase& d, CameraBoardSocket s, int sz, int o) {
+                std::vector<uint8_t> data;
+                {
+                    py::gil_scoped_release release;
+                    data =  d.readCcmEepromRaw(s, sz, o);
+                }
+                return py::bytes(reinterpret_cast<const char*>(data.data()), data.size());
+            },
+            py::arg("socket"),
+            py::arg("size"),
+            py::arg("offset") = 0,
+            DOC(dai, DeviceBase, readCcmEepromRaw))
+        .def(
+            "writeCcmEepromRaw",
+            [](DeviceBase& d, CameraBoardSocket s, py::bytes buf, int o) {
+                py::gil_scoped_release release;
+
+                std::string_view sv = buf;
+
+                return d.writeCcmEepromRaw(s, std::vector<uint8_t>(sv.begin(), sv.end()), o);
+            },
+            py::arg("socket"),
+            py::arg("data"),
+            py::arg("offset") = 0,
+            DOC(dai, DeviceBase, writeCcmEepromRaw))
+
         .def(
             "flashEepromClear",
             [](DeviceBase& d) {

--- a/bindings/python/src/DeviceBindings.cpp
+++ b/bindings/python/src/DeviceBindings.cpp
@@ -835,7 +835,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
 
                 std::string_view sv = buf;
 
-                return d.writeCcmEepromRaw(s, std::vector<uint8_t>(sv.begin(), sv.end()), o);
+                d.writeCcmEepromRaw(s, std::vector<uint8_t>(sv.begin(), sv.end()), o);
             },
             py::arg("socket"),
             py::arg("data"),

--- a/bindings/python/src/DeviceBindings.cpp
+++ b/bindings/python/src/DeviceBindings.cpp
@@ -743,67 +743,76 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
             DOC(dai, DeviceBase, getCalibration))
         .def(
             "readCalibration2",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.readCalibration2();
+                return d.readCalibration2(cameraSocket);
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, readCalibration2))
         .def(
             "readCalibrationOrDefault",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.readCalibrationOrDefault();
+                return d.readCalibrationOrDefault(cameraSocket);
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, readCalibrationOrDefault))
         .def(
             "factoryResetCalibration",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.factoryResetCalibration();
+                return d.factoryResetCalibration(cameraSocket);
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, factoryResetCalibration))
         .def(
             "flashFactoryCalibration",
-            [](DeviceBase& d, CalibrationHandler ch) {
+            [](DeviceBase& d, CalibrationHandler ch, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.flashFactoryCalibration(ch);
+                return d.flashFactoryCalibration(ch, cameraSocket);
             },
+            py::arg("calibrationHandler"),
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, flashFactoryCalibration))
         .def(
             "readFactoryCalibration",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.readFactoryCalibration();
+                return d.readFactoryCalibration(cameraSocket);
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, readFactoryCalibration))
         .def(
             "readFactoryCalibrationOrDefault",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                return d.readFactoryCalibrationOrDefault();
+                return d.readFactoryCalibrationOrDefault(cameraSocket);
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, readFactoryCalibrationOrDefault))
         .def(
             "readCalibrationRaw",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 std::vector<uint8_t> data;
                 {
                     py::gil_scoped_release release;
-                    data = d.readCalibrationRaw();
+                    data = d.readCalibrationRaw(cameraSocket);
                 }
                 return py::bytes(reinterpret_cast<const char*>(data.data()), data.size());
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, readCalibrationRaw))
         .def(
             "readFactoryCalibrationRaw",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 std::vector<uint8_t> data;
                 {
                     py::gil_scoped_release release;
-                    data = d.readFactoryCalibrationRaw();
+                    data = d.readFactoryCalibrationRaw(cameraSocket);
                 }
                 return py::bytes(reinterpret_cast<const char*>(data.data()), data.size());
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, readFactoryCalibrationRaw))
         .def(
             "readCcmEepromRaw",
@@ -835,17 +844,19 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
 
         .def(
             "flashEepromClear",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                d.flashEepromClear();
+                d.flashEepromClear(cameraSocket);
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, flashEepromClear))
         .def(
             "flashFactoryEepromClear",
-            [](DeviceBase& d) {
+            [](DeviceBase& d, dai::CameraBoardSocket cameraSocket = dai::CameraBoardSocket::AUTO) {
                 py::gil_scoped_release release;
-                d.flashFactoryEepromClear();
+                d.flashFactoryEepromClear(cameraSocket);
             },
+            py::arg("cameraSocket") = dai::CameraBoardSocket::AUTO,
             DOC(dai, DeviceBase, flashFactoryEepromClear))
         .def(
             "setTimesync",

--- a/bindings/python/src/pipeline/node/ToFBindings.cpp
+++ b/bindings/python/src/pipeline/node/ToFBindings.cpp
@@ -37,6 +37,7 @@ void bind_tof(pybind11::module& m, void* pCallstack) {
         .def_readonly("amplitude", &ToFBase::amplitude, DOC(dai, node, ToFBase, amplitude), DOC(dai, node, ToFBase, amplitude))
         .def_readonly("intensity", &ToFBase::intensity, DOC(dai, node, ToFBase, intensity), DOC(dai, node, ToFBase, intensity))
         .def_readonly("phase", &ToFBase::phase, DOC(dai, node, ToFBase, phase), DOC(dai, node, ToFBase, phase))
+        .def_readonly("raw", &ToFBase::raw, DOC(dai, node, ToFBase, raw), DOC(dai, node, ToFBase, raw))
         .def_readonly("initialConfig", &ToFBase::initialConfig, DOC(dai, node, ToFBase, initialConfig), DOC(dai, node, ToFBase, initialConfig))
         .def("build",
              &ToFBase::build,
@@ -57,6 +58,8 @@ void bind_tof(pybind11::module& m, void* pCallstack) {
             "intensity", [](const ToF& self) -> const dai::DeviceNode::Output& { return self.intensity; }, DOC(dai, node, ToF, intensity))
         .def_property_readonly(
             "phase", [](const ToF& self) -> const dai::DeviceNode::Output& { return self.phase; }, DOC(dai, node, ToF, phase))
+        .def_property_readonly(
+            "raw", [](const ToF& self) -> const dai::DeviceNode::Output& { return self.raw; }, DOC(dai, node, ToF, raw))
         .def_property_readonly(
             "tofBaseInputConfig",
             [](const ToF& self) -> const dai::DeviceNode::Input& { return self.tofBaseInputConfig; },

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "358472a96039cc24ae416b9612210f04544c1928")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "0ede29ac6b9a3f7786e44b5f7a9bf4838486c249")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -707,18 +707,21 @@ class DeviceBase {
      * Stores the Calibration and Device information to the Device EEPROM
      *
      * @param calibrationObj CalibrationHandler object which is loaded with calibration information.
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @return true on successful flash, false on failure
      */
-    bool tryFlashCalibration(CalibrationHandler calibrationDataHandler);
+    bool tryFlashCalibration(CalibrationHandler calibrationDataHandler, CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Stores the Calibration and Device information to the Device EEPROM
      *
      * @throws std::runtime_error if failed to flash the calibration
      * @param calibrationObj CalibrationHandler object which is loaded with calibration information.
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      */
-    void flashCalibration(CalibrationHandler calibrationDataHandler);
+    void flashCalibration(CalibrationHandler calibrationDataHandler, CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Sets the Calibration at runtime. This is not persistent and will be lost after device reset.

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -757,91 +757,114 @@ class DeviceBase {
      * Fetches the EEPROM data from the device and loads it into CalibrationHandler object
      * If no calibration is flashed, it returns default
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM
      */
-    CalibrationHandler readCalibration();
+    CalibrationHandler readCalibration(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Fetches the EEPROM data from the device and loads it into CalibrationHandler object
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @throws std::runtime_error if no calibration is flashed
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM
      */
-    CalibrationHandler readCalibration2();
+    CalibrationHandler readCalibration2(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Fetches the EEPROM data from the device and loads it into CalibrationHandler object
      * If no calibration is flashed, it returns default
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM
      */
-    CalibrationHandler readCalibrationOrDefault();
+    CalibrationHandler readCalibrationOrDefault(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Factory reset EEPROM data if factory backup is available.
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @throws std::runtime_error If factory reset was unsuccessful
      */
-    void factoryResetCalibration();
+    void factoryResetCalibration(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Stores the Calibration and Device information to the Device EEPROM in Factory area
      * To perform this action, correct env variable must be set
+     * 
+     * @param calibrationHandler CalibrationHandler
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error if failed to flash the calibration
      * @return True on successful flash, false on failure
      */
-    void flashFactoryCalibration(CalibrationHandler calibrationHandler);
+    void flashFactoryCalibration(CalibrationHandler calibrationHandler, CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Destructive action, deletes User area EEPROM contents
      * Requires PROTECTED permissions
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @throws std::runtime_error if failed to flash the calibration
      * @return True on successful flash, false on failure
      */
-    void flashEepromClear();
+    void flashEepromClear(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Destructive action, deletes Factory area EEPROM contents
      * Requires FACTORY PROTECTED permissions
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @throws std::runtime_error if failed to flash the calibration
      * @return True on successful flash, false on failure
      */
-    void flashFactoryEepromClear();
+    void flashFactoryEepromClear(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Fetches the EEPROM data from Factory area and loads it into CalibrationHandler object
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @throws std::runtime_error if no calibration is flashed
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM in Factory Area
      */
-    CalibrationHandler readFactoryCalibration();
+    CalibrationHandler readFactoryCalibration(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Fetches the EEPROM data from Factory area and loads it into CalibrationHandler object
      * If no calibration is flashed, it returns default
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM in Factory Area
      */
-    CalibrationHandler readFactoryCalibrationOrDefault();
+    CalibrationHandler readFactoryCalibrationOrDefault(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Fetches the raw EEPROM data from User area
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @throws std::runtime_error if any error occurred
      * @returns Binary dump of User area EEPROM data
      */
-    std::vector<std::uint8_t> readCalibrationRaw();
+    std::vector<std::uint8_t> readCalibrationRaw(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Fetches the raw EEPROM data from Factory area
      *
+     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     *
      * @throws std::runtime_error if any error occurred
      * @returns Binary dump of Factory area EEPROM data
      */
-    std::vector<std::uint8_t> readFactoryCalibrationRaw();
+    std::vector<std::uint8_t> readFactoryCalibrationRaw(CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
 
     /**
      * Fetches the raw EEPROM data from the specified CCM (compact camera module).
@@ -851,6 +874,7 @@ class DeviceBase {
      * @param size Size in bytes to read
      * @param offset Absolute offset in EEPROM memory to read from
      * @throws std::runtime_exception if any error occurred
+     * 
      * @returns Binary dump of EEPROM data
      */
     std::vector<std::uint8_t> readCcmEepromRaw(CameraBoardSocket socket, int size, int offset = 0);
@@ -862,6 +886,7 @@ class DeviceBase {
      * @param socket CameraBoardSocket where the CCM is placed
      * @param data Data buffer to write
      * @param offset Absolute offset in EEPROM memory to read from
+     * 
      * @throws std::runtime_exception if any error occurred
      */
     void writeCcmEepromRaw(CameraBoardSocket socket, std::vector<uint8_t> data, int offset = 0);

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -844,6 +844,29 @@ class DeviceBase {
     std::vector<std::uint8_t> readFactoryCalibrationRaw();
 
     /**
+     * Fetches the raw EEPROM data from the specified CCM (compact camera module).
+     * Note: only certain CCMs (e.g. ToF) do have an EEPROM chip on-module
+     *
+     * @param socket CameraBoardSocket where the CCM is placed
+     * @param size Size in bytes to read
+     * @param offset Absolute offset in EEPROM memory to read from
+     * @throws std::runtime_exception if any error occurred
+     * @returns Binary dump of EEPROM data
+     */
+    std::vector<std::uint8_t> readCcmEepromRaw(CameraBoardSocket socket, int size, int offset = 0);
+
+    /**
+     * Writes the raw EEPROM data from the specified CCM (compact camera module).
+     * Note: only certain CCMs (e.g. ToF) do have an EEPROM chip on-module
+     *
+     * @param socket CameraBoardSocket where the CCM is placed
+     * @param data Data buffer to write
+     * @param offset Absolute offset in EEPROM memory to read from
+     * @throws std::runtime_exception if any error occurred
+     */
+    void writeCcmEepromRaw(CameraBoardSocket socket, std::vector<uint8_t> data, int offset = 0);
+
+    /**
      * Retrieves USB connection speed
      *
      * @returns USB connection speed of connected device if applicable. Unknown otherwise.

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -707,7 +707,7 @@ class DeviceBase {
      * Stores the Calibration and Device information to the Device EEPROM
      *
      * @param calibrationObj CalibrationHandler object which is loaded with calibration information.
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @return true on successful flash, false on failure
      */
@@ -718,7 +718,7 @@ class DeviceBase {
      *
      * @throws std::runtime_error if failed to flash the calibration
      * @param calibrationObj CalibrationHandler object which is loaded with calibration information.
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      */
     void flashCalibration(CalibrationHandler calibrationDataHandler, CameraBoardSocket cameraSocket = CameraBoardSocket::AUTO);
@@ -760,7 +760,7 @@ class DeviceBase {
      * Fetches the EEPROM data from the device and loads it into CalibrationHandler object
      * If no calibration is flashed, it returns default
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM
      */
@@ -769,7 +769,7 @@ class DeviceBase {
     /**
      * Fetches the EEPROM data from the device and loads it into CalibrationHandler object
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error if no calibration is flashed
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM
@@ -780,7 +780,7 @@ class DeviceBase {
      * Fetches the EEPROM data from the device and loads it into CalibrationHandler object
      * If no calibration is flashed, it returns default
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM
      */
@@ -789,7 +789,7 @@ class DeviceBase {
     /**
      * Factory reset EEPROM data if factory backup is available.
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error If factory reset was unsuccessful
      */
@@ -800,7 +800,7 @@ class DeviceBase {
      * To perform this action, correct env variable must be set
      * 
      * @param calibrationHandler CalibrationHandler
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error if failed to flash the calibration
      * @return True on successful flash, false on failure
@@ -811,7 +811,7 @@ class DeviceBase {
      * Destructive action, deletes User area EEPROM contents
      * Requires PROTECTED permissions
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error if failed to flash the calibration
      * @return True on successful flash, false on failure
@@ -822,7 +822,7 @@ class DeviceBase {
      * Destructive action, deletes Factory area EEPROM contents
      * Requires FACTORY PROTECTED permissions
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error if failed to flash the calibration
      * @return True on successful flash, false on failure
@@ -832,7 +832,7 @@ class DeviceBase {
     /**
      * Fetches the EEPROM data from Factory area and loads it into CalibrationHandler object
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error if no calibration is flashed
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM in Factory Area
@@ -843,7 +843,7 @@ class DeviceBase {
      * Fetches the EEPROM data from Factory area and loads it into CalibrationHandler object
      * If no calibration is flashed, it returns default
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @return The CalibrationHandler object containing the calibration currently flashed on device EEPROM in Factory Area
      */
@@ -852,7 +852,7 @@ class DeviceBase {
     /**
      * Fetches the raw EEPROM data from User area
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error if any error occurred
      * @returns Binary dump of User area EEPROM data
@@ -862,7 +862,7 @@ class DeviceBase {
     /**
      * Fetches the raw EEPROM data from Factory area
      *
-     * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
+     * @param cameraSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      *
      * @throws std::runtime_error if any error occurred
      * @returns Binary dump of Factory area EEPROM data

--- a/include/depthai/pipeline/node/ToF.hpp
+++ b/include/depthai/pipeline/node/ToF.hpp
@@ -49,6 +49,7 @@ class ToFBase : public DeviceNodeCRTP<DeviceNode, ToFBase, ToFProperties> {
     Output amplitude{*this, {"amplitude", DEFAULT_GROUP, {{{DatatypeEnum::ImgFrame, true}}}}};
     Output intensity{*this, {"intensity", DEFAULT_GROUP, {{{DatatypeEnum::ImgFrame, true}}}}};
     Output phase{*this, {"phase", DEFAULT_GROUP, {{{DatatypeEnum::ImgFrame, true}}}}};
+    Output raw{*this, {"raw", DEFAULT_GROUP, {{{DatatypeEnum::ImgFrame, true}}}}};
 
     /**
      * Build with a specific board socket
@@ -86,6 +87,7 @@ class ToF : public DeviceNodeGroup {
           amplitude{tofBase->amplitude},
           intensity{tofBase->intensity},
           phase{tofBase->phase},
+          raw{tofBase->raw},
           tofBaseInputConfig{tofBase->inputConfig},
           imageFiltersInputConfig{imageFilters->inputConfig},
           tofBaseNode{*tofBase},
@@ -143,6 +145,11 @@ class ToF : public DeviceNodeGroup {
      * Phase output
      */
     Output& phase;
+
+    /**
+     * Raw data coming from the sensor
+     */
+    Output& raw;
 
     /**
      * Input config for ToF base node

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1895,6 +1895,27 @@ std::vector<std::uint8_t> DeviceBase::readCalibrationRaw() {
     return eepromDataRaw;
 }
 
+std::vector<std::uint8_t> DeviceBase::readCcmEepromRaw(CameraBoardSocket socket, int size, int offset) {
+    bool success;
+    std::string errorMsg;
+    std::vector<uint8_t> eepromDataRaw;
+    std::tie(success, errorMsg, eepromDataRaw) =
+        pimpl->rpcClient->call("readCcmEepromRaw", socket, size, offset).as<std::tuple<bool, std::string, std::vector<uint8_t>>>();
+    if(!success) {
+        throw EepromError(errorMsg);
+    }
+    return eepromDataRaw;
+}
+
+void DeviceBase::writeCcmEepromRaw(CameraBoardSocket socket, std::vector<uint8_t> data, int offset) {
+    bool success;
+    std::string errorMsg;
+    std::tie(success, errorMsg) = pimpl->rpcClient->call("writeCcmEepromRaw", socket, data, offset).as<std::tuple<bool, std::string>>();
+    if(!success) {
+        throw EepromError(errorMsg);
+    }
+}
+
 std::vector<std::uint8_t> DeviceBase::readFactoryCalibrationRaw() {
     bool success;
     std::string errorMsg;

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1740,9 +1740,9 @@ bool DeviceBase::isCalibrationAvailable() {
     return pimpl->rpcCall("isCalibrationAvailable").as<bool>();
 }
 
-bool DeviceBase::tryFlashCalibration(CalibrationHandler calibrationDataHandler) {
+bool DeviceBase::tryFlashCalibration(CalibrationHandler calibrationDataHandler, CameraBoardSocket cameraSocket) {
     try {
-        flashCalibration(calibrationDataHandler);
+        flashCalibration(calibrationDataHandler, cameraSocket);
     } catch(const EepromError& e) {
         pimpl->logger.error("Failed to flash calibration: {}", e.what());
         return false;
@@ -1750,7 +1750,7 @@ bool DeviceBase::tryFlashCalibration(CalibrationHandler calibrationDataHandler) 
     return true;
 }
 
-void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
+void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler, CameraBoardSocket cameraSocket) {
     bool factoryPermissions = false;
     bool protectedPermissions = false;
     getFlashingPermissions(factoryPermissions, protectedPermissions);
@@ -1763,7 +1763,7 @@ void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
     bool success;
     std::string errorMsg;
     std::tie(success, errorMsg) =
-        pimpl->rpcCallChecked<std::tuple<bool, std::string>>("storeToEeprom", calibrationDataHandler.getEepromData(), factoryPermissions, protectedPermissions);
+        pimpl->rpcCallChecked<std::tuple<bool, std::string>>("storeToEeprom", calibrationDataHandler.getEepromData(), factoryPermissions, protectedPermissions, cameraSocket);
 
     if(!success) {
         throw EepromError(errorMsg);

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1808,35 +1808,35 @@ CalibrationHandler DeviceBase::getCalibration() {
     return CalibrationHandler(eepromData);
 }
 
-CalibrationHandler DeviceBase::readCalibration() {
+CalibrationHandler DeviceBase::readCalibration(CameraBoardSocket cameraSocket) {
     dai::EepromData eepromData{};
     try {
-        return readCalibration2();
+        return readCalibration2(cameraSocket);
     } catch(const EepromError&) {
         // ignore - use default
     }
     return CalibrationHandler(eepromData);
 }
-CalibrationHandler DeviceBase::readCalibration2() {
+CalibrationHandler DeviceBase::readCalibration2(CameraBoardSocket cameraSocket) {
     bool success;
     std::string errorMsg;
     dai::EepromData eepromData;
-    std::tie(success, errorMsg, eepromData) = pimpl->rpcCallChecked<std::tuple<bool, std::string, dai::EepromData>>("readFromEeprom");
+    std::tie(success, errorMsg, eepromData) = pimpl->rpcCallChecked<std::tuple<bool, std::string, dai::EepromData>>("readFromEeprom", cameraSocket);
     if(!success) {
         throw EepromError(errorMsg);
     }
     return CalibrationHandler(eepromData);
 }
 
-CalibrationHandler DeviceBase::readCalibrationOrDefault() {
-    return readCalibration();
+CalibrationHandler DeviceBase::readCalibrationOrDefault(CameraBoardSocket cameraSocket) {
+    return readCalibration(cameraSocket);
 }
 
-void DeviceBase::flashFactoryCalibration(CalibrationHandler calibrationDataHandler) {
+void DeviceBase::flashFactoryCalibration(CalibrationHandler calibrationDataHandler, CameraBoardSocket cameraSocket) {
     bool factoryPermissions = false;
     bool protectedPermissions = false;
     getFlashingPermissions(factoryPermissions, protectedPermissions);
-    pimpl->logger.debug("Flashing factory calibration. Factory permissions {}, Protected permissions {}", factoryPermissions, protectedPermissions);
+    pimpl->logger.debug("Flashing factory calibration. Factory permissions {}, Protected permissions {}", factoryPermissions, protectedPermissions, cameraSocket);
 
     if(!factoryPermissions) {
         throw std::runtime_error("Calling factory API is not allowed in current configuration");
@@ -1849,46 +1849,46 @@ void DeviceBase::flashFactoryCalibration(CalibrationHandler calibrationDataHandl
     bool success;
     std::string errorMsg;
     std::tie(success, errorMsg) = pimpl->rpcCallChecked<std::tuple<bool, std::string>>(
-        "storeToEepromFactory", calibrationDataHandler.getEepromData(), factoryPermissions, protectedPermissions);
+        "storeToEepromFactory", calibrationDataHandler.getEepromData(), factoryPermissions, protectedPermissions, cameraSocket);
     if(!success) {
         throw EepromError(errorMsg);
     }
 }
 
-CalibrationHandler DeviceBase::readFactoryCalibration() {
+CalibrationHandler DeviceBase::readFactoryCalibration(CameraBoardSocket cameraSocket) {
     bool success;
     std::string errorMsg;
     dai::EepromData eepromData;
-    std::tie(success, errorMsg, eepromData) = pimpl->rpcCallChecked<std::tuple<bool, std::string, dai::EepromData>>("readFromEepromFactory");
+    std::tie(success, errorMsg, eepromData) = pimpl->rpcCallChecked<std::tuple<bool, std::string, dai::EepromData>>("readFromEepromFactory", cameraSocket);
     if(!success) {
         throw EepromError(errorMsg);
     }
     return CalibrationHandler(eepromData);
 }
-CalibrationHandler DeviceBase::readFactoryCalibrationOrDefault() {
+CalibrationHandler DeviceBase::readFactoryCalibrationOrDefault(CameraBoardSocket cameraSocket) {
     dai::EepromData eepromData{};
     try {
-        return readFactoryCalibration();
+        return readFactoryCalibration(cameraSocket);
     } catch(const EepromError&) {
         // ignore - use default
     }
     return CalibrationHandler(eepromData);
 }
 
-void DeviceBase::factoryResetCalibration() {
+void DeviceBase::factoryResetCalibration(CameraBoardSocket cameraSocket) {
     bool success;
     std::string errorMsg;
-    std::tie(success, errorMsg) = pimpl->rpcCallChecked<std::tuple<bool, std::string>>("eepromFactoryReset");
+    std::tie(success, errorMsg) = pimpl->rpcCallChecked<std::tuple<bool, std::string>>("eepromFactoryReset", cameraSocket);
     if(!success) {
         throw EepromError(errorMsg);
     }
 }
 
-std::vector<std::uint8_t> DeviceBase::readCalibrationRaw() {
+std::vector<std::uint8_t> DeviceBase::readCalibrationRaw(CameraBoardSocket cameraSocket) {
     bool success;
     std::string errorMsg;
     std::vector<uint8_t> eepromDataRaw;
-    std::tie(success, errorMsg, eepromDataRaw) = pimpl->rpcCallChecked<std::tuple<bool, std::string, std::vector<uint8_t>>>("readFromEepromRaw");
+    std::tie(success, errorMsg, eepromDataRaw) = pimpl->rpcCallChecked<std::tuple<bool, std::string, std::vector<uint8_t>>>("readFromEepromRaw", cameraSocket);
     if(!success) {
         throw EepromError(errorMsg);
     }
@@ -1916,18 +1916,18 @@ void DeviceBase::writeCcmEepromRaw(CameraBoardSocket socket, std::vector<uint8_t
     }
 }
 
-std::vector<std::uint8_t> DeviceBase::readFactoryCalibrationRaw() {
+std::vector<std::uint8_t> DeviceBase::readFactoryCalibrationRaw(CameraBoardSocket cameraSocket) {
     bool success;
     std::string errorMsg;
     std::vector<uint8_t> eepromDataRaw;
-    std::tie(success, errorMsg, eepromDataRaw) = pimpl->rpcCallChecked<std::tuple<bool, std::string, std::vector<uint8_t>>>("readFromEepromFactoryRaw");
+    std::tie(success, errorMsg, eepromDataRaw) = pimpl->rpcCallChecked<std::tuple<bool, std::string, std::vector<uint8_t>>>("readFromEepromFactoryRaw", cameraSocket);
     if(!success) {
         throw EepromError(errorMsg);
     }
     return eepromDataRaw;
 }
 
-void DeviceBase::flashEepromClear() {
+void DeviceBase::flashEepromClear(CameraBoardSocket cameraSocket) {
     bool factoryPermissions = false;
     bool protectedPermissions = false;
     getFlashingPermissions(factoryPermissions, protectedPermissions);
@@ -1939,17 +1939,17 @@ void DeviceBase::flashEepromClear() {
 
     bool success;
     std::string errorMsg;
-    std::tie(success, errorMsg) = pimpl->rpcCallChecked<std::tuple<bool, std::string>>("eepromClear", protectedPermissions, factoryPermissions);
+    std::tie(success, errorMsg) = pimpl->rpcCallChecked<std::tuple<bool, std::string>>("eepromClear", protectedPermissions, factoryPermissions, cameraSocket);
     if(!success) {
         throw EepromError(errorMsg);
     }
 }
 
-void DeviceBase::flashFactoryEepromClear() {
+void DeviceBase::flashFactoryEepromClear(CameraBoardSocket cameraSocket) {
     bool factoryPermissions = false;
     bool protectedPermissions = false;
     getFlashingPermissions(factoryPermissions, protectedPermissions);
-    pimpl->logger.debug("Clearing User EEPROM contents. Factory permissions {}, Protected permissions {}", factoryPermissions, protectedPermissions);
+    pimpl->logger.debug("Clearing User EEPROM contents. Factory permissions {}, Protected permissions {}", factoryPermissions, protectedPermissions, cameraSocket);
 
     if(!protectedPermissions || !factoryPermissions) {
         throw std::runtime_error("Calling factory EEPROM clear API is not allowed in current configuration");
@@ -1957,7 +1957,7 @@ void DeviceBase::flashFactoryEepromClear() {
 
     bool success;
     std::string errorMsg;
-    std::tie(success, errorMsg) = pimpl->rpcCallChecked<std::tuple<bool, std::string>>("eepromFactoryClear", protectedPermissions, factoryPermissions);
+    std::tie(success, errorMsg) = pimpl->rpcCallChecked<std::tuple<bool, std::string>>("eepromFactoryClear", protectedPermissions, factoryPermissions, cameraSocket);
     if(!success) {
         throw EepromError(errorMsg);
     }

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1900,7 +1900,7 @@ std::vector<std::uint8_t> DeviceBase::readCcmEepromRaw(CameraBoardSocket socket,
     std::string errorMsg;
     std::vector<uint8_t> eepromDataRaw;
     std::tie(success, errorMsg, eepromDataRaw) =
-        pimpl->rpcClient->call("readCcmEepromRaw", socket, size, offset).as<std::tuple<bool, std::string, std::vector<uint8_t>>>();
+        pimpl->rpcCall("readCcmEepromRaw", socket, size, offset).as<std::tuple<bool, std::string, std::vector<uint8_t>>>();
     if(!success) {
         throw EepromError(errorMsg);
     }
@@ -1910,7 +1910,7 @@ std::vector<std::uint8_t> DeviceBase::readCcmEepromRaw(CameraBoardSocket socket,
 void DeviceBase::writeCcmEepromRaw(CameraBoardSocket socket, std::vector<uint8_t> data, int offset) {
     bool success;
     std::string errorMsg;
-    std::tie(success, errorMsg) = pimpl->rpcClient->call("writeCcmEepromRaw", socket, data, offset).as<std::tuple<bool, std::string>>();
+    std::tie(success, errorMsg) = pimpl->rpcCall("writeCcmEepromRaw", socket, data, offset).as<std::tuple<bool, std::string>>();
     if(!success) {
         throw EepromError(errorMsg);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration and EEPROM management APIs now support per-camera socket selection
  * Added raw EEPROM read/write accessors for compact camera modules
  * ToF node now exposes raw sensor output stream

* **Updates**
  * Device-side firmware updated to latest version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1791)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->