### PR TITLE
Fix: Perspective distortion numerical stability

### DIFF
--- a/examples/cpp/Remapping/CMakeLists.txt
+++ b/examples/cpp/Remapping/CMakeLists.txt
@@ -5,4 +5,7 @@ cmake_minimum_required(VERSION 3.10)
 ## function: dai_set_example_test_labels(example_name ...)
 
 dai_add_example(point_remapping point_remapping.cpp ON OFF)
+dai_add_example(single_cam_remapping single_cam_remapping.cpp ON OFF)
+
 dai_set_example_test_labels(point_remapping ondevice rvc2_all rvc4 ci)
+dai_set_example_test_labels(single_cam_remapping ondevice rvc2_all rvc4 ci)

--- a/examples/cpp/Remapping/single_cam_remapping.cpp
+++ b/examples/cpp/Remapping/single_cam_remapping.cpp
@@ -1,0 +1,163 @@
+#include <atomic>
+#include <cmath>
+#include <csignal>
+#include <iomanip>
+#include <iostream>
+#include <opencv2/opencv.hpp>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "depthai/depthai.hpp"
+
+const std::string DISTORTED_WINDOW = "CAM_A distorted 640x480";
+const std::string UNDISTORTED_WINDOW = "CAM_A undistorted 1000x400";
+const std::pair<uint32_t, uint32_t> DISTORTED_SIZE = {640, 480};
+const std::pair<uint32_t, uint32_t> UNDISTORTED_SIZE = {1000, 400};
+
+std::atomic<bool> quitEvent(false);
+std::optional<cv::Point> selectedPoint = std::nullopt;
+
+void signalHandler(int) {
+    quitEvent = true;
+}
+
+void onLeftClick(int event, int x, int y, int flags, void* param) {
+    (void)flags;
+    (void)param;
+
+    if(event == cv::EVENT_LBUTTONDOWN) {
+        selectedPoint = cv::Point(x, y);
+    }
+}
+
+cv::Mat toColorFrame(const cv::Mat& frame) {
+    if(frame.channels() == 3) {
+        return frame;
+    }
+
+    cv::Mat colorFrame;
+    cv::cvtColor(frame, colorFrame, cv::COLOR_GRAY2BGR);
+    return colorFrame;
+}
+
+void addStatusLines(cv::Mat& frame, const std::vector<std::string>& lines, const cv::Scalar& color = cv::Scalar(255, 0, 255)) {
+    for(size_t index = 0; index < lines.size(); ++index) {
+        cv::putText(frame,
+                    lines[index],
+                    cv::Point(10, 28 + static_cast<int>(index) * 24),
+                    cv::FONT_HERSHEY_SIMPLEX,
+                    0.65,
+                    color,
+                    2,
+                    cv::LINE_AA);
+    }
+}
+
+bool isInsideFrame(const dai::Point2f& point, const cv::Mat& frame) {
+    return 0 <= point.x && point.x < frame.cols && 0 <= point.y && point.y < frame.rows;
+}
+
+void drawPoint(cv::Mat& frame, const std::optional<dai::Point2f>& point, const cv::Scalar& color) {
+    if(!point.has_value() || !isInsideFrame(*point, frame)) {
+        return;
+    }
+
+    const cv::Point intPoint(static_cast<int>(std::lround(point->x)), static_cast<int>(std::lround(point->y)));
+    if(intPoint.x < 0 || intPoint.x >= frame.cols || intPoint.y < 0 || intPoint.y >= frame.rows) {
+        return;
+    }
+
+    cv::drawMarker(frame, intPoint, color, cv::MARKER_CROSS, 16, 2);
+    cv::circle(frame, intPoint, 6, color, 1);
+}
+
+std::string formatPointStatus(const std::string& prefix, const dai::Point2f& point) {
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(1) << prefix << ": (" << point.x << ", " << point.y << ")";
+    return stream.str();
+}
+
+int main() {
+    signal(SIGTERM, signalHandler);
+    signal(SIGINT, signalHandler);
+
+    dai::Pipeline pipeline;
+
+    auto camera = pipeline.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_A);
+    auto* distorted = camera->requestOutput(DISTORTED_SIZE, std::nullopt, dai::ImgResizeMode::CROP, std::nullopt, false);
+    auto* undistorted = camera->requestOutput(UNDISTORTED_SIZE, std::nullopt, dai::ImgResizeMode::CROP, std::nullopt, true);
+
+    auto distQueue = distorted->createOutputQueue();
+    auto undistQueue = undistorted->createOutputQueue();
+
+    cv::namedWindow(DISTORTED_WINDOW);
+    cv::namedWindow(UNDISTORTED_WINDOW);
+    cv::setMouseCallback(DISTORTED_WINDOW, onLeftClick);
+
+    std::cout << "Left click in the distorted CAM_A window to remap a point to the undistorted output." << std::endl;
+    std::cout << "Press 'c' to clear the point and 'q' to quit." << std::endl;
+
+    pipeline.start();
+    while(pipeline.isRunning() && !quitEvent) {
+        auto distortedFrame = distQueue->get<dai::ImgFrame>();
+        auto undistortedFrame = undistQueue->get<dai::ImgFrame>();
+
+        if(distortedFrame == nullptr || undistortedFrame == nullptr) {
+            continue;
+        }
+
+        if(!distortedFrame->validateTransformations() || !undistortedFrame->validateTransformations()) {
+            std::cerr << "Invalid transformations!" << std::endl;
+            continue;
+        }
+
+        auto& distortedTransform = distortedFrame->getTransformation();
+        auto& undistortedTransform = undistortedFrame->getTransformation();
+
+        cv::Mat distortedView = toColorFrame(distortedFrame->getCvFrame());
+        cv::Mat undistortedView = toColorFrame(undistortedFrame->getCvFrame());
+
+        std::optional<dai::Point2f> sourcePoint = std::nullopt;
+        std::optional<dai::Point2f> remappedPoint = std::nullopt;
+        std::string sourceStatus = "Click in this window to select a point";
+        std::string targetStatus = "Waiting for a selected point";
+
+        if(selectedPoint.has_value()) {
+            sourcePoint = dai::Point2f(static_cast<float>(selectedPoint->x), static_cast<float>(selectedPoint->y));
+            remappedPoint = distortedTransform.remapPointTo(undistortedTransform, *sourcePoint);
+            sourceStatus = formatPointStatus("Source", *sourcePoint);
+            targetStatus = formatPointStatus("Remapped", *remappedPoint);
+            if(!isInsideFrame(*remappedPoint, undistortedView)) {
+                targetStatus += " outside target frame";
+            }
+        }
+
+        drawPoint(distortedView, sourcePoint, cv::Scalar(0, 255, 0));
+        drawPoint(undistortedView, remappedPoint, cv::Scalar(0, 255, 255));
+
+        addStatusLines(distortedView, {"Distorted CAM_A output", sourceStatus, "Press c to clear, q to quit"});
+        addStatusLines(undistortedView,
+                       {"Undistorted CAM_A output",
+                        targetStatus,
+                        "Target size: " + std::to_string(UNDISTORTED_SIZE.first) + "x" + std::to_string(UNDISTORTED_SIZE.second)});
+
+        cv::imshow(DISTORTED_WINDOW, distortedView);
+        cv::imshow(UNDISTORTED_WINDOW, undistortedView);
+
+        const int key = cv::waitKey(1);
+        if(key == 'q') {
+            pipeline.stop();
+            break;
+        }
+        if(key == 'c') {
+            selectedPoint = std::nullopt;
+        }
+    }
+
+    pipeline.stop();
+    pipeline.wait();
+    return 0;
+}

