### PR TITLE
Fix: hasNormalization boolean is never set when building normalized transformed point

### DIFF
--- a/src/pipeline/datatype/ImgTransformations.cpp
+++ b/src/pipeline/datatype/ImgTransformations.cpp
@@ -378,6 +378,7 @@ dai::Point2f ImgTransformation::remapPointTo(const ImgTransformation& to, dai::P
         transformed.x /= to.width;
         transformed.y /= to.height;
         transformed.normalized = true;
+        transformed.hasNormalized = true;
     }
     return transformed;
 }
@@ -452,6 +453,7 @@ dai::Point2f ImgTransformation::projectPointTo(const ImgTransformation& to, dai:
         targetPoint.x /= to.width;
         targetPoint.y /= to.height;
         targetPoint.normalized = true;
+        targetPoint.hasNormalized = true;
     }
     return targetPoint;
 }

--- a/tests/src/onhost_tests/normalization_test.cpp
+++ b/tests/src/onhost_tests/normalization_test.cpp
@@ -78,3 +78,33 @@ TEST_CASE("Normalized rect remap") {
     REQUIRE(float_eq(rect.size.width, 0.8));
     REQUIRE(float_eq(rect.size.height, 1.0));
 }
+
+TEST_CASE("Normalized point corner outputs keep explicit normalization") {
+    dai::Extrinsics extrinsics{{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}, {0, 0, 0}, dai::CameraBoardSocket::CAM_A};
+    dai::ImgTransformation transformFrom(2000, 1000);
+    dai::ImgTransformation transformTo(2000, 1000);
+    transformFrom.setExtrinsics(extrinsics);
+    transformTo.setExtrinsics(extrinsics);
+    transformTo.addScale(2, 2);
+    transformTo.addCrop(0, 0, 2000, 1000);
+
+    SECTION("remapPointTo preserves normalized flag at (1, 1)") {
+        dai::Point2f pt(0.5, 0.5, true);
+        const auto remapped = transformFrom.remapPointTo(transformTo, pt);
+
+        REQUIRE(float_eq(remapped.x, 1.0));
+        REQUIRE(float_eq(remapped.y, 1.0));
+        REQUIRE(remapped.hasNormalized);
+        REQUIRE(remapped.isNormalized());
+    }
+
+    SECTION("projectPointTo preserves normalized flag at (1, 1)") {
+        dai::Point2f pt(0.5, 0.5, true);
+        const auto projected = transformFrom.projectPointTo(transformTo, pt, 1000.0f);
+
+        REQUIRE(float_eq(projected.x, 1.0));
+        REQUIRE(float_eq(projected.y, 1.0));
+        REQUIRE(projected.hasNormalized);
+        REQUIRE(projected.isNormalized());
+    }
+}

--- a/tests/src/onhost_tests/normalization_test.cpp
+++ b/tests/src/onhost_tests/normalization_test.cpp
@@ -79,7 +79,7 @@ TEST_CASE("Normalized rect remap") {
     REQUIRE(float_eq(rect.size.height, 1.0));
 }
 
-TEST_CASE("Normalized point corner outputs keep explicit normalization") {
+TEST_CASE("Normalized point outputs stay normalized outside unit range") {
     dai::Extrinsics extrinsics{{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}, {0, 0, 0}, dai::CameraBoardSocket::CAM_A};
     dai::ImgTransformation transformFrom(2000, 1000);
     dai::ImgTransformation transformTo(2000, 1000);
@@ -88,22 +88,24 @@ TEST_CASE("Normalized point corner outputs keep explicit normalization") {
     transformTo.addScale(2, 2);
     transformTo.addCrop(0, 0, 2000, 1000);
 
-    SECTION("remapPointTo preserves normalized flag at (1, 1)") {
-        dai::Point2f pt(0.5, 0.5, true);
+    SECTION("remapPointTo preserves normalized flag for values above 1") {
+        dai::Point2f pt(0.75, 0.75, true);
         const auto remapped = transformFrom.remapPointTo(transformTo, pt);
 
-        REQUIRE(float_eq(remapped.x, 1.0));
-        REQUIRE(float_eq(remapped.y, 1.0));
+        REQUIRE(float_eq(remapped.x, 1.5));
+        REQUIRE(float_eq(remapped.y, 1.5));
+        REQUIRE(remapped.normalized);
         REQUIRE(remapped.hasNormalized);
         REQUIRE(remapped.isNormalized());
     }
 
-    SECTION("projectPointTo preserves normalized flag at (1, 1)") {
-        dai::Point2f pt(0.5, 0.5, true);
+    SECTION("projectPointTo preserves normalized flag for values above 1") {
+        dai::Point2f pt(0.75, 0.75, true);
         const auto projected = transformFrom.projectPointTo(transformTo, pt, 1000.0f);
 
-        REQUIRE(float_eq(projected.x, 1.0));
-        REQUIRE(float_eq(projected.y, 1.0));
+        REQUIRE(float_eq(projected.x, 1.5));
+        REQUIRE(float_eq(projected.y, 1.5));
+        REQUIRE(projected.normalized);
         REQUIRE(projected.hasNormalized);
         REQUIRE(projected.isNormalized());
     }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
There was a bug when normalized points were transformed out of the image range and then normalized back, the hasNormalized flag is the precondition for points using the normalized flag. 
 
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: me

Submitted code was reviewed by a human: myself

The author is taking the responsibility for the contribution: and I


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of normalized image points to ensure consistent normalization state across coordinate transformations.

* **Tests**
  * Added validation tests to ensure normalized input points preserve their normalized state through transformations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->