### PR TITLE
Remove unused logger in SpatialUtils

### DIFF
--- a/src/pipeline/utilities/SpatialLocationCalculator/SpatialUtils.cpp
+++ b/src/pipeline/utilities/SpatialLocationCalculator/SpatialUtils.cpp
@@ -302,8 +302,7 @@ dai::SpatialImgDetection computeSpatialDetection(const dai::ImgFrame& depthFrame
                                                  const int instanceIndex,
                                                  const dai::ImgTransformation& detectionsTransformation,
                                                  const int segMaskWidth,
-                                                 const int segMaskHeight,
-                                                 const std::shared_ptr<spdlog::async_logger>& logger) {
+                                                 const int segMaskHeight) {
     const uint32_t lowerThreshold = config.globalLowerThreshold;
     const uint32_t upperThreshold = config.globalUpperThreshold;
     const SpatialLocationCalculatorAlgorithm calculationAlgorithm = config.globalCalculationAlgorithm;
@@ -454,8 +453,7 @@ void computeSpatialDetections(const dai::ImgFrame& depthFrame,
                                                                                i,
                                                                                *detectionsTransformation,
                                                                                static_cast<int>(segmentationMaskWidth),
-                                                                               static_cast<int>(segmentationMaskHeight),
-                                                                               logger);
+                                                                               static_cast<int>(segmentationMaskHeight));
         spatialDetections.detections[i] = spatialImgDetection;
     }
 }


### PR DESCRIPTION
## Remove unused variable
- remove a logger from `SpatialUtils.cpp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal spatial calculation functions by removing unnecessary logging parameters from function signatures, streamlining the computation workflow with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->