### PR TITLE
Enabling builds without OpenCV

### DIFF
--- a/include/depthai/pipeline/node/ToF.hpp
+++ b/include/depthai/pipeline/node/ToF.hpp
@@ -82,14 +82,24 @@ class ToF : public DeviceNodeGroup {
     ToF(const std::shared_ptr<Device>& device)
         : DeviceNodeGroup(device),
           rawDepth{tofBase->depth},
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
           depth{imageFilters->output},
+#else
+          depth{tofBase->depth},
+#endif
           amplitude{tofBase->amplitude},
           intensity{tofBase->intensity},
           phase{tofBase->phase},
           tofBaseInputConfig{tofBase->inputConfig},
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
           imageFiltersInputConfig{imageFilters->inputConfig},
-          tofBaseNode{*tofBase},
-          imageFiltersNode{*imageFilters} {}
+#endif
+          tofBaseNode{*tofBase}
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
+          ,
+          imageFiltersNode{*imageFilters}
+#endif
+    {}
 
     ~ToF() override;
 
@@ -102,22 +112,28 @@ class ToF : public DeviceNodeGroup {
     void buildInternal() override {
         // Build all subnodes, call their internal build functions
         tofBase->buildInternal();
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
         imageFilters->buildInternal();
 
         // Link subnodes together
         tofBase->depth.link(imageFilters->input);
+#endif
     }
 
     std::shared_ptr<ToF> build(dai::CameraBoardSocket boardSocket = dai::CameraBoardSocket::AUTO,
                                dai::ImageFiltersPresetMode presetMode = dai::ImageFiltersPresetMode::TOF_MID_RANGE,
                                std::optional<float> fps = std::nullopt) {
         tofBase->build(boardSocket, presetMode, fps);
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
         imageFilters->build(presetMode);
+#endif
         return std::static_pointer_cast<ToF>(shared_from_this());
     }
 
     Subnode<ToFBase> tofBase{*this, "tofBase"};
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
     Subnode<ImageFilters> imageFilters{*this, "imageFilters"};
+#endif
 
     /**
      * Raw depth output from ToF sensor
@@ -149,20 +165,24 @@ class ToF : public DeviceNodeGroup {
      */
     Input& tofBaseInputConfig;
 
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
     /**
      * Input config for image filters
      */
     Input& imageFiltersInputConfig;
+#endif
 
     /**
      * ToF base node
      */
     ToFBase& tofBaseNode;
 
+#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
     /**
      * Image filters node
      */
     ImageFilters& imageFiltersNode;
+#endif
 };
 
 }  // namespace node

--- a/src/pipeline/node/Rectification.cpp
+++ b/src/pipeline/node/Rectification.cpp
@@ -32,6 +32,14 @@ bool Rectification::runOnHost() const {
     return runOnHostVar;
 }
 
+CalibrationHandler Rectification::getCalibrationData() const {
+    if(device) {
+        return device->readCalibration();
+    } else {
+        return getParentPipeline().getCalibrationData();
+    }
+}
+
 #if !defined(DEPTHAI_HAVE_OPENCV_SUPPORT)
 void Rectification::run() {
     throw std::runtime_error("Rectification node requires OpenCV support to run. Please enable OpenCV support in your build configuration.");
@@ -94,14 +102,6 @@ std::string matToString(const cv::Mat& mat) {
 }
 
 }  // namespace
-
-CalibrationHandler Rectification::getCalibrationData() const {
-    if(device) {
-        return device->readCalibration();
-    } else {
-        return getParentPipeline().getCalibrationData();
-    }
-}
 
 std::vector<std::vector<float> > applyRectificationMatrix(const dai::Extrinsics& extrinsics, const cv::Mat& rectificationMatrix) {
     cv::Mat rectificationMatrixInv;

--- a/src/utility/PipelineImplHelper.cpp
+++ b/src/utility/PipelineImplHelper.cpp
@@ -96,7 +96,7 @@ void PipelineImplHelper::setupHolisticRecordAndReplay(std::weak_ptr<PipelineImpl
                         }
                     }
 #else
-                    recordConfig.state = RecordConfig::RecordReplayState::NONE;
+                    pipeline->recordConfig.state = RecordConfig::RecordReplayState::NONE;
                     if(!recordPath.empty() || !replayPath.empty()) {
                         Logging::getInstance().logger.warn("Merged target is required to use holistic record/replay.");
                     }

