### PR TITLE
Examples/minimal fsync and ptp examples

### DIFF
--- a/examples/cpp/Misc/MultiDevice/CMakeLists.txt
+++ b/examples/cpp/Misc/MultiDevice/CMakeLists.txt
@@ -5,3 +5,5 @@ cmake_minimum_required(VERSION 3.10)
 ## function: dai_set_example_test_labels(example_name ...)
 
 dai_add_example(multi_device_frame_sync multi_device_frame_sync.cpp OFF OFF)
+dai_add_example(ptp_frame_sync_minimal ptp_frame_sync_minimal.cpp OFF OFF)
+dai_add_example(external_sync_frame_sync_minimal external_sync_frame_sync_minimal.cpp OFF OFF)

--- a/examples/cpp/Misc/MultiDevice/external_sync_frame_sync_minimal.cpp
+++ b/examples/cpp/Misc/MultiDevice/external_sync_frame_sync_minimal.cpp
@@ -1,0 +1,233 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <opencv2/highgui.hpp>
+
+#include "depthai/depthai.hpp"
+
+namespace {
+
+constexpr float TARGET_FPS = 30.0f;
+constexpr std::pair<uint32_t, uint32_t> RESOLUTION{640, 480};
+constexpr double SYNC_THRESHOLD_SEC = 1e-3;
+
+std::atomic_bool running{true};
+
+void interruptHandler(int) {
+    if(running.exchange(false)) {
+        std::cout << "Interrupted! Exiting..." << std::endl;
+    } else {
+        std::cout << "Exiting now!" << std::endl;
+        std::exit(0);
+    }
+}
+
+std::string getDeviceName(const std::shared_ptr<dai::Device>& device) {
+    const auto info = device->getDeviceInfo();
+    auto name = info.deviceId;
+    if(!info.name.empty()) {
+        name += "[" + info.name + "]";
+    }
+    return name;
+}
+
+}  // namespace
+
+int main() {
+    signal(SIGINT, interruptHandler);
+
+    // This example only works on devices that are connected with M8 cables with FSYNC Y splitters.
+    const auto deviceInfos = dai::Device::getAllAvailableDevices();
+
+    // Variables to keep track of master and slave pipelines and outputs
+    std::shared_ptr<dai::Pipeline> masterPipeline;
+    std::optional<std::map<std::string, dai::Node::Output*>> masterOutputs;
+    std::optional<std::string> masterName;
+
+    std::map<std::string, std::shared_ptr<dai::Pipeline>> slavePipelines;
+    std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>> slaveQueues;
+
+    // keep track of sync node inputs for slaves
+    std::map<std::string, std::shared_ptr<dai::InputQueue>> inputQueues;
+    // keep track of all sync node output names
+    std::vector<std::string> outputNames;
+
+    for(const auto& deviceInfo : deviceInfos) {
+        // Create pipeline for each device
+        auto pipeline = std::make_shared<dai::Pipeline>(std::make_shared<dai::Device>(deviceInfo));
+        auto device = pipeline->getDefaultDevice();
+        const auto deviceName = getDeviceName(device);
+        const auto fsyncRole = device->getExternalFrameSyncRole();
+
+        for(const auto socket : device->getConnectedCameras()) {
+            // create a queue for each camera on the device
+            std::shared_ptr<dai::node::Camera> cam;
+            if(fsyncRole == dai::ExternalFrameSyncRole::MASTER) {
+                cam = pipeline->create<dai::node::Camera>()->build(socket, std::nullopt, TARGET_FPS);
+            } else {
+                // slaves will lock to the master's FPS
+                cam = pipeline->create<dai::node::Camera>()->build(socket);
+            }
+
+            auto* output = cam->requestOutput(RESOLUTION, dai::ImgFrame::Type::NV12, dai::ImgResizeMode::CROP);
+            const auto socketName = dai::toString(socket);
+
+            // Master cameras will be linked to the sync node directly
+            if(fsyncRole == dai::ExternalFrameSyncRole::MASTER) {
+                if(!masterOutputs.has_value()) {
+                    masterOutputs.emplace();
+                }
+                (*masterOutputs)[socketName] = output;
+            // Gather all slave camera outputs
+            } else if(fsyncRole == dai::ExternalFrameSyncRole::SLAVE) {
+                slaveQueues[deviceName][socketName] = output->createOutputQueue();
+            }
+        }
+
+        if(fsyncRole == dai::ExternalFrameSyncRole::MASTER) {
+            device->setExternalStrobeEnable(true);
+            std::cout << device->getDeviceId() << " is master" << std::endl;
+
+            if(masterPipeline != nullptr) {
+                throw std::runtime_error("Only one master pipeline is supported");
+            }
+
+            masterPipeline = pipeline;
+            masterName = deviceName;
+        } else if(fsyncRole == dai::ExternalFrameSyncRole::SLAVE) {
+            slavePipelines[deviceName] = pipeline;
+            std::cout << device->getDeviceId() << " is slave" << std::endl;
+        }
+    }
+
+    if(masterPipeline == nullptr || !masterOutputs.has_value() || !masterName.has_value()) {
+        throw std::runtime_error("No master detected!");
+    }
+
+    if(slavePipelines.empty()) {
+        throw std::runtime_error("No slaves detected!");
+    }
+
+    // Create sync node
+    auto sync = masterPipeline->create<dai::node::Sync>();
+    // Sync node will run on the host, since it needs to sync multiple devices
+    sync->setRunOnHost(true);
+    // group frames into pairs that are within 1/2 frame period
+    sync->setSyncThreshold(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(0.5 / TARGET_FPS)));
+
+    // Link master camera outputs to the sync node
+    for(const auto& [socketName, output] : *masterOutputs) {
+        const auto name = "master_" + *masterName + "_" + socketName;
+        output->link(sync->inputs[name]);
+        outputNames.push_back(name);
+    }
+
+    // For slaves, we must create an input queue for each output
+    // We will then manually forward the frames from each input queue to the output queue
+    // This is because slave devices have separate pipelines from the master
+    for(const auto& [deviceName, sockets] : slaveQueues) {
+        for(const auto& [socketName, queue] : sockets) {
+            (void)queue;
+            const auto name = "slave_" + deviceName + "_" + socketName;
+            outputNames.push_back(name);
+            inputQueues[name] = sync->inputs[name].createInputQueue();
+        }
+    }
+
+    auto syncedGroups = sync->out.createOutputQueue();
+
+    // thread worker for forwarding slave queues to sync node
+    auto dataCollector = [&](std::string deviceName, std::string socketName) {
+        const auto queueName = "slave_" + deviceName + "_" + socketName;
+        auto camOutputQueue = slaveQueues.at(deviceName).at(socketName);
+        auto inputQueue = inputQueues.at(queueName);
+
+        // Send frames from slave output queues to sync node input queues
+        while(running.load()) {
+            if(camOutputQueue->has()) {
+                inputQueue->send(camOutputQueue->get());
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+    };
+
+    // Start pipelines
+    masterPipeline->start();
+    for(const auto& [deviceName, pipeline] : slavePipelines) {
+        (void)deviceName;
+        pipeline->start();
+    }
+
+    // Start threads
+    std::vector<std::thread> threads;
+    for(const auto& [deviceName, sockets] : slaveQueues) {
+        for(const auto& [socketName, queue] : sockets) {
+            (void)queue;
+            threads.emplace_back(dataCollector, deviceName, socketName);
+        }
+    }
+
+    std::optional<std::shared_ptr<dai::MessageGroup>> latestFrameGroup;
+
+    // main display loop
+    while(running.load()) {
+        // Get frames from sync node output queue
+        while(syncedGroups->has()) {
+            latestFrameGroup = syncedGroups->get<dai::MessageGroup>();
+        }
+
+        if(latestFrameGroup.has_value() && static_cast<size_t>(latestFrameGroup.value()->getNumMessages()) == outputNames.size()) {
+            using ts_type = std::chrono::time_point<std::chrono::steady_clock>;
+            std::map<std::string, ts_type> tsValues;
+            for(auto name : outputNames) {
+                auto frame = latestFrameGroup.value()->get<dai::ImgFrame>(name);
+                tsValues.emplace(name, frame->getTimestamp(dai::CameraExposureOffset::END));
+            }
+            auto compFunct = [](const std::pair<std::string, ts_type>& p1, const std::pair<std::string, ts_type>& p2) -> bool { return p1.second < p2.second; };
+
+            auto maxElement = std::max_element(tsValues.begin(), tsValues.end(), compFunct);
+            auto minElement = std::min_element(tsValues.begin(), tsValues.end(), compFunct);
+
+            auto delta = maxElement->second - minElement->second;
+            auto deltaUs = std::chrono::duration_cast<std::chrono::microseconds>(delta).count();
+
+            if(deltaUs >= SYNC_THRESHOLD_SEC * 1e6) {
+                std::cout << "Sync error: Sync lost, threshold exceeded " << deltaUs << " us" << std::endl;
+                continue;
+            }
+
+            for(const auto& outputName : outputNames) {
+                auto frame = latestFrameGroup.value()->get<dai::ImgFrame>(outputName);
+                cv::imshow("synced_view_" + outputName, frame->getCvFrame());
+            }
+
+            latestFrameGroup.reset();  // Wait for next batch
+        }
+
+        if((cv::waitKey(1) & 0xFF) == 'q') {
+            running.store(false);
+            break;
+        }
+    }
+
+    for(auto& thread : threads) {
+        thread.join();
+    }
+
+    cv::destroyAllWindows();
+    return 0;
+}

--- a/examples/cpp/Misc/MultiDevice/multi_device_frame_sync.cpp
+++ b/examples/cpp/Misc/MultiDevice/multi_device_frame_sync.cpp
@@ -136,7 +136,8 @@ void setUpCameraSocket(std::shared_ptr<dai::Pipeline>& pipeline,
                        std::optional<dai::ExternalFrameSyncRole> role,
                        std::optional<std::map<std::string, dai::Node::Output*>>& masterNode,
                        std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>>& slaveQueues,
-                       std::vector<std::string>& camSockets) {
+                       std::vector<std::string>& camSockets,
+                       std::optional<std::string>& masterName) {
     auto outNode = createCameraOutputs(pipeline, socket, targetFps, syncType, role);
 
     if(syncType == SyncType::EXTERNAL) {
@@ -162,6 +163,9 @@ void setUpCameraSocket(std::shared_ptr<dai::Pipeline>& pipeline,
         // Actual PTP master might be different, but it doesn't matter for this example.
         if(!masterNode.has_value()) {
             masterNode.emplace();
+            masterName = name;
+        }
+        if (masterName == name) {
             masterNode.value().emplace(dai::toString(socket), outNode);
         } else {
             if(slaveQueues.find(name) == slaveQueues.end()) {
@@ -214,7 +218,7 @@ void setupDevice(dai::DeviceInfo& deviceInfo,
     std::cout << "    Num of cameras: " << device->getConnectedCameras().size() << std::endl;
 
     for(auto socket : device->getConnectedCameras()) {
-        setUpCameraSocket(pipeline, socket, name, targetFps, syncType, role, masterNode, slaveQueues, camSockets);
+        setUpCameraSocket(pipeline, socket, name, targetFps, syncType, role, masterNode, slaveQueues, camSockets, masterName);
     }
 
     if(syncType == SyncType::EXTERNAL) {
@@ -238,7 +242,6 @@ void setupDevice(dai::DeviceInfo& deviceInfo,
         // Actual PTP master might be different, but it doesn't matter for this example.
         if(masterPipeline == nullptr) {
             masterPipeline = pipeline;
-            masterName = name;
         } else {
             slavePipelines[name] = pipeline;
         }

--- a/examples/cpp/Misc/MultiDevice/ptp_frame_sync_minimal.cpp
+++ b/examples/cpp/Misc/MultiDevice/ptp_frame_sync_minimal.cpp
@@ -1,0 +1,228 @@
+#include <atomic>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <opencv2/highgui.hpp>
+
+#include "depthai/depthai.hpp"
+
+namespace {
+
+constexpr float TARGET_FPS = 30.0f;
+constexpr std::pair<uint32_t, uint32_t> RESOLUTION{640, 480};
+constexpr double SYNC_THRESHOLD_SEC = 1e-3;
+
+std::atomic_bool running{true};
+
+void interruptHandler(int) {
+    if(running.exchange(false)) {
+        std::cout << "Interrupted! Exiting..." << std::endl;
+    } else {
+        std::cout << "Exiting now!" << std::endl;
+        std::exit(0);
+    }
+}
+
+std::string getDeviceName(const std::shared_ptr<dai::Device>& device) {
+    const auto info = device->getDeviceInfo();
+    auto name = info.deviceId;
+    if(!info.name.empty()) {
+        name += "[" + info.name + "]";
+    }
+    return name;
+}
+
+std::string getSensorName(const std::shared_ptr<dai::Device>& device, dai::CameraBoardSocket socket) {
+    const auto sensorNames = device->getCameraSensorNames();
+    const auto it = sensorNames.find(socket);
+    if(it == sensorNames.end()) {
+        throw std::runtime_error("No sensor name found for " + dai::toString(socket) + " on " + getDeviceName(device));
+    }
+    return it->second;
+}
+
+}  // namespace
+
+int main() {
+    signal(SIGINT, interruptHandler);
+
+    // This example only works on devices that have PTP enabled.
+    const auto deviceInfos = dai::Device::getAllAvailableDevices();
+
+    // Variables to keep track of master and slave pipelines and outputs
+    std::shared_ptr<dai::Pipeline> masterPipeline;
+    std::optional<std::map<std::string, dai::Node::Output*>> masterOutputs;
+    std::optional<std::string> masterName;
+
+    std::map<std::string, std::shared_ptr<dai::Pipeline>> slavePipelines;
+    std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>> slaveQueues;
+
+    // keep track of sync node inputs for slaves
+    std::map<std::string, std::shared_ptr<dai::InputQueue>> inputQueues;
+    // keep track of all sync node output names
+    std::vector<std::string> outputNames;
+
+    for(const auto& deviceInfo : deviceInfos) {
+        // Create pipeline for each device
+        auto pipeline = std::make_shared<dai::Pipeline>(std::make_shared<dai::Device>(deviceInfo));
+        auto device = pipeline->getDefaultDevice();
+        const auto deviceName = getDeviceName(device);
+
+        for(const auto socket : device->getConnectedCameras()) {
+            // TODO: remove this when OV9282 is supported for PTP.
+            if(getSensorName(device, socket) == "OV9282") {
+                continue;
+            }
+
+            // create a queue for each camera on the device
+            auto cam = pipeline->create<dai::node::Camera>()->build(socket, std::nullopt, TARGET_FPS);
+            auto* output = cam->requestOutput(RESOLUTION, dai::ImgFrame::Type::NV12, dai::ImgResizeMode::CROP);
+            const auto socketName = dai::toString(socket);
+
+            // Set sync mode to PTP
+            cam->initialControl.setFrameSyncMode(dai::CameraControl::FrameSyncMode::TIME_PTP);
+
+            // Put the first camera in master
+            // Actual PTP master might be different, but it doesn't matter for this example
+            if(!masterOutputs.has_value()) {
+                masterOutputs.emplace();
+                masterName = deviceName;
+            }
+
+            if(*masterName == deviceName) {
+                (*masterOutputs)[socketName] = output;
+            } else {
+                slaveQueues[deviceName][socketName] = output->createOutputQueue();
+            }
+        }
+
+        if(masterPipeline == nullptr) {
+            masterPipeline = pipeline;
+        } else {
+            slavePipelines[deviceName] = pipeline;
+        }
+    }
+
+    // Create sync node
+    auto sync = masterPipeline->create<dai::node::Sync>();
+    // Sync node will run on the host, since it needs to sync multiple devices
+    sync->setRunOnHost(true);
+    // group frames into pairs that are within 1/2 frame period
+    sync->setSyncThreshold(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(0.5 / TARGET_FPS)));
+
+    // Link master camera outputs to the sync node
+    for(const auto& [socketName, output] : *masterOutputs) {
+        const auto name = "master_" + *masterName + "_" + socketName;
+        output->link(sync->inputs[name]);
+        outputNames.push_back(name);
+    }
+
+    // For slaves, we must create an input queue for each output
+    // We will then manually forward the frames from each input queue to the output queue
+    // This is because slave devices have separate pipelines from the master
+    for(const auto& [deviceName, sockets] : slaveQueues) {
+        for(const auto& [socketName, queue] : sockets) {
+            (void)queue;
+            const auto name = "slave_" + deviceName + "_" + socketName;
+            outputNames.push_back(name);
+            inputQueues[name] = sync->inputs[name].createInputQueue();
+        }
+    }
+
+    auto syncedGroups = sync->out.createOutputQueue();
+
+    // thread worker for forwarding slave queues to sync node
+    auto dataCollector = [&](std::string deviceName, std::string socketName) {
+        const auto queueName = "slave_" + deviceName + "_" + socketName;
+        auto camOutputQueue = slaveQueues.at(deviceName).at(socketName);
+        auto inputQueue = inputQueues.at(queueName);
+
+        // Send frames from slave output queues to sync node input queues
+        while(running.load()) {
+            if(camOutputQueue->has()) {
+                inputQueue->send(camOutputQueue->get());
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+    };
+
+    // Start pipelines
+    masterPipeline->start();
+    for(const auto& [deviceName, pipeline] : slavePipelines) {
+        (void)deviceName;
+        pipeline->start();
+    }
+
+    // Start threads
+    std::vector<std::thread> threads;
+    for(const auto& [deviceName, sockets] : slaveQueues) {
+        for(const auto& [socketName, queue] : sockets) {
+            (void)queue;
+            threads.emplace_back(dataCollector, deviceName, socketName);
+        }
+    }
+
+    std::optional<std::shared_ptr<dai::MessageGroup>> latestFrameGroup;
+
+    // main display loop
+    while(running.load()) {
+        // Get frames from sync node output queue
+        while(syncedGroups->has()) {
+            latestFrameGroup = syncedGroups->get<dai::MessageGroup>();
+        }
+
+        if(latestFrameGroup.has_value() && static_cast<size_t>(latestFrameGroup.value()->getNumMessages()) == outputNames.size()) {
+            using ts_type = std::chrono::time_point<std::chrono::steady_clock>;
+            std::map<std::string, ts_type> tsValues;
+            for(auto name : outputNames) {
+                auto frame = latestFrameGroup.value()->get<dai::ImgFrame>(name);
+                tsValues.emplace(name, frame->getTimestamp(dai::CameraExposureOffset::END));
+            }
+            auto compFunct = [](const std::pair<std::string, ts_type>& p1, const std::pair<std::string, ts_type>& p2) -> bool { return p1.second < p2.second; };
+
+            auto maxElement = std::max_element(tsValues.begin(), tsValues.end(), compFunct);
+            auto minElement = std::min_element(tsValues.begin(), tsValues.end(), compFunct);
+
+            auto delta = maxElement->second - minElement->second;
+            auto deltaUs = std::chrono::duration_cast<std::chrono::microseconds>(delta).count();
+
+            if(deltaUs >= SYNC_THRESHOLD_SEC * 1e6) {
+                std::cout << "Sync error: Sync lost, threshold exceeded " << deltaUs << " us" << std::endl;
+                continue;
+            }
+
+            for(const auto& outputName : outputNames) {
+                auto frame = latestFrameGroup.value()->get<dai::ImgFrame>(outputName);
+                cv::imshow("synced_view_" + outputName, frame->getCvFrame());
+            }
+
+            latestFrameGroup.reset();  // Wait for next batch
+        }
+
+        if((cv::waitKey(1) & 0xFF) == 'q') {
+            running.store(false);
+            break;
+        }
+    }
+
+    for(auto& thread : threads) {
+        thread.join();
+    }
+
+    cv::destroyAllWindows();
+    return 0;
+}

--- a/examples/python/Misc/MultiDevice/external_sync_frame_sync_minimal.py
+++ b/examples/python/Misc/MultiDevice/external_sync_frame_sync_minimal.py
@@ -1,0 +1,179 @@
+import depthai as dai
+import contextlib
+from typing import Optional, Dict
+from datetime import timedelta, datetime
+import signal
+import time
+import threading
+import cv2
+
+# This example only works on devices that are connected with M8 cables with FSYNC Y splitters
+
+deviceInfos = dai.Device.getAllAvailableDevices()
+targetFps = 30
+resolution = (640, 480)
+syncThresholdSec = 1e-3  # 1ms
+running = True
+
+def interruptHandler(sig, frame):
+    global running
+    if running:
+        print("Interrupted! Exiting...")
+        running = False
+    else:
+        print("Exiting now!")
+        exit(0)
+
+signal.signal(signal.SIGINT, interruptHandler)
+
+def getDeviceName(device : dai.Device) -> str:
+    info = device.getDeviceInfo()
+    name = info.deviceId
+    if info.name is not None and info.name != "":
+        name += "[" + info.name + "]"
+    return name
+
+with contextlib.ExitStack() as stack:
+    # Variables to keep track of master and slave pipelines and outputs
+    masterPipeline: Optional[dai.Pipeline] = None
+    masterNode: Optional[Dict[str, dai.Node.Output]] = None
+    masterName: Optional[str] = None
+
+    slavePipelines: Dict[str, dai.Pipeline] = {}
+    slaveQueues: Dict[str, Dict[str, dai.MessageQueue]] = {}
+
+    # keep track of sync node inputs for slaves
+    inputQueues = {}
+
+    # keep track of all sync node output names
+    outputNames = []
+
+    for deviceInfo in deviceInfos:
+        # Create pipeline for each device
+        devicePipeline = stack.enter_context(dai.Pipeline(dai.Device(deviceInfo)))
+        device = devicePipeline.getDefaultDevice()
+        deviceName = getDeviceName(device)
+        fsyncRole = device.getExternalFrameSyncRole()
+
+        for socket in device.getConnectedCameras():
+            # create a queue for each camera on the device
+            if fsyncRole == dai.ExternalFrameSyncRole.MASTER:
+                cam = devicePipeline.create(dai.node.Camera).build(socket, sensorFps=targetFps)
+            else:
+                # slaves will lock to the master's FPS
+                cam = devicePipeline.create(dai.node.Camera).build(socket)
+            outputNode = cam.requestOutput(resolution, dai.ImgFrame.Type.NV12, dai.ImgResizeMode.CROP)
+
+            # Master cameras will be linked to the sync node directly
+            if fsyncRole == dai.ExternalFrameSyncRole.MASTER:
+                if masterNode is None:
+                    masterNode = {}
+                
+                masterNode[socket.name] = outputNode
+            
+            # Gather all slave camera outputs
+            elif fsyncRole == dai.ExternalFrameSyncRole.SLAVE:
+                if slaveQueues.get(deviceName) is None:
+                    slaveQueues[deviceName] = {}
+                slaveQueues[deviceName][socket.name] = outputNode.createOutputQueue()
+            
+        if fsyncRole == dai.ExternalFrameSyncRole.MASTER:
+            device.setExternalStrobeEnable(True)
+            print(f"{device.getDeviceId()} is master")
+
+            if masterPipeline is not None:
+                raise RuntimeError("Only one master pipeline is supported")
+            
+            masterPipeline = devicePipeline
+            masterName = deviceName
+        elif fsyncRole == dai.ExternalFrameSyncRole.SLAVE:
+            slavePipelines[deviceName] = devicePipeline
+            print(f"{device.getDeviceId()} is slave")
+
+    if masterPipeline is None or masterNode is None:
+        raise RuntimeError("No master detected!")
+
+    if len(slavePipelines) < 1:
+        raise RuntimeError("No slaves detected!")
+
+    # Create sync node
+    syncNode = masterPipeline.create(dai.node.Sync)
+
+    # Sync node will run on the host, since it needs to sync multiple devices
+    syncNode.setRunOnHost(True)
+    # group frames into pairs that are within 1/2 frame period
+    syncNode.setSyncThreshold(timedelta(milliseconds=1000 / (2 * targetFps)))
+
+    # Link master camera outputs to the sync node
+    for socketName, camOutput in masterNode.items():
+        name = f"master_{masterName}_{socketName}"
+        camOutput.link(syncNode.inputs[name])
+        outputNames.append(name)
+
+    # For slaves, we must create an input queue for each output
+    # We will then manually forward the frames from each input queue to the output queue
+    # This is because slave devices have separate pipelines from the master
+    for deviceName, sockets in slaveQueues.items():
+        for socketName, _ in sockets.items():
+            name = f"slave_{deviceName}_{socketName}"
+            outputNames.append(name)
+            input_queue = syncNode.inputs[name].createInputQueue()
+            inputQueues[name] = input_queue
+
+    syncedGroups = syncNode.out.createOutputQueue()
+
+    # thread worker for forwarding slave queues to sync node
+    def data_collector(deviceName, socketName):
+        # Send frames from slave output queues to sync node input queues
+        camOutputQueue = slaveQueues[deviceName][socketName]
+        while running:
+            if camOutputQueue.has():
+                inputQueues[f"slave_{deviceName}_{socketName}"].send(camOutputQueue.get())
+            else:
+                time.sleep(0.001)
+
+    # Start pipelines
+    masterPipeline.start()
+    for _, slavePipeline in slavePipelines.items():
+        slavePipeline.start()
+
+    # Start threads
+    threads = {}
+    for deviceName, sockets in slaveQueues.items():
+        for socketName, camOutputQueue in sockets.items():
+            threads[f"slave_{deviceName}_{socketName}"] = threading.Thread(target=data_collector, args=(deviceName, socketName))
+            threads[f"slave_{deviceName}_{socketName}"].start()
+
+    # main display loop
+    latestFrameGroup = None
+    while running:
+        # Get frames from sync node output queue
+        while syncedGroups.has():
+            latestFrameGroup = syncedGroups.get()
+
+        if latestFrameGroup is not None and latestFrameGroup.getNumMessages() == len(outputNames):
+            tsValues = {}
+            for name in outputNames:
+                tsValues[name] = latestFrameGroup[name].getTimestamp(dai.CameraExposureOffset.END).total_seconds()
+
+            delta = max(tsValues.values()) - min(tsValues.values())
+            syncStatus = abs(delta) < syncThresholdSec
+
+            if not syncStatus:
+                print(f"Sync error: Sync lost, threshold exceeded {delta * 1e6} us")
+                continue
+
+            for outputName in outputNames:
+                msg = latestFrameGroup[outputName]
+                frame = msg.getCvFrame()
+                cv2.imshow(f"synced_view_{outputName}", frame)
+            
+            latestFrameGroup = None  # Wait for next batch
+
+        if cv2.waitKey(1) & 0xFF == ord("q"):
+            running = False
+            break
+    
+    for t in threads.keys():
+        threads[t].join()
+    cv2.destroyAllWindows()

--- a/examples/python/Misc/MultiDevice/multi_device_frame_sync.py
+++ b/examples/python/Misc/MultiDevice/multi_device_frame_sync.py
@@ -108,7 +108,7 @@ def setUpCameraSocket(
         deviceName: str,
         targetFps: float,
         role: dai.ExternalFrameSyncRole):
-    global masterNode, slaveQueues, camSockets, syncType
+    global masterNode, slaveQueues, camSockets, syncType, masterName
     pipeline, outNode = createCameraOutputs(pipeline, socket, targetFps, role)
 
     if syncType == SyncType.EXTERNAL:
@@ -131,6 +131,9 @@ def setUpCameraSocket(
         # Actual PTP master might be different, but it doesn't matter for this example
         if masterNode is None:
             masterNode = {}
+            masterName = deviceName
+
+        if masterName == deviceName:
             masterNode[socket.name] = outNode
         else:
             if slaveQueues.get(deviceName) is None:
@@ -196,7 +199,6 @@ def setupDevice(
         # Actual PTP master might be different, but it doesn't matter for this example
         if masterPipeline is None:
             masterPipeline = pipeline
-            masterName = name
         else:
             slavePipelines[name] = pipeline
 

--- a/examples/python/Misc/MultiDevice/ptp_frame_sync_minimal.py
+++ b/examples/python/Misc/MultiDevice/ptp_frame_sync_minimal.py
@@ -1,0 +1,176 @@
+import depthai as dai
+import contextlib
+from typing import Optional, Dict
+from datetime import timedelta, datetime
+import signal
+import time
+import threading
+import cv2
+
+# This example only works on devices that have PTP enabled
+
+deviceInfos = dai.Device.getAllAvailableDevices()
+targetFps = 30
+resolution = (640, 480)
+syncThresholdSec = 1e-3  # 1ms
+running = True
+
+def interruptHandler(sig, frame):
+    global running
+    if running:
+        print("Interrupted! Exiting...")
+        running = False
+    else:
+        print("Exiting now!")
+        exit(0)
+
+signal.signal(signal.SIGINT, interruptHandler)
+
+def getDeviceName(device : dai.Device) -> str:
+    info = device.getDeviceInfo()
+    name = info.deviceId
+    if info.name is not None and info.name != "":
+        name += "[" + info.name + "]"
+    return name
+
+with contextlib.ExitStack() as stack:
+    # Variables to keep track of master and slave pipelines and outputs
+    masterPipeline: Optional[dai.Pipeline] = None
+    masterNode: Optional[Dict[str, dai.Node.Output]] = None
+    masterName: Optional[str] = None
+
+    slavePipelines: Dict[str, dai.Pipeline] = {}
+    slaveQueues: Dict[str, Dict[str, dai.MessageQueue]] = {}
+
+    # keep track of sync node inputs for slaves
+    inputQueues = {}
+
+    # keep track of all sync node output names
+    outputNames = []
+
+    for deviceInfo in deviceInfos:
+        # Create pipeline for each device
+        devicePipeline = stack.enter_context(dai.Pipeline(dai.Device(deviceInfo)))
+        device = devicePipeline.getDefaultDevice()
+        deviceName = getDeviceName(device)
+
+        for socket in device.getConnectedCameras():
+            ########################################################################
+            # TODO: remove this when OV9282 is supporter for PTP
+            sensorName = ""
+            for sckt, sName in device.getCameraSensorNames().items():
+                if sckt == socket:
+                    sensorName = sName
+                    break
+            if sensorName == "":
+                raise RuntimeError(f"No sensor name found for {socket.name} on {deviceName}")
+            if sensorName == "OV9282":
+                continue
+            ########################################################################
+
+            # create a queue for each camera on the device
+            cam = devicePipeline.create(dai.node.Camera).build(socket, sensorFps=targetFps)
+            outputNode = cam.requestOutput(resolution, dai.ImgFrame.Type.NV12, dai.ImgResizeMode.CROP)
+
+            # Set sync mode to PTP
+            cam.initialControl.setFrameSyncMode(dai.CameraControl.FrameSyncMode.TIME_PTP)
+
+            # Put the first camera in master
+            # Actual PTP master might be different, but it doesn't matter for this example
+            if masterNode is None:
+                masterNode = {}
+                masterName = deviceName
+
+            if masterName == deviceName:
+                masterNode[socket.name] = outputNode
+            else:
+                if slaveQueues.get(deviceName) is None:
+                    slaveQueues[deviceName] = {}
+                slaveQueues[deviceName][socket.name] = outputNode.createOutputQueue()
+            
+        if masterPipeline is None:
+            masterPipeline = devicePipeline
+        else:
+            slavePipelines[deviceName] = devicePipeline
+
+    # Create sync node
+    syncNode = masterPipeline.create(dai.node.Sync)
+
+    # Sync node will run on the host, since it needs to sync multiple devices
+    syncNode.setRunOnHost(True)
+    # group frames into pairs that are within 1/2 frame period
+    syncNode.setSyncThreshold(timedelta(milliseconds=1000 / (2 * targetFps)))
+
+    # Link master camera outputs to the sync node
+    for socketName, camOutput in masterNode.items():
+        name = f"master_{masterName}_{socketName}"
+        camOutput.link(syncNode.inputs[name])
+        outputNames.append(name)
+
+    # For slaves, we must create an input queue for each output
+    # We will then manually forward the frames from each input queue to the output queue
+    # This is because slave devices have separate pipelines from the master
+    for deviceName, sockets in slaveQueues.items():
+        for socketName, _ in sockets.items():
+            name = f"slave_{deviceName}_{socketName}"
+            outputNames.append(name)
+            input_queue = syncNode.inputs[name].createInputQueue()
+            inputQueues[name] = input_queue
+
+    syncedGroups = syncNode.out.createOutputQueue()
+
+    # thread worker for forwarding slave queues to sync node
+    def data_collector(deviceName, socketName):
+        # Send frames from slave output queues to sync node input queues
+        camOutputQueue = slaveQueues[deviceName][socketName]
+        while running:
+            if camOutputQueue.has():
+                inputQueues[f"slave_{deviceName}_{socketName}"].send(camOutputQueue.get())
+            else:
+                time.sleep(0.001)
+
+    # Start pipelines
+    masterPipeline.start()
+    for _, slavePipeline in slavePipelines.items():
+        slavePipeline.start()
+
+    # Start threads
+    threads = {}
+    for deviceName, sockets in slaveQueues.items():
+        for socketName, camOutputQueue in sockets.items():
+            threads[f"slave_{deviceName}_{socketName}"] = threading.Thread(target=data_collector, args=(deviceName, socketName))
+            threads[f"slave_{deviceName}_{socketName}"].start()
+
+    # main display loop
+    latestFrameGroup = None
+    while running:
+        # Get frames from sync node output queue
+        while syncedGroups.has():
+            latestFrameGroup = syncedGroups.get()
+
+        if latestFrameGroup is not None and latestFrameGroup.getNumMessages() == len(outputNames):
+            tsValues = {}
+            for name in outputNames:
+                tsValues[name] = latestFrameGroup[name].getTimestamp(dai.CameraExposureOffset.END).total_seconds()
+
+            delta = max(tsValues.values()) - min(tsValues.values())
+            syncStatus = abs(delta) < syncThresholdSec
+
+            if not syncStatus:
+                print(f"Sync error: Sync lost, threshold exceeded {delta * 1e6} us")
+                continue
+
+            for outputName in outputNames:
+                msg = latestFrameGroup[outputName]
+                frame = msg.getCvFrame()
+                cv2.imshow(f"synced_view_{outputName}", frame)
+            
+            latestFrameGroup = None  # Wait for next batch
+
+        if cv2.waitKey(1) & 0xFF == ord("q"):
+            running = False
+            break
+    
+    for t in threads.keys():
+        threads[t].join()
+    cv2.destroyAllWindows()

--- a/examples/python/Misc/MultiDevice/ptp_frame_sync_minimal.py
+++ b/examples/python/Misc/MultiDevice/ptp_frame_sync_minimal.py
@@ -24,6 +24,15 @@ def interruptHandler(sig, frame):
         print("Exiting now!")
         exit(0)
 
+def getSensorName(device: dai.Device, socket: dai.CameraBoardSocket) -> str:
+    sensorName = ""
+    for sckt, sName in device.getCameraSensorNames().items():
+        if sckt == socket:
+            sensorName = sName
+            break
+    if sensorName == "":
+        raise RuntimeError(f"No sensor name found for {socket.name} on {deviceName}")
+
 signal.signal(signal.SIGINT, interruptHandler)
 
 def getDeviceName(device : dai.Device) -> str:
@@ -55,18 +64,9 @@ with contextlib.ExitStack() as stack:
         deviceName = getDeviceName(device)
 
         for socket in device.getConnectedCameras():
-            ########################################################################
             # TODO: remove this when OV9282 is supporter for PTP
-            sensorName = ""
-            for sckt, sName in device.getCameraSensorNames().items():
-                if sckt == socket:
-                    sensorName = sName
-                    break
-            if sensorName == "":
-                raise RuntimeError(f"No sensor name found for {socket.name} on {deviceName}")
-            if sensorName == "OV9282":
+            if getSensorName(device, socket) == "OV9282":
                 continue
-            ########################################################################
 
             # create a queue for each camera on the device
             cam = devicePipeline.create(dai.node.Camera).build(socket, sensorFps=targetFps)

--- a/examples/python/Misc/MultiDevice/ptp_frame_sync_minimal.py
+++ b/examples/python/Misc/MultiDevice/ptp_frame_sync_minimal.py
@@ -143,6 +143,8 @@ with contextlib.ExitStack() as stack:
 
     # main display loop
     latestFrameGroup = None
+    initialSync = False
+    displayedInitialSyncMessage = False
     while running:
         # Get frames from sync node output queue
         while syncedGroups.has():
@@ -157,8 +159,16 @@ with contextlib.ExitStack() as stack:
             syncStatus = abs(delta) < syncThresholdSec
 
             if not syncStatus:
-                print(f"Sync error: Sync lost, threshold exceeded {delta * 1e6} us")
+                if not initialSync:
+                    if not displayedInitialSyncMessage:
+                        print("Waiting for initial sync...")
+                        displayedInitialSyncMessage = True
+                else:
+                    print(f"Sync error: Sync lost, threshold exceeded {delta * 1e6} us")
                 continue
+
+            if not initialSync:
+                initialSync = True
 
             for outputName in outputNames:
                 msg = latestFrameGroup[outputName]

--- a/tests/include/fsync_ptp_test_utils.hpp
+++ b/tests/include/fsync_ptp_test_utils.hpp
@@ -56,7 +56,8 @@ void setUpCameraSocket(std::shared_ptr<dai::Pipeline>& pipeline,
                        std::optional<dai::ExternalFrameSyncRole> role,
                        std::optional<std::map<std::string, dai::Node::Output*>>& masterNode,
                        std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>>& slaveQueues,
-                       std::vector<std::string>& camSockets);
+                       std::vector<std::string>& camSockets,
+                       std::optional<std::string>& masterName);
 
 void setUpIrLeds(std::shared_ptr<dai::Device> device);
 

--- a/tests/src/onhost_tests/utility/fsync_ptp_test_utils.cpp
+++ b/tests/src/onhost_tests/utility/fsync_ptp_test_utils.cpp
@@ -183,7 +183,8 @@ void setUpCameraSocket(std::shared_ptr<dai::Pipeline>& pipeline,
                        std::optional<dai::ExternalFrameSyncRole> role,
                        std::optional<std::map<std::string, dai::Node::Output*>>& masterNode,
                        std::map<std::string, std::map<std::string, std::shared_ptr<dai::MessageQueue>>>& slaveQueues,
-                       std::vector<std::string>& camSockets) {
+                       std::vector<std::string>& camSockets,
+                       std::optional<std::string>& masterName) {
     auto outNode = createPipeline(pipeline, socket, targetFps, syncType, role);
 
     if(syncType == SyncType::EXTERNAL) {
@@ -207,6 +208,9 @@ void setUpCameraSocket(std::shared_ptr<dai::Pipeline>& pipeline,
         // Actual PTP master might be different, but it doesn't matter for this test.
         if(!masterNode.has_value()) {
             masterNode.emplace();
+            masterName = name;
+        }
+        if (masterName == name) {
             masterNode.value().emplace(dai::toString(socket), outNode);
         } else {
             if(slaveQueues.find(name) == slaveQueues.end()) {
@@ -274,7 +278,7 @@ void setupDevice(dai::DeviceInfo& deviceInfo,
     std::cout << "    Num of cameras: " << device->getConnectedCameras().size() << std::endl;
 
     for(auto socket : device->getConnectedCameras()) {
-        setUpCameraSocket(pipeline, socket, name, targetFps, syncType, role, masterNode, slaveQueues, camSockets);
+        setUpCameraSocket(pipeline, socket, name, targetFps, syncType, role, masterNode, slaveQueues, camSockets, masterName);
     }
 
     setUpIrLeds(device);
@@ -300,7 +304,6 @@ void setupDevice(dai::DeviceInfo& deviceInfo,
         // Actual PTP master might be different, but it doesn't matter for this test.
         if(masterPipeline == nullptr) {
             masterPipeline = pipeline;
-            masterName = name;
         } else {
             slavePipelines[name] = pipeline;
         }


### PR DESCRIPTION
Add minimal examples for ptp and fsync for docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added complete C++ and Python example apps demonstrating multi-device frame synchronization for PTP and external (FSYNC) modes, with live synchronized display and graceful shutdown.

* **Improvements**
  * More consistent master/slave selection and coordination across multi-device sync modes, improving synchronization reliability.

* **Tests**
  * Updated test utilities to align PTP master selection with the improved coordination logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->