--- a/examples/python/Remapping/single_cam_remapping.py
+++ b/examples/python/Remapping/single_cam_remapping.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import cv2
+import depthai as dai
+
+DISTORTED_WINDOW = "CAM_A distorted 640x480"
+UNDISTORTED_WINDOW = "CAM_A undistorted 1000x400"
+DISTORTED_SIZE = (640, 480)
+UNDISTORTED_SIZE = (1000, 400)
+
+selectedPoint = None
+
+
+def onLeftClick(event, x, y, flags, param):
+    del flags, param
+    global selectedPoint
+    if event == cv2.EVENT_LBUTTONDOWN:
+        selectedPoint = (x, y)
+
+
+def toColorFrame(frame):
+    if len(frame.shape) == 3 and frame.shape[2] == 3:
+        return frame
+    return cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+
+
+def addStatusLines(frame, lines, color=(255, 0, 255)):
+    for index, line in enumerate(lines):
+        cv2.putText(
+            frame,
+            line,
+            (10, 28 + index * 24),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.65,
+            color,
+            2,
+            cv2.LINE_AA,
+        )
+
+
+def isInsideFrame(point, frame):
+    height, width = frame.shape[:2]
+    return 0 <= point.x < width and 0 <= point.y < height
+
+
+def drawPoint(frame, point, color):
+    if point is None or not isInsideFrame(point, frame):
+        return
+    intPoint = (int(round(point.x)), int(round(point.y)))
+    cv2.drawMarker(frame, intPoint, color, markerType=cv2.MARKER_CROSS, markerSize=16, thickness=2)
+    cv2.circle(frame, intPoint, 6, color, 1)
+
+
+if __name__ == "__main__":
+    with dai.Pipeline() as pipeline:
+        camera = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_A)
+        distorted = camera.requestOutput(DISTORTED_SIZE, resizeMode=dai.ImgResizeMode.CROP, enableUndistortion=False)
+        undistorted = camera.requestOutput(UNDISTORTED_SIZE, resizeMode=dai.ImgResizeMode.CROP, enableUndistortion=True)
+
+        dist_ququeue = distorted.createOutputQueue()
+        undist_ququeue = undistorted.createOutputQueue()
+
+        cv2.namedWindow(DISTORTED_WINDOW)
+        cv2.namedWindow(UNDISTORTED_WINDOW)
+        cv2.setMouseCallback(DISTORTED_WINDOW, onLeftClick)
+
+        print("Left click in the distorted CAM_A window to remap a point to the undistorted output.")
+        print("Press 'c' to clear the point and 'q' to quit.")
+
+        pipeline.start()
+        while pipeline.isRunning():
+            distortedFrame = dist_ququeue.get()
+            undistortedFrame = undist_ququeue.get()
+            assert isinstance(distortedFrame, dai.ImgFrame)
+            assert isinstance(undistortedFrame, dai.ImgFrame)
+            assert isinstance(distortedFrame, dai.ImgFrame)
+            assert isinstance(undistortedFrame, dai.ImgFrame)
+            assert distortedFrame.validateTransformations()
+            assert undistortedFrame.validateTransformations()
+
+            distortedTransform = distortedFrame.getTransformation()
+            undistortedTransform = undistortedFrame.getTransformation()
+
+            distortedView = toColorFrame(distortedFrame.getCvFrame())
+            undistortedView = toColorFrame(undistortedFrame.getCvFrame())
+
+            sourcePoint = None
+            remappedPoint = None
+            sourceStatus = "Click in this window to select a point"
+            targetStatus = "Waiting for a selected point"
+
+            if selectedPoint is not None:
+                sourcePoint = dai.Point2f(float(selectedPoint[0]), float(selectedPoint[1]))
+                remappedPoint = distortedTransform.remapPointTo(undistortedTransform, sourcePoint)
+                sourceStatus = f"Source: ({sourcePoint.x:.1f}, {sourcePoint.y:.1f})"
+                targetStatus = f"Remapped: ({remappedPoint.x:.1f}, {remappedPoint.y:.1f})"
+                if not isInsideFrame(remappedPoint, undistortedView):
+                    targetStatus += " outside target frame"
+
+
+            drawPoint(distortedView, sourcePoint, (0, 255, 0))
+            drawPoint(undistortedView, remappedPoint, (0, 255, 255))
+
+            addStatusLines(
+                distortedView,
+                [
+                    "Distorted CAM_A output",
+                    sourceStatus,
+                    "Press c to clear, q to quit",
+                ],
+            )
+            addStatusLines(
+                undistortedView,
+                [
+                    "Undistorted CAM_A output",
+                    targetStatus,
+                    f"Target size: {UNDISTORTED_SIZE[0]}x{UNDISTORTED_SIZE[1]}",
+                ],
+            )
+
+            cv2.imshow(DISTORTED_WINDOW, distortedView)
+            cv2.imshow(UNDISTORTED_WINDOW, undistortedView)
+
+            key = cv2.waitKey(1)
+            if key == ord("q"):
+                break
+            if key == ord("c"):
+                selectedPoint = None

