### PR TITLE
CBACalibrationHandler now handles legacy non CBA camera sockets

### DIFF
--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -56,11 +56,15 @@ void validateImuCalibrationMatrix(const std::vector<std::vector<float>>& calibra
 }
 
 EepromData validateCBAEepromData(EepromData eepromData) {
-    if(eepromData.cameraData.empty()) {
-        return eepromData;
+    if(eepromData.cameraData.size() != 1) {
+        throw std::runtime_error("CBA calibration data must contain exactly one cameraData entry.");
     }
-    if(eepromData.cameraData.size() != 1 || eepromData.cameraData.find(CameraBoardSocket::CBA) == eepromData.cameraData.end()) {
-        throw std::runtime_error("CBA calibration data must contain only a CameraBoardSocket::CBA cameraData entry.");
+
+    auto it = eepromData.cameraData.begin();
+    if(it->first != CameraBoardSocket::CBA) {
+        CameraInfo cameraInfo = it->second;
+        eepromData.cameraData.erase(it);
+        eepromData.cameraData.emplace(CameraBoardSocket::CBA, cameraInfo);
     }
     return eepromData;
 }

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -98,12 +98,10 @@ dai::CameraBoardSocket validatePhysicalCBASocket(dai::CameraBoardSocket cbaSocke
     return cbaSocket;
 }
 
-void validateCBACalibrationData(const dai::CBACalibrationHandler& calibrationDataHandler) {
+bool validateCBACalibrationData(const dai::CBACalibrationHandler& calibrationDataHandler) {
     const auto eepromData = calibrationDataHandler.getEepromData();
     const auto& cameraData = eepromData.cameraData;
-    if(cameraData.size() != 1 || cameraData.find(dai::CameraBoardSocket::CBA) == cameraData.end()) {
-        throw std::runtime_error("CBA calibration data must contain exactly one CameraBoardSocket::CBA cameraData entry.");
-    }
+    return cameraData.size() == 1 && cameraData.find(dai::CameraBoardSocket::CBA) != cameraData.end();
 }
 
 std::string lowercase(std::string value) {
@@ -2009,6 +2007,10 @@ bool DeviceBase::tryFlashCalibration(CalibrationHandler calibrationDataHandler) 
 }
 
 bool DeviceBase::tryFlashCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket) {
+    if(!validateCBACalibrationData(calibrationDataHandler)) {
+        return false;
+    }
+
     try {
         flashCBACalibration(calibrationDataHandler, camSocket);
     } catch(const EepromError& e) {
@@ -2036,7 +2038,9 @@ void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
 
 void DeviceBase::flashCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket) {
     camSocket = validatePhysicalCBASocket(camSocket);
-    validateCBACalibrationData(calibrationDataHandler);
+    if(!validateCBACalibrationData(calibrationDataHandler)) {
+        throw std::runtime_error("CBA calibration data must contain exactly one CameraBoardSocket::CBA cameraData entry.");
+    }
 
     bool factoryPermissions = false;
     bool protectedPermissions = false;
@@ -2167,7 +2171,9 @@ void DeviceBase::flashFactoryCalibration(CalibrationHandler calibrationDataHandl
 
 void DeviceBase::flashFactoryCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket) {
     camSocket = validatePhysicalCBASocket(camSocket);
-    validateCBACalibrationData(calibrationDataHandler);
+    if(!validateCBACalibrationData(calibrationDataHandler)) {
+        throw std::runtime_error("CBA calibration data must contain exactly one CameraBoardSocket::CBA cameraData entry.");
+    }
 
     bool factoryPermissions = false;
     bool protectedPermissions = false;

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -98,6 +98,14 @@ dai::CameraBoardSocket validatePhysicalCBASocket(dai::CameraBoardSocket cbaSocke
     return cbaSocket;
 }
 
+void validateCBACalibrationData(const dai::CBACalibrationHandler& calibrationDataHandler) {
+    const auto eepromData = calibrationDataHandler.getEepromData();
+    const auto& cameraData = eepromData.cameraData;
+    if(cameraData.size() != 1 || cameraData.find(dai::CameraBoardSocket::CBA) == cameraData.end()) {
+        throw std::runtime_error("CBA calibration data must contain exactly one CameraBoardSocket::CBA cameraData entry.");
+    }
+}
+
 std::string lowercase(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
     return value;
@@ -2028,6 +2036,7 @@ void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
 
 void DeviceBase::flashCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket) {
     camSocket = validatePhysicalCBASocket(camSocket);
+    validateCBACalibrationData(calibrationDataHandler);
 
     bool factoryPermissions = false;
     bool protectedPermissions = false;
@@ -2097,13 +2106,12 @@ CalibrationHandler DeviceBase::readCalibration() {
 }
 
 CBACalibrationHandler DeviceBase::readCBACalibration(CameraBoardSocket camSocket) {
-    dai::EepromData eepromData{};
     try {
         return readCBACalibration2(camSocket);
     } catch(const EepromError&) {
         // ignore - use default
     }
-    return CBACalibrationHandler(eepromData);
+    return CBACalibrationHandler();
 }
 
 CalibrationHandler DeviceBase::readCalibration2() {
@@ -2159,6 +2167,7 @@ void DeviceBase::flashFactoryCalibration(CalibrationHandler calibrationDataHandl
 
 void DeviceBase::flashFactoryCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket) {
     camSocket = validatePhysicalCBASocket(camSocket);
+    validateCBACalibrationData(calibrationDataHandler);
 
     bool factoryPermissions = false;
     bool protectedPermissions = false;
@@ -2217,13 +2226,12 @@ CalibrationHandler DeviceBase::readFactoryCalibrationOrDefault() {
 }
 
 CBACalibrationHandler DeviceBase::readFactoryCBACalibrationOrDefault(CameraBoardSocket camSocket) {
-    dai::EepromData eepromData{};
     try {
         return readFactoryCBACalibration(camSocket);
     } catch(const EepromError&) {
         // ignore - use default
     }
-    return CBACalibrationHandler(eepromData);
+    return CBACalibrationHandler();
 }
 
 void DeviceBase::factoryResetCalibration() {

--- a/tests/src/onhost_tests/calibration_handler_test.cpp
+++ b/tests/src/onhost_tests/calibration_handler_test.cpp
@@ -1375,3 +1375,39 @@ TEST_CASE("getCameraToImuExtrinsics scales translation for all units", "[getCame
         requireMatrixApproxEqual(result, expected);
     }
 }
+
+TEST_CASE("CBA calibration handler updates a legacy single camera socket to a CBA socket", "[CBACalibrationHandler]") {
+    dai::EepromData data;
+
+    dai::CameraInfo cam;
+    cam.width = 640;
+    cam.height = 480;
+    cam.lensPosition = 42;
+    cam.specHfovDeg = 72.0f;
+
+    data.cameraData[CameraBoardSocket::CAM_B] = cam;
+
+    CBACalibrationHandler handler(data);
+    const auto loaded = handler.getEepromData();
+
+    REQUIRE(loaded.cameraData.size() == 1);
+    auto cbaCameraData = loaded.cameraData.find(CameraBoardSocket::CBA);
+    REQUIRE(cbaCameraData != loaded.cameraData.end());
+
+    const auto& loadedCam = cbaCameraData->second;
+    REQUIRE(loadedCam.width == cam.width);
+    REQUIRE(loadedCam.height == cam.height);
+    REQUIRE(loadedCam.lensPosition == cam.lensPosition);
+    REQUIRE(loadedCam.specHfovDeg == cam.specHfovDeg);
+}
+
+TEST_CASE("CBA calibration handler requires exactly one cameraData entry", "[CBACalibrationHandler]") {
+    dai::EepromData empty;
+    REQUIRE_THROWS_WITH(CBACalibrationHandler(empty), Catch::Matchers::ContainsSubstring("exactly one cameraData entry"));
+
+    dai::EepromData data;
+    data.cameraData[CameraBoardSocket::CAM_B] = dai::CameraInfo{};
+    data.cameraData[CameraBoardSocket::CAM_C] = dai::CameraInfo{};
+
+    REQUIRE_THROWS_WITH(CBACalibrationHandler(data), Catch::Matchers::ContainsSubstring("exactly one cameraData entry"));
+}


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
* When reading CBA calibrations stored on a CBA, where the calibration was flashed before the `CBACalibrationHandler` update, the read would fail due to the CameraData not containing the expected `CameraBoardSocket::CBA` entry.
This is now fixed, where in such cases, the CameraData entry is automatically updated as a `CameraBoardSocket::CBA` instead of the old cam socket.

* Added test coverage for this. 

* Added additional checks when flashing CBA calibration - which checks if the camera data we are trying to flash contains only a single socket entry of the type `CameraBoardSocket::CBA`

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME: Codex 5.4.

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of camera calibration data to enforce stricter requirements.
  * Enhanced error handling for corrupted or invalid calibration entries by returning safe defaults.
  * Added support for legacy camera configurations through automatic remapping.

* **Tests**
  * Added test coverage for calibration validation and legacy configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->