### PR TITLE
Fix GPUStereo example, clang formatting and AutoCalibration warning

### DIFF
--- a/examples/cpp/RVC4/GPUStereo/check_device_gpu.cpp
+++ b/examples/cpp/RVC4/GPUStereo/check_device_gpu.cpp
@@ -1,16 +1,13 @@
+#include <argparse/argparse.hpp>
 #include <iostream>
 #include <string>
-
-#include <argparse/argparse.hpp>
 
 #include "depthai/depthai.hpp"
 
 int main(int argc, char** argv) {
     argparse::ArgumentParser program("check_device_gpu", "1.0.0");
     program.add_description("Print basic device GPU availability info.");
-    program.add_argument("--device", "-d")
-        .default_value(std::string(""))
-        .help("Device IP address / device ID (default: auto-discover)");
+    program.add_argument("--device", "-d").default_value(std::string("")).help("Device IP address / device ID (default: auto-discover)");
 
     try {
         program.parse_args(argc, argv);

--- a/examples/cpp/RVC4/GPUStereo/check_device_gpu.cpp
+++ b/examples/cpp/RVC4/GPUStereo/check_device_gpu.cpp
@@ -21,11 +21,15 @@ int main(int argc, char** argv) {
     }
 
     const auto deviceArg = program.get<std::string>("--device");
-    dai::Device device = deviceArg.empty() ? dai::Device() : dai::Device(deviceArg);
+    std::unique_ptr<dai::Device> device;
+    if(deviceArg.empty()) {
+        device = std::make_unique<dai::Device>();
+    } else {
+        device = std::make_unique<dai::Device>(deviceArg);
+    }
 
-    std::cout << "Product: " << device.getProductName() << std::endl;
-    std::cout << "Platform: " << device.getPlatformAsString() << std::endl;
-    std::cout << "GPU available: " << (device.hasGPU() ? "true" : "false") << std::endl;
+    std::cout << "Product: " << device->getProductName() << std::endl;
+    std::cout << "Platform: " << device->getPlatformAsString() << std::endl;
+    std::cout << "GPU available: " << (device->hasGPU() ? "true" : "false") << std::endl;
     return 0;
 }
-

--- a/examples/cpp/Remapping/single_cam_remapping.cpp
+++ b/examples/cpp/Remapping/single_cam_remapping.cpp
@@ -45,14 +45,7 @@ cv::Mat toColorFrame(const cv::Mat& frame) {
 
 void addStatusLines(cv::Mat& frame, const std::vector<std::string>& lines, const cv::Scalar& color = cv::Scalar(255, 0, 255)) {
     for(size_t index = 0; index < lines.size(); ++index) {
-        cv::putText(frame,
-                    lines[index],
-                    cv::Point(10, 28 + static_cast<int>(index) * 24),
-                    cv::FONT_HERSHEY_SIMPLEX,
-                    0.65,
-                    color,
-                    2,
-                    cv::LINE_AA);
+        cv::putText(frame, lines[index], cv::Point(10, 28 + static_cast<int>(index) * 24), cv::FONT_HERSHEY_SIMPLEX, 0.65, color, 2, cv::LINE_AA);
     }
 }
 

--- a/include/depthai/pipeline/node/GPUStereo.hpp
+++ b/include/depthai/pipeline/node/GPUStereo.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include <depthai/pipeline/DeviceNode.hpp>
 #include <depthai/pipeline/Subnode.hpp>
 #include <depthai/pipeline/datatype/GPUStereoConfig.hpp>
@@ -9,6 +7,7 @@
 #include <depthai/pipeline/node/Rectification.hpp>
 #include <depthai/pipeline/node/Sync.hpp>
 #include <depthai/properties/GPUStereoProperties.hpp>
+#include <memory>
 
 namespace dai {
 namespace node {

--- a/src/pipeline/node/AutoCalibration.cpp
+++ b/src/pipeline/node/AutoCalibration.cpp
@@ -361,7 +361,7 @@ bool AutoCalibration::validateIncomingData() {
             }
 
             if(leftImgFrame->getWidth() != rightImgFrame->getWidth() || leftImgFrame->getHeight() != rightImgFrame->getHeight()) {
-                logger->warn("AutoCalibration: Not initialized - currently supports only sensors with same resolutions.");
+                logger->info("AutoCalibration: Not initialized - currently supports only sensors with same resolutions.");
                 return false;
             }
             const auto h = leftImgFrame->getHeight();
@@ -370,7 +370,7 @@ bool AutoCalibration::validateIncomingData() {
             const bool supportedResolution = (h == 800 && w == 1280) || (h == 400 && w == 640);
 
             if(!supportedResolution) {
-                logger->warn(
+                logger->info(
                     "AutoCalibration: Not initialized - currently supports only "
                     "1280x800 or 640x400 resolution not {}x{}.",
                     w,

--- a/tests/src/ondevice_tests/gpu_stereo_node_test.cpp
+++ b/tests/src/ondevice_tests/gpu_stereo_node_test.cpp
@@ -7,11 +7,13 @@ TEST_CASE("GPUStereo produces disparity on supported devices", "[GPUStereo][onde
     try {
         device = std::make_shared<dai::Device>();
     } catch(const std::exception& e) {
-        SKIP(std::string("No device available: ") + e.what());
+        WARN(std::string("Skipping GPUStereo test: no device available: ") + e.what());
+        return;
     }
 
     if(!device->hasGPU()) {
-        SKIP("GPU not available on this device");
+        WARN("Skipping GPUStereo test: GPU not available on this device");
+        return;
     }
 
     dai::Pipeline pipeline(device);


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy warnings by lowering log level for certain auto‑calibration validation messages.

* **Refactor**
  * Improved device initialization flow for GPU examples to be more robust.

* **Style / Chores**
  * Minor formatting and header ordering cleanups in example code and headers; small formatting tweaks to status text rendering.

* **Tests**
  * Adjusted on-device GPU test behavior to emit warnings and return early when GPU/device is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->