--- a/examples/python/Remapping/single_cam_remapping.py
+++ b/examples/python/Remapping/single_cam_remapping.py
@@ -57,8 +57,8 @@ if __name__ == "__main__":
         distorted = camera.requestOutput(DISTORTED_SIZE, resizeMode=dai.ImgResizeMode.CROP, enableUndistortion=False)
         undistorted = camera.requestOutput(UNDISTORTED_SIZE, resizeMode=dai.ImgResizeMode.CROP, enableUndistortion=True)
 
-        dist_ququeue = distorted.createOutputQueue()
-        undist_ququeue = undistorted.createOutputQueue()
+        distQueue = distorted.createOutputQueue()
+        undistQueue = undistorted.createOutputQueue()
 
         cv2.namedWindow(DISTORTED_WINDOW)
         cv2.namedWindow(UNDISTORTED_WINDOW)
@@ -69,8 +69,8 @@ if __name__ == "__main__":
 
         pipeline.start()
         while pipeline.isRunning():
-            distortedFrame = dist_ququeue.get()
-            undistortedFrame = undist_ququeue.get()
+            distortedFrame = distQueue.get()
+            undistortedFrame = undistQueue.get()
             assert isinstance(distortedFrame, dai.ImgFrame)
             assert isinstance(undistortedFrame, dai.ImgFrame)
             assert isinstance(distortedFrame, dai.ImgFrame)

