### PR TITLE
Change that  intrinsics are taken from transformations in DCL

### DIFF
--- a/include/depthai/pipeline/node/DynamicCalibrationNode.hpp
+++ b/include/depthai/pipeline/node/DynamicCalibrationNode.hpp
@@ -179,6 +179,8 @@ class DynamicCalibration : public DeviceNodeCRTP<DeviceNode, DynamicCalibration,
      * DAI held properties
      */
     CalibrationHandler calibrationHandler;
+    ImgTransformation imgTransformationA;
+    ImgTransformation imgTransformationB;
 
     CameraBoardSocket daiSocketA = CameraBoardSocket::CAM_B;
     CameraBoardSocket daiSocketB = CameraBoardSocket::CAM_C;

--- a/src/pipeline/node/DynamicCalibrationNode.cpp
+++ b/src/pipeline/node/DynamicCalibrationNode.cpp
@@ -54,12 +54,11 @@ std::pair<std::shared_ptr<dcl::CameraCalibrationHandle>, std::shared_ptr<dcl::Ca
     const CalibrationHandler& currentCalibration,
     const CameraBoardSocket boardSocketA,
     const CameraBoardSocket boardSocketB,
-    const std::pair<int, int>& resolutionA,
-    const std::pair<int, int>& resolutionB) {
+    ImgTransformation& imgTransformationA,
+    ImgTransformation& imgTransformationB) {
     // clang-format off
-    std::shared_ptr<dcl::CameraCalibrationHandle> calibA = DclUtils::createDclCalibration(
-	currentCalibration.getCameraIntrinsics(boardSocketA, resolutionA.first, resolutionA.second, Point2f(), Point2f(),false),
-        currentCalibration.getDistortionCoefficients(boardSocketA),
+    std::array<std::array<float, 3>, 3> cameraMatrixA = imgTransformationA.getSourceIntrinsicMatrix();
+    std::shared_ptr<dcl::CameraCalibrationHandle> calibA = DclUtils::createDclCalibration(cameraMatrixA, imgTransformationA.getDistortionCoefficients(),
 	{
 	    {1.0f, 0.0f, 0.0f},
 	    {0.0f, 1.0f, 0.0f},
@@ -68,12 +67,12 @@ std::pair<std::shared_ptr<dcl::CameraCalibrationHandle>, std::shared_ptr<dcl::Ca
 	{0.0f, 0.0f, 0.0f},
 	currentCalibration.getDistortionModel(boardSocketA)
     );
-    std::shared_ptr<dcl::CameraCalibrationHandle> calibB = DclUtils::createDclCalibration(
-        currentCalibration.getCameraIntrinsics(boardSocketB, resolutionB.first, resolutionB.second, Point2f(), Point2f(),false),
-        currentCalibration.getDistortionCoefficients(boardSocketB),
-	currentCalibration.getCameraRotationMatrix(boardSocketA, boardSocketB),
-	currentCalibration.getCameraTranslationVector(boardSocketA, boardSocketB, false, LengthUnit::METER),
-	currentCalibration.getDistortionModel(boardSocketB)
+    std::array<std::array<float, 3>, 3> cameraMatrixB = imgTransformationB.getSourceIntrinsicMatrix();
+    std::shared_ptr<dcl::CameraCalibrationHandle> calibB = DclUtils::createDclCalibration(cameraMatrixB,
+        imgTransformationB.getDistortionCoefficients(),
+	    currentCalibration.getCameraRotationMatrix(boardSocketA, boardSocketB),
+	    currentCalibration.getCameraTranslationVector(boardSocketA, boardSocketB, false, LengthUnit::METER),
+	    currentCalibration.getDistortionModel(boardSocketB)
     );
     // clang-format on
     return std::make_pair(calibA, calibB);
@@ -98,7 +97,8 @@ dcl::PerformanceMode DclUtils::daiPerformanceModeToDclPerformanceMode(const dai:
 
 #define DCL_PERSPECTIVE_DISTORTION_SIZE (14)
 #define DCL_FISHEYE_DISTORTION_SIZE (4)
-std::shared_ptr<dcl::CameraCalibrationHandle> DclUtils::createDclCalibration(const std::vector<std::vector<float>>& cameraMatrix,
+
+std::shared_ptr<dcl::CameraCalibrationHandle> DclUtils::createDclCalibration(const std::array<std::array<float, 3>, 3>& cameraMatrix,
                                                                              const std::vector<float>& distortionCoefficients,
                                                                              const std::vector<std::vector<float>>& rotationMatrix,
                                                                              const std::vector<float>& translationVector,
@@ -265,13 +265,13 @@ void DynamicCalibration::setCalibration(CalibrationHandler& handler, bool flash)
     if(flash) {
         device->flashCalibration(handler);
     }
-    auto [calibA, calibB] = DclUtils::convertDaiCalibrationToDcl(handler, daiSocketA, daiSocketB, resolutionA, resolutionB);
+    auto [calibA, calibB] = DclUtils::convertDaiCalibrationToDcl(handler, daiSocketA, daiSocketB, imgTransformationA, imgTransformationB);
     pimplDCL->dynCalibImpl.setCalibration(pimplDCL->sensorA, calibA);
     pimplDCL->dynCalibImpl.setCalibration(pimplDCL->sensorB, calibB);
 }
 
 void DynamicCalibration::computeMetrics(const CalibrationHandler& handler) {
-    auto [calibA, calibB] = DclUtils::convertDaiCalibrationToDcl(handler, daiSocketA, daiSocketB, resolutionA, resolutionB);
+    auto [calibA, calibB] = DclUtils::convertDaiCalibrationToDcl(handler, daiSocketA, daiSocketB, imgTransformationA, imgTransformationB);
     auto dataConfidence = pimplDCL->dynCalibImpl.computeDataConfidence(pimplDCL->sensorA, pimplDCL->sensorB);
     auto calibrationConfidence = pimplDCL->dynCalibImpl.computeCalibrationConfidence(calibA, calibB, pimplDCL->sensorA, pimplDCL->sensorB);
     auto metrics = std::make_shared<CalibrationMetrics>();
@@ -437,6 +437,9 @@ DynamicCalibration::ErrorCode DynamicCalibration::initializePipeline(const std::
     resolutionA = std::make_pair(leftFrame->getWidth(), leftFrame->getHeight());
     resolutionB = std::make_pair(rightFrame->getWidth(), rightFrame->getHeight());
 
+    imgTransformationA = leftFrame->getTransformation();
+    imgTransformationB = rightFrame->getTransformation();
+
     daiSocketA = static_cast<CameraBoardSocket>(leftFrame->instanceNum);
     daiSocketB = static_cast<CameraBoardSocket>(rightFrame->instanceNum);
     if(daiSocketA == daiSocketB) {
@@ -453,7 +456,7 @@ DynamicCalibration::ErrorCode DynamicCalibration::initializePipeline(const std::
         logger->trace("The calibration on the device is old (distortion correction is disabled), for optimal performance full re-calibration is recommended!");
         oldCalibrationWarningIssued = true;
     }
-    auto [calibA, calibB] = DclUtils::convertDaiCalibrationToDcl(calibrationHandler, daiSocketA, daiSocketB, resolutionA, resolutionB);
+    auto [calibA, calibB] = DclUtils::convertDaiCalibrationToDcl(calibrationHandler, daiSocketA, daiSocketB, imgTransformationA, imgTransformationB);
 
     // set up the dynamic calibration
     pimplDCL->device = pimplDCL->dynCalibImpl.addDevice();

--- a/src/pipeline/node/DynamicCalibrationNode.cpp
+++ b/src/pipeline/node/DynamicCalibrationNode.cpp
@@ -54,8 +54,8 @@ std::pair<std::shared_ptr<dcl::CameraCalibrationHandle>, std::shared_ptr<dcl::Ca
     const CalibrationHandler& currentCalibration,
     const CameraBoardSocket boardSocketA,
     const CameraBoardSocket boardSocketB,
-    ImgTransformation& imgTransformationA,
-    ImgTransformation& imgTransformationB) {
+    const ImgTransformation& imgTransformationA,
+    const ImgTransformation& imgTransformationB) {
     // clang-format off
     std::array<std::array<float, 3>, 3> cameraMatrixA = imgTransformationA.getSourceIntrinsicMatrix();
     std::shared_ptr<dcl::CameraCalibrationHandle> calibA = DclUtils::createDclCalibration(cameraMatrixA, imgTransformationA.getDistortionCoefficients(),

--- a/src/pipeline/node/DynamicCalibrationUtils.hpp
+++ b/src/pipeline/node/DynamicCalibrationUtils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <DynamicCalibration.hpp>
+#include <array>
 #include <depthai/pipeline/DeviceNode.hpp>
 #include <depthai/pipeline/Subnode.hpp>
 #include <depthai/pipeline/node/Sync.hpp>
@@ -15,7 +16,7 @@ struct DclUtils {
                                            const CameraBoardSocket socketSrc,
                                            const CameraBoardSocket socketDest);
 
-    static std::shared_ptr<dcl::CameraCalibrationHandle> createDclCalibration(const std::vector<std::vector<float>>& cameraMatrix,
+    static std::shared_ptr<dcl::CameraCalibrationHandle> createDclCalibration(const std::array<std::array<float, 3>, 3>& cameraMatrix,
                                                                               const std::vector<float>& distortionCoefficients,
                                                                               const std::vector<std::vector<float>>& rotationMatrix,
                                                                               const std::vector<float>& translationVector,
@@ -25,8 +26,8 @@ struct DclUtils {
         const CalibrationHandler& currentCalibration,
         const CameraBoardSocket boardSocketA,
         const CameraBoardSocket boardSocketB,
-        const std::pair<int, int>& resolutionA,
-        const std::pair<int, int>& resolutionB);
+        ImgTransformation& imgTransformationA,
+        ImgTransformation& imgTransformationB);
 
 #ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
     static dcl::ImageData cvMatToImageData(const cv::Mat& mat);

--- a/src/pipeline/node/DynamicCalibrationUtils.hpp
+++ b/src/pipeline/node/DynamicCalibrationUtils.hpp
@@ -26,8 +26,8 @@ struct DclUtils {
         const CalibrationHandler& currentCalibration,
         const CameraBoardSocket boardSocketA,
         const CameraBoardSocket boardSocketB,
-        ImgTransformation& imgTransformationA,
-        ImgTransformation& imgTransformationB);
+        const ImgTransformation& imgTransformationA,
+        const ImgTransformation& imgTransformationB);
 
 #ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
     static dcl::ImageData cvMatToImageData(const cv::Mat& mat);


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Calibration now uses per-camera image transformation data instead of simple resolution information, improving stereo calibration accuracy and consistency across sensor setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1795)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->