--- a/src/utility/RecordReplay.cpp
+++ b/src/utility/RecordReplay.cpp
@@ -231,7 +231,7 @@ std::string matchTo(const std::vector<std::string>& deviceIds, const std::vector
 }
 
 #ifndef DEPTHAI_HAVE_OPENCV_SUPPORT
-std::tuple<size_t, size_t> getVideoSize(const std::string& filePath) {
+std::tuple<size_t, size_t, double> getVideoSize(const std::string& filePath) {
     (void)filePath;
     throw std::runtime_error("OpenCV is required to get video size");
 }


### PR DESCRIPTION
## Purpose
Enabling builds without OpenCV (`DEPTHAI_OPENCV_SUPPORT=OFF`)

## Specification
Building depthai-core with `-DDEPTHAI_OPENCV_SUPPORT=OFF` currently fails to
compile and link. (This was previously fixed in #1574 but has since regressed —
the OpenCV-off configuration isn't covered by CI.) Four issues are addressed:

- **`src/utility/RecordReplay.cpp`** — the no-OpenCV `getVideoSize()` fallback
  returned `std::tuple<size_t, size_t>`, but the declaration in
  `RecordReplayImpl.hpp` is `std::tuple<size_t, size_t, double>`, so it failed
  as an overload differing only by return type. Fallback signature corrected to
  match the declaration.
- **`src/utility/PipelineImplHelper.cpp`** — the `#else` (non-`DEPTHAI_MERGED_TARGET`)
  branch referenced a bare `recordConfig` instead of `pipeline->recordConfig`
  (undeclared identifier). Qualified correctly.
- **`include/depthai/pipeline/node/ToF.hpp`** — the `ToF` node group
  unconditionally embeds a `Subnode<ImageFilters>` (ImageFilters is an
  OpenCV-only node) and exposes `imageFilters->output` as its filtered `depth`
  output, pulling ImageFilters' vtable/symbols into the always-compiled `ToF`.
  The `ImageFilters` subnode, its `build`/link wiring, and the `imageFilters*`
  accessors are now guarded behind `DEPTHAI_HAVE_OPENCV_SUPPORT`. When OpenCV is
  unavailable, `ToF::depth` falls back to the raw `tofBase` depth output.
- **`src/pipeline/node/Rectification.cpp`** — `Rectification::getCalibrationData()`
  (which uses no OpenCV) was defined only inside the OpenCV-enabled block,
  leaving the always-emitted `Rectification` vtable with an undefined reference.
  Moved it out so it is always defined.

## Dependencies & Potential Impact
No impact on the default (OpenCV-enabled) build — all changes are inside
`#ifdef DEPTHAI_HAVE_OPENCV_SUPPORT` guards or are a no-op relocation of a
non-OpenCV method. No public API change in the OpenCV-on configuration.

Behavioral note for the OpenCV-off configuration only: with OpenCV disabled,
`ToF::depth` provides unfiltered (raw) depth instead of ImageFilters-filtered
depth, and the `imageFiltersInputConfig` / `imageFiltersNode` accessors are not
present — consistent with `Rectification::run()` already throwing without
OpenCV. No ABI break, since the OpenCV-off configuration did not previously
compile at all.

## Deployment Plan
Not applicable — source-only build fix, no runtime/rollout component. Rollback
is reverting the commit.

## Testing & Validation
Built `depthai-core` on macOS arm64 (Apple Silicon) with OpenCV **not installed
at all** and `-DDEPTHAI_OPENCV_SUPPORT=OFF`:
configures (OpenCV not found/disabled), compiles all translation units, and
links `libdepthai-core` with **zero OpenCV linkage** (verified via `otool -L`).

End-to-end validated against real hardware: built a downstream consumer
(RGB + StereoDepth + VideoEncoder pipeline) against the OpenCV-off
`libdepthai-core` and ran it on an OAK-D Lite — device boots, depth aligns to
RGB (1280x720), MJPEG-encoded pipeline runs, frames stream — all with no OpenCV
present.

## AI Usage
Assisted-by: Claude:claude-opus-4 clang-tidy

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Video size retrieval now provides enhanced information.

* **Bug Fixes**
  * Fixed record and replay state management in holistic configurations.
  * Improved calibration data availability across different build scenarios.
  * Enhanced device compatibility when optional image processing features are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/depthai-core/pull/1818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->