--- a/examples/python/Remapping/single_cam_remapping.py
+++ b/examples/python/Remapping/single_cam_remapping.py
@@ -73,8 +73,6 @@ if __name__ == "__main__":
             undistortedFrame = undistQueue.get()
             assert isinstance(distortedFrame, dai.ImgFrame)
             assert isinstance(undistortedFrame, dai.ImgFrame)
-            assert isinstance(distortedFrame, dai.ImgFrame)
-            assert isinstance(undistortedFrame, dai.ImgFrame)
             assert distortedFrame.validateTransformations()
             assert undistortedFrame.validateTransformations()
 

--- a/src/pipeline/utilities/Alignment/AlignmentUtilities.cpp
+++ b/src/pipeline/utilities/Alignment/AlignmentUtilities.cpp
@@ -189,10 +189,8 @@ std::array<float, 3> undistortPerspective(std::array<float, 3> point, const std:
     const float u = x;
     const float v = y;
 
-    std::array<std::array<float, 3>, 3> invTilt = {};
-    std::array<std::array<float, 3>, 3> tilt = {};
-    invTilt = makeInvTiltMatrix(tauX, tauY);
-    tilt = makeTiltMatrix(tauX, tauY);
+    const std::array<std::array<float, 3>, 3> invTilt = makeInvTiltMatrix(tauX, tauY);
+    const std::array<std::array<float, 3>, 3> tilt = makeTiltMatrix(tauX, tauY);
     const auto untilted = dai::matrix::matVecMul(invTilt, {x, y, 1.0f});
 
     float invProj = std::abs(untilted[2]) > kTiny ? 1.0f / untilted[2] : 1.0f;
@@ -220,8 +218,8 @@ std::array<float, 3> undistortPerspective(std::array<float, 3> point, const std:
         const float deltaX = 2.0f * p1 * x * y + p2 * (r2 + 2.0f * x * x) + s1 * r2 + s2 * r2 * r2;
         const float deltaY = p1 * (r2 + 2.0f * y * y) + 2.0f * p2 * x * y + s3 * r2 + s4 * r2 * r2;
 
-        float newX = (1.0f - alpha) * x + alpha * (x0 - deltaX) * icdist;
-        float newY = (1.0f - alpha) * y + alpha * (y0 - deltaY) * icdist;
+        const float newX = (1.0f - alpha) * x + alpha * (x0 - deltaX) * icdist;
+        const float newY = (1.0f - alpha) * y + alpha * (y0 - deltaY) * icdist;
 
         r2 = newX * newX + newY * newY;
         const float r4 = r2 * r2;

--- a/src/pipeline/utilities/Alignment/AlignmentUtilities.cpp
+++ b/src/pipeline/utilities/Alignment/AlignmentUtilities.cpp
@@ -6,7 +6,7 @@
 
 namespace {
 
-constexpr float kTiny = 1e-12f;
+constexpr float kTiny = 1e-8f;
 
 std::array<std::array<float, 3>, 3> makeRotXY(float tauX, float tauY) {
     const float cTx = std::cos(tauX);
@@ -161,6 +161,13 @@ std::array<float, 3> distortPoint(std::array<float, 3> point, dai::CameraModel m
 
 /////////////////////////////////////////// Undistortions ///////////////////////////////////////////
 
+/**
+ * Based on the distortion inversion approach used in OpenCV's
+ * undistortPointsInternal implementation:
+ * https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/undistort.dispatch.cpp
+ *
+ * Reimplemented and adapted for this project.
+ */
 std::array<float, 3> undistortPerspective(std::array<float, 3> point, const std::vector<float>& coeffs) {
     const float k1 = coeffAt(coeffs, 0);
     const float k2 = coeffAt(coeffs, 1);
@@ -177,42 +184,77 @@ std::array<float, 3> undistortPerspective(std::array<float, 3> point, const std:
     const float tauX = coeffAt(coeffs, 12);
     const float tauY = coeffAt(coeffs, 13);
 
-    float x = point[0];
-    float y = point[1];
+    float x = point[0] / point[2];
+    float y = point[1] / point[2];
+    const float u = x;
+    const float v = y;
 
-    if(tauX != 0.0f || tauY != 0.0f) {
-        const auto invTilt = makeInvTiltMatrix(tauX, tauY);
-        const auto untilted = dai::matrix::matVecMul(invTilt, {x, y, 1.0f});
-        if(std::abs(untilted[2]) < kTiny) return point;
-        x = untilted[0] / untilted[2];
-        y = untilted[1] / untilted[2];
-    }
+    std::array<std::array<float, 3>, 3> invTilt = {};
+    std::array<std::array<float, 3>, 3> tilt = {};
+    invTilt = makeInvTiltMatrix(tauX, tauY);
+    tilt = makeTiltMatrix(tauX, tauY);
+    const auto untilted = dai::matrix::matVecMul(invTilt, {x, y, 1.0f});
 
-    const float x0 = x;
-    const float y0 = y;
+    float invProj = std::abs(untilted[2]) > kTiny ? 1.0f / untilted[2] : 1.0f;
+
+    float x0 = x = invProj * untilted[0];
+    float y0 = y = invProj * untilted[1];
+
+    float error = std::numeric_limits<float>::max();
+    float prevError = std::numeric_limits<float>::max();
+    float alpha = 1.0f;
 
     for(int i = 0; i < 50; ++i) {
-        const float r2 = x * x + y * y;
+        if(error < 1e-8f) {
+            break;
+        }
+
+        float r2 = x * x + y * y;
+        const float icdist = (1.0f + ((k6 * r2 + k5) * r2 + k4) * r2) / (1.0f + ((k3 * r2 + k2) * r2 + k1) * r2);
+        if(icdist < 0.0f) {
+            x = u;
+            y = v;
+            break;
+        }
+
+        const float deltaX = 2.0f * p1 * x * y + p2 * (r2 + 2.0f * x * x) + s1 * r2 + s2 * r2 * r2;
+        const float deltaY = p1 * (r2 + 2.0f * y * y) + 2.0f * p2 * x * y + s3 * r2 + s4 * r2 * r2;
+
+        float newX = (1.0f - alpha) * x + alpha * (x0 - deltaX) * icdist;
+        float newY = (1.0f - alpha) * y + alpha * (y0 - deltaY) * icdist;
+
+        r2 = newX * newX + newY * newY;
         const float r4 = r2 * r2;
         const float r6 = r4 * r2;
+        const float a1 = 2.0f * newX * newY;
+        const float a2 = r2 + 2.0f * newX * newX;
+        const float a3 = r2 + 2.0f * newY * newY;
+        const float cdist = 1.0f + k1 * r2 + k2 * r4 + k3 * r6;
+        const float icdist2 = 1.0f / (1.0f + k4 * r2 + k5 * r4 + k6 * r6);
+        const float xd0 = newX * cdist * icdist2 + p1 * a1 + p2 * a2 + s1 * r2 + s2 * r4;
+        const float yd0 = newY * cdist * icdist2 + p1 * a3 + p2 * a1 + s3 * r2 + s4 * r4;
 
-        const float num = 1.0f + k4 * r2 + k5 * r4 + k6 * r6;
-        const float den = 1.0f + k1 * r2 + k2 * r4 + k3 * r6;
-        if(std::abs(den) < kTiny) break;
-        const float icdist = num / den;
-        if(!std::isfinite(icdist) || icdist <= 0.0f) break;
+        const auto tilted = dai::matrix::matVecMul(tilt, {xd0, yd0, 1.0f});
+        invProj = std::abs(tilted[2]) > kTiny ? 1.0f / tilted[2] : 1.0f;
 
-        const float deltaX = 2.0f * p1 * x * y + p2 * (r2 + 2.0f * x * x) + s1 * r2 + s2 * r4;
-        const float deltaY = p1 * (r2 + 2.0f * y * y) + 2.0f * p2 * x * y + s3 * r2 + s4 * r4;
+        float xd = invProj * tilted[0];
+        float yd = invProj * tilted[1];
 
-        const float xNew = (x0 - deltaX) * icdist;
-        const float yNew = (y0 - deltaY) * icdist;
+        // opencv project back to pixel coordinates and calculate error in pixel space
+        //  double x_proj = xd * fx + cx;
+        //  double y_proj = yd * fy + cy;
+        //  error = sqrt(pow(x_proj - u, 2) + pow(y_proj - v, 2));
 
-        const float dx = xNew - x;
-        const float dy = yNew - y;
-        x = xNew;
-        y = yNew;
-        if(dx * dx + dy * dy < 1e-14f) break;
+        error = std::hypot(xd - u, yd - v);
+
+        if(error > prevError) {
+            alpha *= 0.5f;
+            continue;
+        }
+
+        x = newX;
+        y = newY;
+        prevError = error;
     }
 
     return {x, y, 1.0f};

--- a/tests/src/ondevice_tests/img_transformation_test.cpp
+++ b/tests/src/ondevice_tests/img_transformation_test.cpp
@@ -725,7 +725,7 @@ TEST_CASE("AlignmentUtilities undistort point") {
     dai::Point2f point{1594.8793471442408, 200.6646247524987};
     cv::Point2d distortedPoint(point.x, point.y);
 
-    std::vector<float> distCoeffs{20.43730926513672,
+    std::vector<float> distCoeffs{16.43730926513672,
                                   -17.942808151245117,
                                   -0.015188916586339474,
                                   0.0008560882997699082,
@@ -772,6 +772,40 @@ TEST_CASE("AlignmentUtilities undistort point") {
         INFO("Undistorted point with OpenCV: " << opencvUndistorted[0].x << ", " << opencvUndistorted[0].y);
         REQUIRE(std::hypot((undistortedRay[0] / undistortedRay[2]) - opencvUndistorted[0].x, (undistortedRay[1] / undistortedRay[2]) - opencvUndistorted[0].y)
                 < 1e-3);
+    }
+
+    SECTION("Perspective undistortion edge points") {
+        const std::vector<dai::Point2f> edgePoints = {
+            {1918.0f, 1077.0f},
+            {1917.0f, 1079.0f},
+            {1917.0f, 1077.0f},
+            {1916.0f, 1077.0f},
+            {1918.0f, 1077.0f},
+            {1918.0f, 5.0f},
+            {1916.0f, 1079.0f},
+            {120.0f, 1040.0f},
+            {3.0f, 540.0f},
+        };
+
+        for(const auto& edgePoint : edgePoints) {
+            const auto undistortedRay = pixelToRay(edgePoint, transformation);
+            std::vector<cv::Point2d> opencvUndistorted;
+            cv::undistortPoints(std::vector<cv::Point2d>{{edgePoint.x, edgePoint.y}},
+                                opencvUndistorted,
+                                cameraMatrix,
+                                distortionCoeffsCv,
+                                cv::noArray(),
+                                cv::noArray(),
+                                {cv::TermCriteria::MAX_ITER | cv::TermCriteria::EPS, 50, 0.0001});
+
+            INFO("Distorted edge point: " << edgePoint.x << ", " << edgePoint.y);
+            INFO("Undistorted point with AlignmentUtilities: " << undistortedRay[0] / undistortedRay[2] << ", " << undistortedRay[1] / undistortedRay[2]);
+            INFO("Undistorted point with OpenCV: " << opencvUndistorted[0].x << ", " << opencvUndistorted[0].y);
+
+            REQUIRE(
+                std::hypot((undistortedRay[0] / undistortedRay[2]) - opencvUndistorted[0].x, (undistortedRay[1] / undistortedRay[2]) - opencvUndistorted[0].y)
+                < 1e-3);
+        }
     }
 
     SECTION("Fisheye undistortion") {
@@ -846,9 +880,14 @@ TEST_CASE("projectPoints test") {
         const auto& aggregatedResult = aggregatedResults.at(captureName);
         const double currentMeanProjectionErrorPx = currentResult.value("mean_projection_error_px", std::numeric_limits<double>::infinity());
         const double aggregatedMeanProjectionErrorPx = aggregatedResult.value("mean_projection_error_px", std::numeric_limits<double>::quiet_NaN());
+        constexpr double meanProjectionErrorTolerancePx = 1e-4;
 
         REQUIRE(std::isfinite(currentMeanProjectionErrorPx));
         REQUIRE(std::isfinite(aggregatedMeanProjectionErrorPx));
-        REQUIRE(currentMeanProjectionErrorPx <= aggregatedMeanProjectionErrorPx);
+
+        INFO("capture=" << captureName << ", current=" << currentMeanProjectionErrorPx << ", baseline=" << aggregatedMeanProjectionErrorPx
+                        << ", tolerance=" << meanProjectionErrorTolerancePx);
+
+        REQUIRE(currentMeanProjectionErrorPx <= aggregatedMeanProjectionErrorPx + meanProjectionErrorTolerancePx);
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
It could happen that close points in image coreners were not properly undistorted and could lead to large coordinate jumps between neighbouring points. This was hard to catch due to the undistorted points being outside the visible rectified target image. This is the exact same issue as [issue #27916](https://github.com/opencv/opencv/issues/27916) on OpenCV. This PR implements the same fix as OpenCV [PR #27993](https://github.com/opencv/opencv/pull/27993). 

In addition the img_transformation_test has been updated:
1) new section that validates corner point undistortion
2) The "AlignmentUtilities undistort point" test case distortionCoefficients had a pole inside the image, making the distortion function undefined (I had manually changed k1 coeficient from 16 to 20 when I first introduced the test).
3) "projectPoints test" now has an error tolerance of 1e-4 pixels

A new `examples/python/Remapping/single_cam_remapping.py`  example is also added to showcase single camera remapping. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Ran img_transformation_test + single_cam_remapping.py example. 

For three given corner points previous implementation would result in the following undistortion results:
```
Remapping point (637.0, 477.0) to (995.3125, 620.3125)
Remapping point (637.0, 478.0) to (995.3125, 621.875)
Remapping point (637.0, 479.0) to (1277.426025390625, 831.4653930664062)
```

And with the fix applied:
```
Remapping point (637.0, 477.0) to (1294.0703125, 788.6543579101562)
Remapping point (637.0, 478.0) to (1297.885498046875, 793.9365844726562)
Remapping point (637.0, 479.0) to (1289.81689453125, 790.5397338867188)
```

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: codex-5.4: High / Xhigh

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standalone Python and C++ examples demonstrating interactive camera remapping with live distorted and undistorted views, point selection, and remapped-point visualization.

* **Bug Fixes**
  * Improved numerical stability and convergence in distortion/undistortion math for more robust transforms.

* **Tests**
  * Updated transformation tests and relaxed projection accuracy checks to align with the revised undistortion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1793)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->