### PR TITLE
Fix: Set Buffer data via rvalue instead of lvalue

### DIFF
--- a/src/pipeline/datatype/ImgDetectionsT.cpp
+++ b/src/pipeline/datatype/ImgDetectionsT.cpp
@@ -28,8 +28,8 @@ void ImgDetectionsT<DetectionT>::setSegmentationMask(const std::vector<std::uint
     if(mask.size() != width * height) {
         throw std::runtime_error("SegmentationMask: data size does not match width*height");
     }
-    auto vecMask = mask;
-    setData(std::move(vecMask));
+    auto vecMask = mask;          // Avoid mutating shared storage by moving a copy of the input into a new buffer
+    setData(std::move(vecMask));  // Call the rvalue overload to allocate a new memory holder
     this->segmentationMaskWidth = width;
     this->segmentationMaskHeight = height;
 }
@@ -41,7 +41,7 @@ void ImgDetectionsT<DetectionT>::setSegmentationMask(dai::ImgFrame& frame) {
     }
     auto dataSpan = frame.getData();
     std::vector<std::uint8_t> vecMask(dataSpan.begin(), dataSpan.end());
-    setData(std::move(vecMask));
+    setData(std::move(vecMask));  // Call the rvalue overload to allocate a new memory holder
     this->segmentationMaskWidth = frame.getWidth();
     this->segmentationMaskHeight = frame.getHeight();
 }
@@ -89,7 +89,7 @@ void ImgDetectionsT<DetectionT>::setCvSegmentationMask(cv::Mat mask) {
     } else {
         dataVec.insert(dataVec.begin(), mask.datastart, mask.dataend);
     }
-    setData(std::move(dataVec));
+    setData(std::move(dataVec));  // Call the rvalue overload to allocate a new memory holder
     this->segmentationMaskWidth = mask.cols;
     this->segmentationMaskHeight = mask.rows;
 }

--- a/src/pipeline/datatype/ImgDetectionsT.cpp
+++ b/src/pipeline/datatype/ImgDetectionsT.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstring>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "depthai/pipeline/datatype/ImgDetections.hpp"
@@ -27,7 +28,8 @@ void ImgDetectionsT<DetectionT>::setSegmentationMask(const std::vector<std::uint
     if(mask.size() != width * height) {
         throw std::runtime_error("SegmentationMask: data size does not match width*height");
     }
-    setData(mask);
+    auto vecMask = mask;
+    setData(std::move(vecMask));
     this->segmentationMaskWidth = width;
     this->segmentationMaskHeight = height;
 }
@@ -39,7 +41,7 @@ void ImgDetectionsT<DetectionT>::setSegmentationMask(dai::ImgFrame& frame) {
     }
     auto dataSpan = frame.getData();
     std::vector<std::uint8_t> vecMask(dataSpan.begin(), dataSpan.end());
-    setData(vecMask);
+    setData(std::move(vecMask));
     this->segmentationMaskWidth = frame.getWidth();
     this->segmentationMaskHeight = frame.getHeight();
 }
@@ -87,7 +89,7 @@ void ImgDetectionsT<DetectionT>::setCvSegmentationMask(cv::Mat mask) {
     } else {
         dataVec.insert(dataVec.begin(), mask.datastart, mask.dataend);
     }
-    setData(dataVec);
+    setData(std::move(dataVec));
     this->segmentationMaskWidth = mask.cols;
     this->segmentationMaskHeight = mask.rows;
 }

--- a/src/pipeline/datatype/SegmentationMask.cpp
+++ b/src/pipeline/datatype/SegmentationMask.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "depthai/common/RotatedRect.hpp"
@@ -43,8 +44,8 @@ void SegmentationMask::setMask(const std::vector<std::uint8_t>& mask, size_t wid
     if(mask.size() != width * height) {
         throw std::runtime_error("SegmentationMask: data size does not match width*height");
     }
-    auto vecMask = mask;
-    setData(std::move(vecMask));
+    auto vecMask = mask;          // Avoid mutating shared storage by moving a copy of the input into a new buffer
+    setData(std::move(vecMask));  // Call the rvalue overload to allocate a new memory holder
     this->width = width;
     this->height = height;
 }
@@ -241,7 +242,7 @@ void SegmentationMask::setCvMask(cv::Mat mask) {
     } else {
         dataVec.insert(dataVec.begin(), mask.datastart, mask.dataend);
     }
-    setData(std::move(dataVec));
+    setData(std::move(dataVec));  // Call the rvalue overload to allocate a new memory holder
     this->width = mask.cols;
     this->height = mask.rows;
 }

--- a/src/pipeline/datatype/SegmentationMask.cpp
+++ b/src/pipeline/datatype/SegmentationMask.cpp
@@ -43,7 +43,8 @@ void SegmentationMask::setMask(const std::vector<std::uint8_t>& mask, size_t wid
     if(mask.size() != width * height) {
         throw std::runtime_error("SegmentationMask: data size does not match width*height");
     }
-    setData(mask);
+    auto vecMask = mask;
+    setData(std::move(vecMask));
     this->width = width;
     this->height = height;
 }
@@ -240,7 +241,7 @@ void SegmentationMask::setCvMask(cv::Mat mask) {
     } else {
         dataVec.insert(dataVec.begin(), mask.datastart, mask.dataend);
     }
-    setData(dataVec);
+    setData(std::move(dataVec));
     this->width = mask.cols;
     this->height = mask.rows;
 }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Segmentation mask data is stored in `std::shared_ptr<Memory> data`. When setting the segmask via lvalue, it uses the following function:
```void Buffer::setData(const std::vector<std::uint8_t>& d) {
    if(data->getMaxSize() >= d.size()) {
        // TODO(themarpe) - has to set offset as well
        memcpy(data->getData().data(), d.data(), d.size());
    } else {
        // allocate new holder
        data = std::make_shared<VectorMemory>(std::move(d));
    }
}
```
If the new `d` is smaller than the current VectorMemory size, then `data->getSize()` will return old memory size.

Setting a segmentation mask should replace the underlying memory or perform copy-on-write, not mutate shared storage in place. So setting via rvalue is needed:
 ```
void Buffer::setData(std::vector<std::uint8_t>&& d) {
    // allocate new holder
    data = std::make_shared<VectorMemory>(std::move(d));
    // *mem = std::move(d);
    // data = mem;
}
```

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: codex:5.4 xhigh

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of segmentation masks and image detections to reduce memory copies and improve performance when setting or converting mask data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->