### PR TITLE
Bump FW RVC2

### DIFF
--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "726915020ea4bd8a0e55180cb92050999aa6fa7f")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "bb3777748d351563ca7798d7b6b7c7f856f32703")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "f273d3443a3a3e9ba2bea7e012dba13a6a2863d6")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "726915020ea4bd8a0e55180cb92050999aa6fa7f")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")


### PR DESCRIPTION
## Stereo depth fix

### Issue
- Stereo depth assumed only sockets topologically connected by calibration handler


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated device-side build metadata to reference a newer device binary snapshot.
  * Metadata-only change; no functional differences, configuration changes, or user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->