### PR TITLE
Add intrinsics and distortion mismatch warnings in PointCloud node

### DIFF
--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -3,7 +3,6 @@
 #include <spdlog/logger.h>
 
 #include <chrono>
-#include <cmath>
 #include <cstring>
 #include <future>
 #include <thread>

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -665,19 +665,8 @@ void PointCloud::processColorized(std::shared_ptr<ImgFrame> depthFrame,
     }
 
     // Check extrinsics mismatches (non-fatal)
-    {
-        auto depthExtrinsics = depthFrame->transformation.getExtrinsics();
-        auto colorExtrinsics = colorFrame->transformation.getExtrinsics();
-        if(depthExtrinsics.toCameraSocket != colorExtrinsics.toCameraSocket) {
-            pimpl->logger->error("PointCloud: color extrinsics toCameraSocket ({}) does not match depth ({}) -- colorization may be misaligned",
-                                 toString(colorExtrinsics.toCameraSocket),
-                                 toString(depthExtrinsics.toCameraSocket));
-        } else if(!depthExtrinsics.isEqualExtrinsics(colorExtrinsics)) {
-            pimpl->logger->error(
-                "PointCloud: depth and color extrinsics differ (same toCameraSocket={} but different rotation/translation) "
-                "-- colorization may be misaligned",
-                toString(depthExtrinsics.toCameraSocket));
-        }
+    if(!depthFrame->transformation.getExtrinsics().isEqualExtrinsics(colorFrame->transformation.getExtrinsics())) {
+        pimpl->logger->error("PointCloud: depth and color extrinsics differ -- colorization may be misaligned");
     }
 
     // Check intrinsics and distortion mismatches (non-fatal)

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -3,6 +3,7 @@
 #include <spdlog/logger.h>
 
 #include <chrono>
+#include <cmath>
 #include <cstring>
 #include <future>
 #include <thread>
@@ -663,44 +664,54 @@ void PointCloud::processColorized(std::shared_ptr<ImgFrame> depthFrame,
         return;
     }
 
-    // Warn about extrinsics mismatches (non-fatal)
+    // Check extrinsics mismatches (non-fatal)
     {
         auto depthExtrinsics = depthFrame->transformation.getExtrinsics();
         auto colorExtrinsics = colorFrame->transformation.getExtrinsics();
         if(depthExtrinsics.toCameraSocket != colorExtrinsics.toCameraSocket) {
-            pimpl->logger->warn("PointCloud: color extrinsics toCameraSocket ({}) does not match depth ({}) -- colorization may be misaligned",
+            pimpl->logger->error("PointCloud: color extrinsics toCameraSocket ({}) does not match depth ({}) -- colorization may be misaligned",
                                 toString(colorExtrinsics.toCameraSocket),
                                 toString(depthExtrinsics.toCameraSocket));
         } else if(depthExtrinsics.rotationMatrix != colorExtrinsics.rotationMatrix || depthExtrinsics.translation.x != colorExtrinsics.translation.x
                   || depthExtrinsics.translation.y != colorExtrinsics.translation.y || depthExtrinsics.translation.z != colorExtrinsics.translation.z) {
-            pimpl->logger->warn(
+            pimpl->logger->error(
                 "PointCloud: depth and color extrinsics differ (same toCameraSocket={} but different rotation/translation) "
                 "-- colorization may be misaligned",
                 toString(depthExtrinsics.toCameraSocket));
         }
     }
 
-    // Warn about intrinsics mismatches (non-fatal)
+    // Epsilon-based float comparison helper (reused for intrinsics and distortion coefficients)
+    constexpr float kEpsilon = 1e-6f;
+    auto approxEqualFloatVectors = [kEpsilon](const float* a, const float* b, size_t n) {
+        for(size_t i = 0; i < n; ++i) {
+            if(std::abs(a[i] - b[i]) > kEpsilon) return false;
+        }
+        return true;
+    };
+
+    // Check intrinsics mismatches (non-fatal)
     {
         auto depthIntrinsics = depthFrame->transformation.getIntrinsicMatrix();
         auto colorIntrinsics = colorFrame->transformation.getIntrinsicMatrix();
-        if(depthIntrinsics != colorIntrinsics) {
-            pimpl->logger->warn("PointCloud: color intrinsics do not match depth intrinsics -- colorization may be misaligned");
+        if(!approxEqualFloatVectors(&depthIntrinsics[0][0], &colorIntrinsics[0][0], 9)) {
+            pimpl->logger->error("PointCloud: color intrinsics do not match depth intrinsics -- colorization may be misaligned");
         }
     }
 
-    // Warn about distortion mismatches (non-fatal)
+    // Check distortion mismatches (non-fatal)
     {
         auto depthDistModel = depthFrame->transformation.getDistortionModel();
         auto colorDistModel = colorFrame->transformation.getDistortionModel();
         auto depthDistCoeffs = depthFrame->transformation.getDistortionCoefficients();
         auto colorDistCoeffs = colorFrame->transformation.getDistortionCoefficients();
         if(depthDistModel != colorDistModel) {
-            pimpl->logger->warn("PointCloud: color distortion model ({}) does not match depth ({}) -- colorization may be misaligned",
+            pimpl->logger->error("PointCloud: color distortion model ({}) does not match depth ({}) -- colorization may be misaligned",
                                 static_cast<int>(colorDistModel),
                                 static_cast<int>(depthDistModel));
-        } else if(depthDistCoeffs != colorDistCoeffs) {
-            pimpl->logger->warn("PointCloud: depth and color distortion coefficients differ -- colorization may be misaligned");
+        } else if(depthDistCoeffs.size() != colorDistCoeffs.size()
+                  || !approxEqualFloatVectors(depthDistCoeffs.data(), colorDistCoeffs.data(), depthDistCoeffs.size())) {
+            pimpl->logger->error("PointCloud: depth and color distortion coefficients differ -- colorization may be misaligned");
         }
     }
 

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -670,10 +670,9 @@ void PointCloud::processColorized(std::shared_ptr<ImgFrame> depthFrame,
         auto colorExtrinsics = colorFrame->transformation.getExtrinsics();
         if(depthExtrinsics.toCameraSocket != colorExtrinsics.toCameraSocket) {
             pimpl->logger->error("PointCloud: color extrinsics toCameraSocket ({}) does not match depth ({}) -- colorization may be misaligned",
-                                toString(colorExtrinsics.toCameraSocket),
-                                toString(depthExtrinsics.toCameraSocket));
-        } else if(depthExtrinsics.rotationMatrix != colorExtrinsics.rotationMatrix || depthExtrinsics.translation.x != colorExtrinsics.translation.x
-                  || depthExtrinsics.translation.y != colorExtrinsics.translation.y || depthExtrinsics.translation.z != colorExtrinsics.translation.z) {
+                                 toString(colorExtrinsics.toCameraSocket),
+                                 toString(depthExtrinsics.toCameraSocket));
+        } else if(!depthExtrinsics.isEqualExtrinsics(colorExtrinsics)) {
             pimpl->logger->error(
                 "PointCloud: depth and color extrinsics differ (same toCameraSocket={} but different rotation/translation) "
                 "-- colorization may be misaligned",
@@ -681,38 +680,9 @@ void PointCloud::processColorized(std::shared_ptr<ImgFrame> depthFrame,
         }
     }
 
-    // Epsilon-based float comparison helper (reused for intrinsics and distortion coefficients)
-    constexpr float kEpsilon = 1e-6f;
-    auto approxEqualFloatVectors = [kEpsilon](const float* a, const float* b, size_t n) {
-        for(size_t i = 0; i < n; ++i) {
-            if(std::abs(a[i] - b[i]) > kEpsilon) return false;
-        }
-        return true;
-    };
-
-    // Check intrinsics mismatches (non-fatal)
-    {
-        auto depthIntrinsics = depthFrame->transformation.getIntrinsicMatrix();
-        auto colorIntrinsics = colorFrame->transformation.getIntrinsicMatrix();
-        if(!approxEqualFloatVectors(&depthIntrinsics[0][0], &colorIntrinsics[0][0], 9)) {
-            pimpl->logger->error("PointCloud: color intrinsics do not match depth intrinsics -- colorization may be misaligned");
-        }
-    }
-
-    // Check distortion mismatches (non-fatal)
-    {
-        auto depthDistModel = depthFrame->transformation.getDistortionModel();
-        auto colorDistModel = colorFrame->transformation.getDistortionModel();
-        auto depthDistCoeffs = depthFrame->transformation.getDistortionCoefficients();
-        auto colorDistCoeffs = colorFrame->transformation.getDistortionCoefficients();
-        if(depthDistModel != colorDistModel) {
-            pimpl->logger->error("PointCloud: color distortion model ({}) does not match depth ({}) -- colorization may be misaligned",
-                                static_cast<int>(colorDistModel),
-                                static_cast<int>(depthDistModel));
-        } else if(depthDistCoeffs.size() != colorDistCoeffs.size()
-                  || !approxEqualFloatVectors(depthDistCoeffs.data(), colorDistCoeffs.data(), depthDistCoeffs.size())) {
-            pimpl->logger->error("PointCloud: depth and color distortion coefficients differ -- colorization may be misaligned");
-        }
+    // Check intrinsics and distortion mismatches (non-fatal)
+    if(!depthFrame->transformation.isAlignedTo(colorFrame->transformation)) {
+        pimpl->logger->error("PointCloud: depth and color transformations are not aligned (intrinsics/distortion differ) -- colorization may be misaligned");
     }
 
     const auto* depthData = depthFrame->getData().data();

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -680,6 +680,30 @@ void PointCloud::processColorized(std::shared_ptr<ImgFrame> depthFrame,
         }
     }
 
+    // Warn about intrinsics mismatches (non-fatal)
+    {
+        auto depthIntrinsics = depthFrame->transformation.getIntrinsicMatrix();
+        auto colorIntrinsics = colorFrame->transformation.getIntrinsicMatrix();
+        if(depthIntrinsics != colorIntrinsics) {
+            pimpl->logger->warn("PointCloud: color intrinsics do not match depth intrinsics -- colorization may be misaligned");
+        }
+    }
+
+    // Warn about distortion mismatches (non-fatal)
+    {
+        auto depthDistModel = depthFrame->transformation.getDistortionModel();
+        auto colorDistModel = colorFrame->transformation.getDistortionModel();
+        auto depthDistCoeffs = depthFrame->transformation.getDistortionCoefficients();
+        auto colorDistCoeffs = colorFrame->transformation.getDistortionCoefficients();
+        if(depthDistModel != colorDistModel) {
+            pimpl->logger->warn("PointCloud: color distortion model ({}) does not match depth ({}) -- colorization may be misaligned",
+                                static_cast<int>(colorDistModel),
+                                static_cast<int>(depthDistModel));
+        } else if(depthDistCoeffs != colorDistCoeffs) {
+            pimpl->logger->warn("PointCloud: depth and color distortion coefficients differ -- colorization may be misaligned");
+        }
+    }
+
     const auto* depthData = depthFrame->getData().data();
     const auto* colorData = colorFrame->getData().data();
     std::vector<Point3fRGBA> coloredPoints;

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -665,12 +665,12 @@ void PointCloud::processColorized(std::shared_ptr<ImgFrame> depthFrame,
 
     // Check extrinsics mismatches (non-fatal)
     if(!depthFrame->transformation.getExtrinsics().isEqualExtrinsics(colorFrame->transformation.getExtrinsics())) {
-        pimpl->logger->error("PointCloud: depth and color extrinsics differ -- colorization may be misaligned");
+        pimpl->logger->warn("PointCloud: depth and color extrinsics differ -- colorization may be misaligned");
     }
 
     // Check intrinsics and distortion mismatches (non-fatal)
     if(!depthFrame->transformation.isAlignedTo(colorFrame->transformation)) {
-        pimpl->logger->error("PointCloud: depth and color transformations are not aligned (intrinsics/distortion differ) -- colorization may be misaligned");
+        pimpl->logger->warn("PointCloud: depth and color transformations are not aligned (intrinsics/distortion differ) -- colorization may be misaligned");
     }
 
     const auto* depthData = depthFrame->getData().data();

--- a/tests/src/ondevice_tests/pointcloud_test.cpp
+++ b/tests/src/ondevice_tests/pointcloud_test.cpp
@@ -66,15 +66,19 @@ TEST_CASE("sparse pointcloud") {
 }
 
 // ============================================================================
-// Colorization proceeds with mismatched extrinsics (warn only, no skip)
+// Colorization proceeds with mismatched extrinsics (error logged, no skip)
 // ============================================================================
 TEST_CASE("Colorization proceeds despite mismatched frame extrinsics") {
     // This test verifies that when depth and color frames have different
     // toCameraSocket extrinsics, the PointCloud node still produces a
-    // colorized point cloud (with a warning) rather than falling back to
+    // colorized point cloud (with an error log) rather than falling back to
     // depth-only output.
 
     dai::Pipeline pipeline;
+    if(pipeline.getDefaultDevice()->getPlatform() == dai::Platform::RVC2) {
+        WARN("Skipping mismatched extrinsics test: PointCloud node is not supported on RVC2.");
+        return;
+    }
 
     auto pc = pipeline.create<dai::node::PointCloud>();
     pc->initialConfig->setLengthUnit(dai::LengthUnit::MILLIMETER);
@@ -146,14 +150,18 @@ TEST_CASE("Colorization proceeds despite mismatched frame extrinsics") {
 }
 
 // ============================================================================
-// Colorization proceeds with mismatched intrinsics (warn only, no skip)
+// Colorization proceeds with mismatched intrinsics (error logged, no skip)
 // ============================================================================
 TEST_CASE("Colorization proceeds despite mismatched frame intrinsics") {
     // This test verifies that when depth and color frames have different
     // intrinsic matrices, the PointCloud node still produces a colorized
-    // point cloud (with a warning) rather than falling back to depth-only.
+    // point cloud (with an error log) rather than falling back to depth-only.
 
     dai::Pipeline pipeline;
+    if(pipeline.getDefaultDevice()->getPlatform() == dai::Platform::RVC2) {
+        WARN("Skipping mismatched intrinsics test: PointCloud node is not supported on RVC2.");
+        return;
+    }
 
     auto pc = pipeline.create<dai::node::PointCloud>();
     pc->initialConfig->setLengthUnit(dai::LengthUnit::MILLIMETER);
@@ -221,15 +229,19 @@ TEST_CASE("Colorization proceeds despite mismatched frame intrinsics") {
 }
 
 // ============================================================================
-// Colorization proceeds with mismatched distortion (warn only, no skip)
+// Colorization proceeds with mismatched distortion (error logged, no skip)
 // ============================================================================
 TEST_CASE("Colorization proceeds despite mismatched frame distortion") {
     // This test verifies that when depth and color frames have different
     // distortion models or coefficients, the PointCloud node still produces
-    // a colorized point cloud (with a warning) rather than falling back
+    // a colorized point cloud (with an error log) rather than falling back
     // to depth-only.
 
     dai::Pipeline pipeline;
+    if(pipeline.getDefaultDevice()->getPlatform() == dai::Platform::RVC2) {
+        WARN("Skipping mismatched distortion test: PointCloud node is not supported on RVC2.");
+        return;
+    }
 
     auto pc = pipeline.create<dai::node::PointCloud>();
     pc->initialConfig->setLengthUnit(dai::LengthUnit::MILLIMETER);
@@ -289,6 +301,83 @@ TEST_CASE("Colorization proceeds despite mismatched frame distortion") {
             REQUIRE(p.r == 80);
             REQUIRE(p.g == 160);
             REQUIRE(p.b == 240);
+        }
+    }
+
+    pipeline.stop();
+}
+
+// ============================================================================
+// Colorization proceeds with mismatched distortion coefficients (same model)
+// ============================================================================
+TEST_CASE("Colorization proceeds despite mismatched distortion coefficients") {
+    // This test exercises the coefficient-comparison branch: same distortion
+    // model on both frames but different coefficient values.
+
+    dai::Pipeline pipeline;
+    if(pipeline.getDefaultDevice()->getPlatform() == dai::Platform::RVC2) {
+        WARN("Skipping mismatched distortion coefficients test: PointCloud node is not supported on RVC2.");
+        return;
+    }
+
+    auto pc = pipeline.create<dai::node::PointCloud>();
+    pc->initialConfig->setLengthUnit(dai::LengthUnit::MILLIMETER);
+
+    auto depthInQ = pc->inputDepth.createInputQueue();
+    auto colorInQ = pc->getColorInput().createInputQueue();
+    auto outQ = pc->outputPointCloud.createOutputQueue(4, false);
+
+    pipeline.start();
+
+    constexpr unsigned W = 4, H = 4;
+    std::array<std::array<float, 3>, 3> intrinsics = {{{100.f, 0.f, 2.f}, {0.f, 100.f, 2.f}, {0.f, 0.f, 1.f}}};
+
+    dai::Extrinsics ext({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}, {0, 0, 0}, dai::CameraBoardSocket::CAM_B);
+
+    // Same model (Fisheye) but different coefficients
+    dai::ImgTransformation depthTransform(W, H, intrinsics, dai::CameraModel::Fisheye, {0.1f, -0.2f, 0.0f, 0.0f, 0.05f}, ext);
+    dai::ImgTransformation colorTransform(W, H, intrinsics, dai::CameraModel::Fisheye, {0.3f, -0.1f, 0.01f, 0.0f, 0.02f}, ext);
+
+    // Create synthetic depth frame (RAW16)
+    auto depthFrame = std::make_shared<dai::ImgFrame>();
+    depthFrame->setWidth(W);
+    depthFrame->setHeight(H);
+    depthFrame->setType(dai::ImgFrame::Type::RAW16);
+    std::vector<uint16_t> depthData(W * H, 1000);
+    std::vector<uint8_t> depthBytes(depthData.size() * sizeof(uint16_t));
+    std::memcpy(depthBytes.data(), depthData.data(), depthBytes.size());
+    depthFrame->setData(std::move(depthBytes));
+    depthFrame->setTransformation(depthTransform);
+
+    // Create synthetic color frame (RGB888i)
+    auto colorFrame = std::make_shared<dai::ImgFrame>();
+    colorFrame->setWidth(W);
+    colorFrame->setHeight(H);
+    colorFrame->setType(dai::ImgFrame::Type::RGB888i);
+    std::vector<uint8_t> colorData(W * H * 3, 0);
+    for(unsigned i = 0; i < W * H; ++i) {
+        colorData[i * 3 + 0] = 70;
+        colorData[i * 3 + 1] = 140;
+        colorData[i * 3 + 2] = 210;
+    }
+    colorFrame->setData(std::move(colorData));
+    colorFrame->setTransformation(colorTransform);
+
+    depthInQ->send(depthFrame);
+    colorInQ->send(colorFrame);
+
+    auto pcd = outQ->get<dai::PointCloudData>();
+    REQUIRE(pcd != nullptr);
+    REQUIRE(pcd->isColor());
+    REQUIRE(pcd->getWidth() > 0);
+
+    auto points = pcd->getPointsRGB();
+    REQUIRE(!points.empty());
+    for(const auto& p : points) {
+        if(p.z > 0.f) {
+            REQUIRE(p.r == 70);
+            REQUIRE(p.g == 140);
+            REQUIRE(p.b == 210);
         }
     }
 

--- a/tests/src/ondevice_tests/pointcloud_test.cpp
+++ b/tests/src/ondevice_tests/pointcloud_test.cpp
@@ -66,12 +66,12 @@ TEST_CASE("sparse pointcloud") {
 }
 
 // ============================================================================
-// Colorization proceeds with mismatched extrinsics (error logged, no skip)
+// Colorization proceeds with mismatched extrinsics (warning logged, no skip)
 // ============================================================================
 TEST_CASE("Colorization proceeds despite mismatched frame extrinsics") {
     // This test verifies that when depth and color frames have different
     // toCameraSocket extrinsics, the PointCloud node still produces a
-    // colorized point cloud (with an error log) rather than falling back to
+    // colorized point cloud (with a warning log) rather than falling back to
     // depth-only output.
 
     dai::Pipeline pipeline;
@@ -150,12 +150,12 @@ TEST_CASE("Colorization proceeds despite mismatched frame extrinsics") {
 }
 
 // ============================================================================
-// Colorization proceeds with mismatched intrinsics (error logged, no skip)
+// Colorization proceeds with mismatched intrinsics (warning logged, no skip)
 // ============================================================================
 TEST_CASE("Colorization proceeds despite mismatched frame intrinsics") {
     // This test verifies that when depth and color frames have different
     // intrinsic matrices, the PointCloud node still produces a colorized
-    // point cloud (with an error log) rather than falling back to depth-only.
+    // point cloud (with a warning log) rather than falling back to depth-only.
 
     dai::Pipeline pipeline;
     if(pipeline.getDefaultDevice()->getPlatform() == dai::Platform::RVC2) {
@@ -229,12 +229,12 @@ TEST_CASE("Colorization proceeds despite mismatched frame intrinsics") {
 }
 
 // ============================================================================
-// Colorization proceeds with mismatched distortion (error logged, no skip)
+// Colorization proceeds with mismatched distortion (warning logged, no skip)
 // ============================================================================
 TEST_CASE("Colorization proceeds despite mismatched frame distortion") {
     // This test verifies that when depth and color frames have different
     // distortion models or coefficients, the PointCloud node still produces
-    // a colorized point cloud (with an error log) rather than falling back
+    // a colorized point cloud (with a warning log) rather than falling back
     // to depth-only.
 
     dai::Pipeline pipeline;

--- a/tests/src/ondevice_tests/pointcloud_test.cpp
+++ b/tests/src/ondevice_tests/pointcloud_test.cpp
@@ -144,3 +144,153 @@ TEST_CASE("Colorization proceeds despite mismatched frame extrinsics") {
 
     pipeline.stop();
 }
+
+// ============================================================================
+// Colorization proceeds with mismatched intrinsics (warn only, no skip)
+// ============================================================================
+TEST_CASE("Colorization proceeds despite mismatched frame intrinsics") {
+    // This test verifies that when depth and color frames have different
+    // intrinsic matrices, the PointCloud node still produces a colorized
+    // point cloud (with a warning) rather than falling back to depth-only.
+
+    dai::Pipeline pipeline;
+
+    auto pc = pipeline.create<dai::node::PointCloud>();
+    pc->initialConfig->setLengthUnit(dai::LengthUnit::MILLIMETER);
+
+    auto depthInQ = pc->inputDepth.createInputQueue();
+    auto colorInQ = pc->getColorInput().createInputQueue();
+    auto outQ = pc->outputPointCloud.createOutputQueue(4, false);
+
+    pipeline.start();
+
+    constexpr unsigned W = 4, H = 4;
+
+    // Different intrinsics for depth and color
+    std::array<std::array<float, 3>, 3> depthIntrinsics = {{{100.f, 0.f, 2.f}, {0.f, 100.f, 2.f}, {0.f, 0.f, 1.f}}};
+    std::array<std::array<float, 3>, 3> colorIntrinsics = {{{200.f, 0.f, 3.f}, {0.f, 200.f, 3.f}, {0.f, 0.f, 1.f}}};
+
+    dai::Extrinsics ext({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}, {0, 0, 0}, dai::CameraBoardSocket::CAM_B);
+    dai::ImgTransformation depthTransform(W, H, depthIntrinsics, dai::CameraModel::Perspective, {}, ext);
+    dai::ImgTransformation colorTransform(W, H, colorIntrinsics, dai::CameraModel::Perspective, {}, ext);
+
+    // Create synthetic depth frame (RAW16)
+    auto depthFrame = std::make_shared<dai::ImgFrame>();
+    depthFrame->setWidth(W);
+    depthFrame->setHeight(H);
+    depthFrame->setType(dai::ImgFrame::Type::RAW16);
+    std::vector<uint16_t> depthData(W * H, 1000);
+    std::vector<uint8_t> depthBytes(depthData.size() * sizeof(uint16_t));
+    std::memcpy(depthBytes.data(), depthData.data(), depthBytes.size());
+    depthFrame->setData(std::move(depthBytes));
+    depthFrame->setTransformation(depthTransform);
+
+    // Create synthetic color frame (RGB888i)
+    auto colorFrame = std::make_shared<dai::ImgFrame>();
+    colorFrame->setWidth(W);
+    colorFrame->setHeight(H);
+    colorFrame->setType(dai::ImgFrame::Type::RGB888i);
+    std::vector<uint8_t> colorData(W * H * 3, 0);
+    for(unsigned i = 0; i < W * H; ++i) {
+        colorData[i * 3 + 0] = 50;
+        colorData[i * 3 + 1] = 100;
+        colorData[i * 3 + 2] = 200;
+    }
+    colorFrame->setData(std::move(colorData));
+    colorFrame->setTransformation(colorTransform);
+
+    depthInQ->send(depthFrame);
+    colorInQ->send(colorFrame);
+
+    auto pcd = outQ->get<dai::PointCloudData>();
+    REQUIRE(pcd != nullptr);
+    REQUIRE(pcd->isColor());
+    REQUIRE(pcd->getWidth() > 0);
+
+    auto points = pcd->getPointsRGB();
+    REQUIRE(!points.empty());
+    for(const auto& p : points) {
+        if(p.z > 0.f) {
+            REQUIRE(p.r == 50);
+            REQUIRE(p.g == 100);
+            REQUIRE(p.b == 200);
+        }
+    }
+
+    pipeline.stop();
+}
+
+// ============================================================================
+// Colorization proceeds with mismatched distortion (warn only, no skip)
+// ============================================================================
+TEST_CASE("Colorization proceeds despite mismatched frame distortion") {
+    // This test verifies that when depth and color frames have different
+    // distortion models or coefficients, the PointCloud node still produces
+    // a colorized point cloud (with a warning) rather than falling back
+    // to depth-only.
+
+    dai::Pipeline pipeline;
+
+    auto pc = pipeline.create<dai::node::PointCloud>();
+    pc->initialConfig->setLengthUnit(dai::LengthUnit::MILLIMETER);
+
+    auto depthInQ = pc->inputDepth.createInputQueue();
+    auto colorInQ = pc->getColorInput().createInputQueue();
+    auto outQ = pc->outputPointCloud.createOutputQueue(4, false);
+
+    pipeline.start();
+
+    constexpr unsigned W = 4, H = 4;
+    std::array<std::array<float, 3>, 3> intrinsics = {{{100.f, 0.f, 2.f}, {0.f, 100.f, 2.f}, {0.f, 0.f, 1.f}}};
+
+    dai::Extrinsics ext({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}, {0, 0, 0}, dai::CameraBoardSocket::CAM_B);
+
+    // Different distortion: depth has no distortion, color has some coefficients
+    dai::ImgTransformation depthTransform(W, H, intrinsics, dai::CameraModel::Perspective, {}, ext);
+    dai::ImgTransformation colorTransform(W, H, intrinsics, dai::CameraModel::Fisheye, {0.1f, -0.2f, 0.0f, 0.0f, 0.05f}, ext);
+
+    // Create synthetic depth frame (RAW16)
+    auto depthFrame = std::make_shared<dai::ImgFrame>();
+    depthFrame->setWidth(W);
+    depthFrame->setHeight(H);
+    depthFrame->setType(dai::ImgFrame::Type::RAW16);
+    std::vector<uint16_t> depthData(W * H, 1000);
+    std::vector<uint8_t> depthBytes(depthData.size() * sizeof(uint16_t));
+    std::memcpy(depthBytes.data(), depthData.data(), depthBytes.size());
+    depthFrame->setData(std::move(depthBytes));
+    depthFrame->setTransformation(depthTransform);
+
+    // Create synthetic color frame (RGB888i)
+    auto colorFrame = std::make_shared<dai::ImgFrame>();
+    colorFrame->setWidth(W);
+    colorFrame->setHeight(H);
+    colorFrame->setType(dai::ImgFrame::Type::RGB888i);
+    std::vector<uint8_t> colorData(W * H * 3, 0);
+    for(unsigned i = 0; i < W * H; ++i) {
+        colorData[i * 3 + 0] = 80;
+        colorData[i * 3 + 1] = 160;
+        colorData[i * 3 + 2] = 240;
+    }
+    colorFrame->setData(std::move(colorData));
+    colorFrame->setTransformation(colorTransform);
+
+    depthInQ->send(depthFrame);
+    colorInQ->send(colorFrame);
+
+    auto pcd = outQ->get<dai::PointCloudData>();
+    REQUIRE(pcd != nullptr);
+    REQUIRE(pcd->isColor());
+    REQUIRE(pcd->getWidth() > 0);
+
+    auto points = pcd->getPointsRGB();
+    REQUIRE(!points.empty());
+    for(const auto& p : points) {
+        if(p.z > 0.f) {
+            REQUIRE(p.r == 80);
+            REQUIRE(p.g == 160);
+            REQUIRE(p.b == 240);
+        }
+    }
+
+    pipeline.stop();
+}

--- a/tests/src/onhost_tests/point_cloud_test.cpp
+++ b/tests/src/onhost_tests/point_cloud_test.cpp
@@ -1532,19 +1532,6 @@ TEST_CASE("PointCloudData stores and retrieves ImgTransformation", "[PointCloud]
     REQUIRE(retrievedIntrinsics[1][2] == Catch::Approx(200.f));
 }
 
-TEST_CASE("PointCloudData transformation default is identity", "[PointCloud][Transformation]") {
-    dai::PointCloudData pc;
-    const auto& t = pc.getTransformation();
-    auto intrinsics = t.getIntrinsicMatrix();
-
-    // Default intrinsic matrix is identity
-    REQUIRE(intrinsics[0][0] == Catch::Approx(1.f));
-    REQUIRE(intrinsics[1][1] == Catch::Approx(1.f));
-    REQUIRE(intrinsics[2][2] == Catch::Approx(1.f));
-    REQUIRE(intrinsics[0][1] == Catch::Approx(0.f));
-    REQUIRE(intrinsics[0][2] == Catch::Approx(0.f));
-}
-
 TEST_CASE("PointCloudData transformation mutated via setter", "[PointCloud][Transformation]") {
     dai::PointCloudData pc;
     std::array<std::array<float, 3>, 3> intrinsics = {{{300.f, 0.f, 160.f}, {0.f, 300.f, 120.f}, {0.f, 0.f, 1.f}}};


### PR DESCRIPTION
## Purpose
Add non-fatal warnings in the PointCloud node when color and depth frames have mismatched intrinsics or distortion parameters, helping users diagnose colorization alignment issues. Also removes a broken unit test.

## Specification
- Added intrinsics comparison warning in `processColorized()` when color and depth `getIntrinsicMatrix()` differ
- Added distortion comparison warning in `processColorized()` when color and depth `getDistortionModel()` or `getDistortionCoefficients()` differ
- Removed `PointCloudData transformation default is identity` test — `getTransformation()` throws when transformation is unset, so the test was always broken

## Dependencies & Potential Impact
None — warnings are non-fatal and do not change processing behavior.

## Deployment Plan
None / not applicable

## Testing & Validation
- Added two ondevice integration tests: `Colorization proceeds despite mismatched frame intrinsics` and `Colorization proceeds despite mismatched frame distortion`
- All point cloud tests pass: `point_cloud_test` (64 cases), `pointclouddata_test` (16 cases), `pointcloud_test` (5 cases)

## AI Usage
Assisted-by: GitHub Copilot:claude-opus-4

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added on-device coverage to confirm colorized point clouds remain valid when depth vs. color intrinsics or distortion parameters differ, and that per-point RGB matches expected values for valid depth.
  * Added additional on-device cases for distortion model/coefficients mismatches.
  * Removed an outdated host test that asserted a specific default transformation behavior.
* **Bug Fixes**
  * Improved non-fatal calibration-mismatch validation and messaging during colorized point-cloud generation, including clearer reporting for calibration alignment and extrinsics discrepancies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->