### PR TITLE
Add auto-exposure maximum ISO control

### DIFF
--- a/bindings/python/src/pipeline/datatype/CameraControlBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/CameraControlBindings.cpp
@@ -80,7 +80,8 @@ void bind_cameracontrol(pybind11::module& m, void* pCallstack) {
         .value("AF_REGION", CameraControl::Command::AF_REGION)
         .value("LUMA_DENOISE", CameraControl::Command::LUMA_DENOISE)
         .value("CHROMA_DENOISE", CameraControl::Command::CHROMA_DENOISE)
-        .value("WB_COLOR_TEMP", CameraControl::Command::WB_COLOR_TEMP);
+        .value("WB_COLOR_TEMP", CameraControl::Command::WB_COLOR_TEMP)
+        .value("AE_MAX_ISO", CameraControl::Command::AE_MAX_ISO);
 
     camCtrlAttr.push_back("AutoFocusMode");
     cameraControlAutoFocusMode.value("OFF", CameraControl::AutoFocusMode::OFF)
@@ -237,6 +238,10 @@ void bind_cameracontrol(pybind11::module& m, void* pCallstack) {
              py::overload_cast<std::chrono::microseconds>(&CameraControl::setAutoExposureLimit),
              py::arg("maxExposureTime"),
              DOC(dai, CameraControl, setAutoExposureLimit, 2))
+        .def("setAutoExposureMaxISO",
+             &CameraControl::setAutoExposureMaxISO,
+             py::arg("aeMaxISO"),
+             DOC(dai, CameraControl, setAutoExposureMaxISO))
         .def("setAntiBandingMode", &CameraControl::setAntiBandingMode, py::arg("mode"), DOC(dai, CameraControl, setAntiBandingMode))
         .def("setManualExposure",
              py::overload_cast<uint32_t, uint32_t>(&CameraControl::setManualExposure),

--- a/cmake/Depthai/DepthaiDeviceRVC4Config.cmake
+++ b/cmake/Depthai/DepthaiDeviceRVC4Config.cmake
@@ -3,4 +3,4 @@
 set(DEPTHAI_DEVICE_RVC4_MATURITY "snapshot")
 
 # "version if applicable"
-set(DEPTHAI_DEVICE_RVC4_VERSION "0.0.1+656f19d8caeedccb34cd4ba2fe4b2711affab61b")
+set(DEPTHAI_DEVICE_RVC4_VERSION "0.0.1+885c87889c241dabf29cb3cd503bbdfb9be39c35")

--- a/cmake/Depthai/DepthaiDeviceSideConfig.cmake
+++ b/cmake/Depthai/DepthaiDeviceSideConfig.cmake
@@ -2,7 +2,7 @@
 set(DEPTHAI_DEVICE_SIDE_MATURITY "snapshot")
 
 # "full commit hash of device side binary"
-set(DEPTHAI_DEVICE_SIDE_COMMIT "8d6a04d380ce182e0cb3a4694309426370295a9f")
+set(DEPTHAI_DEVICE_SIDE_COMMIT "f273d3443a3a3e9ba2bea7e012dba13a6a2863d6")
 
 # "version if applicable"
 set(DEPTHAI_DEVICE_SIDE_VERSION "")

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -122,6 +122,7 @@ class CameraControl : public Buffer {
         STROBE_TIMINGS = 54,
         MOVE_LENS_RAW = 55, /* lens position: 0.0 - 1.0 */
         HDR = 56,
+        AE_MAX_ISO = 57,
     };
 
     enum class AutoFocusMode : uint8_t {
@@ -562,6 +563,14 @@ class CameraControl : public Buffer {
     CameraControl& setAutoExposureLimit(std::chrono::microseconds maxExposureTime);
 
     /**
+     * Set a command to specify the maximum ISO sensitivity limit for auto-exposure. 
+     * This limits the AE algorithm from increasing sensitivity beyond a certain point
+     * and can help to reduce noise in low-light conditions.
+     * @param aeMaxISO Maximum ISO
+     */
+    CameraControl& setAutoExposureMaxISO(uint32_t aeMaxISO);
+
+    /**
      * Set a command to specify anti-banding mode. Anti-banding / anti-flicker
      * works in auto-exposure mode, by controlling the exposure time to be applied
      * in multiples of half the mains period, for example in multiple of 10ms
@@ -765,6 +774,7 @@ class CameraControl : public Buffer {
     StrobeConfig strobeConfig;
     StrobeTimings strobeTimings;
     uint32_t aeMaxExposureTimeUs;
+    uint32_t aeMaxISO;
     bool aeLockMode{false};
     bool awbLockMode{false};
     int8_t expCompensation;     //  -9 ..  9
@@ -824,6 +834,7 @@ class CameraControl : public Buffer {
                       strobeConfig,
                       strobeTimings,
                       aeMaxExposureTimeUs,
+                      aeMaxISO,
                       expCompensation,
                       brightness,
                       contrast,

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -122,6 +122,11 @@ CameraControl& CameraControl::setAutoExposureLimit(uint32_t maxExposureTimeUs) {
 CameraControl& CameraControl::setAutoExposureLimit(std::chrono::microseconds maxExposureTime) {
     return setAutoExposureLimit(maxExposureTime.count());
 }
+CameraControl& CameraControl::setAutoExposureMaxISO(uint32_t aeMaxISO) {
+    setCommand(CameraControl::Command::AE_MAX_ISO);
+    this->aeMaxISO = aeMaxISO;
+    return *this;
+}
 CameraControl& CameraControl::setAntiBandingMode(AntiBandingMode mode) {
     setCommand(Command::ANTIBANDING_MODE);
     antiBandingMode = mode;

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -7,6 +7,10 @@ for manual exposure/focus:
   exposure time:     I   O      1..33000 [us]
   sensitivity iso:   K   L    100..1600
   focus:             ,   .      0..255 [far..near]
+for auto exposure:
+  Control:          key[dec/inc]  min..max
+  max exposure time:     g   h      1..33000 [us]
+  max ISO:               b   n      100..1600
 To go back to auto controls:
   'E' - autoexposure
   'F' - autofocus (continuous)
@@ -567,6 +571,7 @@ with dai.Pipeline(dai.Device(*dai_device_args)) as pipeline:
     floodIntensity = 0
 
     expTimeLimit = 700
+    expMaxISO = 500
 
     awb_mode = Cycle(dai.CameraControl.AutoWhiteBalanceMode)
     anti_banding_mode = Cycle(dai.CameraControl.AntiBandingMode)
@@ -753,9 +758,20 @@ with dai.Pipeline(dai.Device(*dai_device_args)) as pipeline:
                 expTimeLimit -= 50
             else:
                 expTimeLimit += 50
-            print("Exposure time limit: ", expTimeLimit)
+            print("Auto exposure time limit: ", expTimeLimit)
             ctrl = dai.CameraControl()
             ctrl.setAutoExposureLimit(expTimeLimit)
+            ctrl.setAutoExposureEnable()
+            controlQueueSend(ctrl)
+        elif key in [ord('b'), ord('n')]:
+            if key == ord('b'):
+                expMaxISO -= 50
+            else:
+                expMaxISO += 50
+            print("Auto exposure ISO limit: ", expMaxISO)
+            ctrl = dai.CameraControl()
+            ctrl.setAutoExposureMaxISO(expMaxISO)
+            ctrl.setAutoExposureEnable()
             controlQueueSend(ctrl)
         elif key == ord('1'):
             awb_lock = not awb_lock


### PR DESCRIPTION
## Purpose
Add support for limiting the maximum ISO used by the auto-exposure algorithm, which can help reduce image noise in low-light scenes.

## Specification
Adds a new `CameraControl::Command::AE_MAX_ISO` command and a C++ API method `CameraControl::setAutoExposureMaxISO(uint32_t aeMaxISO)`. The new value is serialized as part of `CameraControl`, and the `AE_MAX_ISO` command enum is exposed in Python bindings.

## Dependencies & Potential Impact
Requires device-side/firmware support for handling the new `AE_MAX_ISO` camera control command. This is an additive API change, so no existing API breakage is expected.

## Deployment Plan
An additional change is required in depthai-device-kb. No changes planned for the RVC2 depthai repo.

## Testing & Validation
Local testing.

## AI Usage
Assisted-by: Codex:GPT-5.4

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auto-exposure maximum ISO control, enabling users to set an upper ISO limit during automatic exposure adjustment
  * Introduced interactive keyboard shortcuts (b/n) to adjust the maximum ISO value in real-time (default: 500)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->