### PR TITLE
Update CalibrationHandler getters/setters

### DIFF
--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -758,6 +758,8 @@ class CalibrationHandler {
                                                               bool useSpecTranslation,
                                                               CameraBoardSocket& originSocket) const;
 
+    void setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix, std::vector<float> translation);
+
     DEPTHAI_SERIALIZE(CalibrationHandler, eepromData);
     void scaleTranslationInPlace(std::vector<std::vector<float>>& mat, LengthUnit unit) const;
     void validateIntrinsicsMatrix(CameraBoardSocket cameraId) const;

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -660,8 +660,8 @@ class CalibrationHandler {
      */
     void updateCameraExtrinsics(CameraBoardSocket srcCameraId,
                                 CameraBoardSocket destCameraId,
-                                std::vector<std::vector<float>> rotationMatrix,
-                                std::vector<float> translation);
+                                const std::vector<std::vector<float>>& rotationMatrix,
+                                const std::vector<float>& translation);
     /**
      * Set the Imu to Camera Extrinsics object
      *

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -764,7 +764,9 @@ class CalibrationHandler {
                                                               CameraBoardSocket& originSocket,
                                                               LengthUnit unit = LengthUnit::CENTIMETER) const;
 
-    void setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix, std::vector<float> translation);
+    void setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix,
+                                             std::vector<float> translation,
+                                             LengthUnit unit = LengthUnit::CENTIMETER);
 
     DEPTHAI_SERIALIZE(CalibrationHandler, eepromData);
     void scaleTranslationInPlace(std::vector<std::vector<float>>& mat, LengthUnit unit) const;

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -27,6 +27,10 @@ namespace dai {
  *  - productName
  */
 
+namespace node {
+class DclUtils;
+}  // namespace node
+
 class CalibrationHandler {
    public:
     CalibrationHandler() = default;
@@ -654,6 +658,7 @@ class CalibrationHandler {
      * @param translation Translation between IMU and destCameraId origins.
      * @param specTranslation Translation between IMU and destCameraId origins from the design.
      */
+
     void setImuExtrinsics(CameraBoardSocket destCameraId,
                           const std::vector<std::vector<float>>& rotationMatrix,
                           const std::vector<float>& translation,
@@ -756,13 +761,15 @@ class CalibrationHandler {
     std::vector<std::vector<float>> getExtrinsicsToOrigin(CameraBoardSocket cameraId, bool useSpecTranslation, CameraBoardSocket& originSocket) const;
     std::vector<std::vector<float>> getHousingToHousingOrigin(const HousingCoordinateSystem housingCS,
                                                               bool useSpecTranslation,
-                                                              CameraBoardSocket& originSocket) const;
+                                                              CameraBoardSocket& originSocket,
+                                                              LengthUnit unit = LengthUnit::CENTIMETER) const;
 
     void setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix, std::vector<float> translation);
 
     DEPTHAI_SERIALIZE(CalibrationHandler, eepromData);
     void scaleTranslationInPlace(std::vector<std::vector<float>>& mat, LengthUnit unit) const;
     void validateIntrinsicsMatrix(CameraBoardSocket cameraId) const;
+    friend dai::node::DclUtils;
 
    protected:
     static constexpr LengthUnit eepromTranslationUnits = LengthUnit::CENTIMETER;

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -651,6 +651,18 @@ class CalibrationHandler {
                              const std::vector<float>& specTranslation = {0, 0, 0});
 
     /**
+     * Overwrite the Camera Extrinsics object where the link already exists
+     *
+     * @param srcCameraId Camera Id of the camera which will be considered as relative origin.
+     * @param destCameraId Camera Id of the camera which will be considered as destination from srcCameraId.
+     * @param rotationMatrix Rotation between srcCameraId and destCameraId origins.
+     * @param translation Translation between srcCameraId and destCameraId origins.
+     */
+    void updateCameraExtrinsics(CameraBoardSocket srcCameraId,
+                                CameraBoardSocket destCameraId,
+                                std::vector<std::vector<float>> rotationMatrix,
+                                std::vector<float> translation);
+    /**
      * Set the Imu to Camera Extrinsics object
      *
      * @param destCameraId Camera Id of the camera which will be considered as destination from IMU.

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -771,10 +771,10 @@ class CalibrationHandler {
      * @return a transformationMatrix which is 4x4 in homogeneous coordinate system
      */
     std::vector<std::vector<float>> getExtrinsicsToOrigin(CameraBoardSocket cameraId, bool useSpecTranslation, CameraBoardSocket& originSocket) const;
-    std::vector<std::vector<float>> getHousingToHousingOrigin(const HousingCoordinateSystem housingCS,
-                                                              bool useSpecTranslation,
-                                                              CameraBoardSocket& originSocket,
-                                                              LengthUnit unit = LengthUnit::CENTIMETER) const;
+    std::vector<std::vector<float>> getHousingToHousingOriginExtrinsics(const HousingCoordinateSystem housingCS,
+                                                                        bool useSpecTranslation,
+                                                                        CameraBoardSocket& originSocket,
+                                                                        LengthUnit unit = LengthUnit::CENTIMETER) const;
 
     void setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix,
                                              std::vector<float> translation,

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -638,11 +638,13 @@ class CalibrationHandler {
     /**
      * Set the Camera Extrinsics object
      *
+     * Translation values are stored in the default CalibrationHandler length unit: centimeters (cm).
+     *
      * @param srcCameraId Camera Id of the camera which will be considered as relative origin.
      * @param destCameraId Camera Id of the camera which will be considered as destination from srcCameraId.
      * @param rotationMatrix Rotation between srcCameraId and destCameraId origins.
-     * @param translation Translation between srcCameraId and destCameraId origins.
-     * @param specTranslation Translation between srcCameraId and destCameraId origins from the design.
+     * @param translation Translation between srcCameraId and destCameraId origins, in centimeters (cm).
+     * @param specTranslation Translation between srcCameraId and destCameraId origins from the design, in centimeters (cm).
      */
     void setCameraExtrinsics(CameraBoardSocket srcCameraId,
                              CameraBoardSocket destCameraId,
@@ -653,10 +655,12 @@ class CalibrationHandler {
     /**
      * Overwrite the Camera Extrinsics object where the link already exists
      *
+     * Translation values are stored in the default CalibrationHandler length unit: centimeters (cm).
+     *
      * @param srcCameraId Camera Id of the camera which will be considered as relative origin.
      * @param destCameraId Camera Id of the camera which will be considered as destination from srcCameraId.
      * @param rotationMatrix Rotation between srcCameraId and destCameraId origins.
-     * @param translation Translation between srcCameraId and destCameraId origins.
+     * @param translation Translation between srcCameraId and destCameraId origins, in centimeters (cm).
      */
     void updateCameraExtrinsics(CameraBoardSocket srcCameraId,
                                 CameraBoardSocket destCameraId,
@@ -665,10 +669,12 @@ class CalibrationHandler {
     /**
      * Set the Imu to Camera Extrinsics object
      *
+     * Translation values are stored in the default CalibrationHandler length unit: centimeters (cm).
+     *
      * @param destCameraId Camera Id of the camera which will be considered as destination from IMU.
      * @param rotationMatrix Rotation between srcCameraId and destCameraId origins.
-     * @param translation Translation between IMU and destCameraId origins.
-     * @param specTranslation Translation between IMU and destCameraId origins from the design.
+     * @param translation Translation between IMU and destCameraId origins, in centimeters (cm).
+     * @param specTranslation Translation between IMU and destCameraId origins from the design, in centimeters (cm).
      */
 
     void setImuExtrinsics(CameraBoardSocket destCameraId,

--- a/include/depthai/utility/matrixOps.hpp
+++ b/include/depthai/utility/matrixOps.hpp
@@ -46,6 +46,7 @@ std::vector<float> matrix3x3ToVector(const std::array<std::array<float, 3>, 3>& 
 std::vector<float> rotationMatrixToVector(const std::vector<std::vector<float>>& R);
 std::vector<std::vector<float>> matrix3x3ToVectorMatrix(const std::array<std::array<float, 3>, 3>& R);
 std::array<std::array<float, 3>, 3> vectorMatrixToMatrix3x3(const std::vector<std::vector<float>>& R);
+void validateRotationMatrix3x3(const std::vector<std::vector<float>>& rotationMatrix);
 
 std::array<std::array<float, 3>, 3> getRotationMatrixFromProjection4x4(const std::array<std::array<float, 4>, 4>& projection);
 

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1121,6 +1121,33 @@ void CalibrationHandler::setCameraType(CameraBoardSocket cameraId, CameraModel c
     return;
 }
 
+void CalibrationHandler::updateCameraExtrinsics(CameraBoardSocket srcCameraId,
+                                                CameraBoardSocket destCameraId,
+                                                std::vector<std::vector<float>> rotationMatrix,
+                                                std::vector<float> translation) {
+    if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
+        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
+    }
+    if(translation.size() != 3) {
+        throw std::runtime_error("Translation vector size should always be 3x1");
+    }
+
+    auto cameraData = eepromData.cameraData.find(srcCameraId);
+    if(cameraData == eepromData.cameraData.end()) {
+        throw std::runtime_error("No existing extrinsics found for the source camera socket");
+    }
+
+    if(cameraData->second.extrinsics.toCameraSocket != destCameraId) {
+        throw std::runtime_error("overwriteExtrinsics crash: source camera socket " + toString(srcCameraId) + " has different toCameraSocket "
+                                 + toString(cameraData->second.extrinsics.toCameraSocket) + ". Correct link should be set with "
+                                 + "setCameraExtrinsics(sourceCameraSocket, destinationCameraSocket, rotationMatrix, translation, specTranslation).");
+    }
+
+    cameraData->second.extrinsics.rotationMatrix = rotationMatrix;
+    cameraData->second.extrinsics.translation = dai::Point3f(translation[0], translation[1], translation[2]);
+    return;
+}
+
 void CalibrationHandler::setCameraExtrinsics(CameraBoardSocket srcCameraId,
                                              CameraBoardSocket destCameraId,
                                              const std::vector<std::vector<float>>& rotationMatrix,

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1146,6 +1146,11 @@ void CalibrationHandler::updateCameraExtrinsics(CameraBoardSocket srcCameraId,
         throw std::runtime_error("No existing extrinsics found for the source camera socket");
     }
 
+    if(cameraData->second.extrinsics.toCameraSocket == CameraBoardSocket::AUTO) {
+        throw std::runtime_error("Cannot overwrite extrinsics for source camera socket " + toString(srcCameraId)
+                                 + " because toCameraSocket is AUTO and there is no existing link to update.");
+    }
+
     if(cameraData->second.extrinsics.toCameraSocket != destCameraId) {
         throw std::runtime_error("overwriteExtrinsics crash: source camera socket " + toString(srcCameraId) + " has different toCameraSocket "
                                  + toString(cameraData->second.extrinsics.toCameraSocket) + ". Correct link should be set with "

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -644,12 +644,12 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOriginExt
     }
 
     // Build 4x4 transform matrix from HousingOrigin to Housing
-    std::vector<std::vector<float>> T_HousingToHousingOrigin(4, std::vector<float>(4, 0.0f));
+    std::vector<std::vector<float>> translationHousingToHousingOrigin(4, std::vector<float>(4, 0.0f));
 
     for(int r = 0; r < 3; ++r) {
         // Copy rotation row
         for(int c = 0; c < 3; ++c) {
-            T_HousingToHousingOrigin[r][c] = housingRotation[r][c];
+            translationHousingToHousingOrigin[r][c] = housingRotation[r][c];
         }
 
         // Pick translation vector
@@ -657,11 +657,11 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOriginExt
 
         // Map row index -> x/y/z
         float tval = (r == 0 ? t.x : (r == 1 ? t.y : t.z));
-        T_HousingToHousingOrigin[r][3] = tval;
+        translationHousingToHousingOrigin[r][3] = tval;
     }
 
     // Last row = [0 0 0 1]
-    T_HousingToHousingOrigin[3][3] = 1.0f;
+    translationHousingToHousingOrigin[3][3] = 1.0f;
 
     // ------------------------------------------------------------
     // Get the requested specific housing coordinate system translation and subtract it
@@ -670,18 +670,18 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOriginExt
         if(const auto requestedDbTranslation = lookupHousingEntry(eepromData.productName, housingCS)) {
             // All housing coordinate systems share the same orientation;
             // only their origins differ. Build the pure-translation transform
-            // T_SpecificHousing_to_Housing from the database position.
-            std::vector<std::vector<float>> T_SpecificHousingToHousing = {{1.0f, 0.0f, 0.0f, (*requestedDbTranslation)[0] * mmToUnitScale},
-                                                                          {0.0f, 1.0f, 0.0f, (*requestedDbTranslation)[1] * mmToUnitScale},
-                                                                          {0.0f, 0.0f, 1.0f, (*requestedDbTranslation)[2] * mmToUnitScale},
-                                                                          {0.0f, 0.0f, 0.0f, 1.0f}};
+            // translationSpecificHousing_to_Housing from the database position.
+            std::vector<std::vector<float>> translationSpecificHousingToHousing = {{1.0f, 0.0f, 0.0f, (*requestedDbTranslation)[0] * mmToUnitScale},
+                                                                                   {0.0f, 1.0f, 0.0f, (*requestedDbTranslation)[1] * mmToUnitScale},
+                                                                                   {0.0f, 0.0f, 1.0f, (*requestedDbTranslation)[2] * mmToUnitScale},
+                                                                                   {0.0f, 0.0f, 0.0f, 1.0f}};
 
-            // Compose: T_SpecificHousing→HousingOrigin = T_Housing→HousingOrigin * T_SpecificHousing→Housing
-            T_HousingToHousingOrigin = matMul(T_HousingToHousingOrigin, T_SpecificHousingToHousing);
+            // Compose: translationSpecificHousing→HousingOrigin = translationHousing→HousingOrigin * translationSpecificHousing→Housing
+            translationHousingToHousingOrigin = matMul(translationHousingToHousingOrigin, translationSpecificHousingToHousing);
         }
     }
 
-    return T_HousingToHousingOrigin;
+    return translationHousingToHousingOrigin;
 }
 
 std::vector<std::vector<float>> CalibrationHandler::getHousingCalibration(CameraBoardSocket srcCamera,

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1190,7 +1190,7 @@ void CalibrationHandler::setHousingToHousingOriginExtrinsics(std::vector<std::ve
     if(translation.size() != 3) {
         throw std::runtime_error("Translation vector size should always be 3x1");
     }
-    const float scale = getLengthUnitMultiplier(getEepromTranslationUnits()) / getLengthUnitMultiplier(unit);
+    const float scale = getDistanceUnitScale(getEepromTranslationUnits(), unit);
     if(scale != 1.0f) {
         for(auto& value : translation) {
             value *= scale;

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -55,17 +55,6 @@ void validateImuCalibrationMatrix(const std::vector<std::vector<float>>& calibra
     }
 }
 
-void validateRotationMatrix3x3(const std::vector<std::vector<float>>& rotationMatrix) {
-    if(rotationMatrix.size() != 3) {
-        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
-    }
-    for(const auto& row : rotationMatrix) {
-        if(row.size() != 3) {
-            throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
-        }
-    }
-}
-
 EepromData validateCBAEepromData(EepromData eepromData) {
     if(eepromData.cameraData.size() != 1) {
         throw std::runtime_error("CBA calibration data must contain exactly one cameraData entry.");

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -611,9 +611,10 @@ CameraBoardSocket CalibrationHandler::getCameraWithLowestId() const {
 
 std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOrigin(const HousingCoordinateSystem housingCS,
                                                                               bool useSpecTranslation,
-                                                                              CameraBoardSocket& originSocket) const {
-    // Define scale parameter for mm to cm conversion
-    constexpr float MM_TO_CM_SCALE = getLengthUnitMultiplier(DepthUnit::MILLIMETER) / getLengthUnitMultiplier(DepthUnit::CENTIMETER);
+                                                                              CameraBoardSocket& originSocket,
+                                                                              LengthUnit unit) const {
+    const float mmToUnitScale = getLengthUnitMultiplier(unit) / getLengthUnitMultiplier(LengthUnit::MILLIMETER);
+    const float cmToUnitScale = getLengthUnitMultiplier(unit) / getLengthUnitMultiplier(LengthUnit::CENTIMETER);
 
     const Extrinsics& housingExtrinsics = eepromData.housingExtrinsics;
 
@@ -623,7 +624,8 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOrigin(co
     HousingCoordinateSystem housingOrigin = static_cast<HousingCoordinateSystem>(static_cast<int32_t>(housingExtrinsics.toCameraSocket));
 
     auto housingRotation = housingExtrinsics.rotationMatrix;
-    auto housingTranslation = housingExtrinsics.translation;          // Point3f
+    auto housingTranslation = Point3f(
+        housingExtrinsics.translation.x * cmToUnitScale, housingExtrinsics.translation.y * cmToUnitScale, housingExtrinsics.translation.z * cmToUnitScale);
     auto housingSpecTranslation = housingExtrinsics.specTranslation;  // Point3f
 
     // ------------------------------------------------------------
@@ -636,7 +638,7 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOrigin(co
             // column of [R | t] must be in the destination (housing-origin) frame:
             // t = -R * db / scale
             std::vector<std::vector<float>> c = {
-                {-(*dbTranslation)[0] / MM_TO_CM_SCALE}, {-(*dbTranslation)[1] / MM_TO_CM_SCALE}, {-(*dbTranslation)[2] / MM_TO_CM_SCALE}};
+                {-(*dbTranslation)[0] * mmToUnitScale}, {-(*dbTranslation)[1] * mmToUnitScale}, {-(*dbTranslation)[2] * mmToUnitScale}};
             auto rc = matMul(housingRotation, c);
             housingSpecTranslation = Point3f(rc[0][0], rc[1][0], rc[2][0]);
         }
@@ -670,9 +672,9 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOrigin(co
             // All housing coordinate systems share the same orientation;
             // only their origins differ. Build the pure-translation transform
             // T_SpecificHousing_to_Housing from the database position.
-            std::vector<std::vector<float>> T_SpecificHousingToHousing = {{1.0f, 0.0f, 0.0f, (*requestedDbTranslation)[0] / MM_TO_CM_SCALE},
-                                                                          {0.0f, 1.0f, 0.0f, (*requestedDbTranslation)[1] / MM_TO_CM_SCALE},
-                                                                          {0.0f, 0.0f, 1.0f, (*requestedDbTranslation)[2] / MM_TO_CM_SCALE},
+            std::vector<std::vector<float>> T_SpecificHousingToHousing = {{1.0f, 0.0f, 0.0f, (*requestedDbTranslation)[0] * mmToUnitScale},
+                                                                          {0.0f, 1.0f, 0.0f, (*requestedDbTranslation)[1] * mmToUnitScale},
+                                                                          {0.0f, 0.0f, 1.0f, (*requestedDbTranslation)[2] * mmToUnitScale},
                                                                           {0.0f, 0.0f, 0.0f, 1.0f}};
 
             // Compose: T_SpecificHousing→HousingOrigin = T_Housing→HousingOrigin * T_SpecificHousing→Housing

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -609,10 +609,10 @@ CameraBoardSocket CalibrationHandler::getCameraWithLowestId() const {
     return currentCameraId;
 }
 
-std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOrigin(const HousingCoordinateSystem housingCS,
-                                                                              bool useSpecTranslation,
-                                                                              CameraBoardSocket& originSocket,
-                                                                              LengthUnit unit) const {
+std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOriginExtrinsics(const HousingCoordinateSystem housingCS,
+                                                                                        bool useSpecTranslation,
+                                                                                        CameraBoardSocket& originSocket,
+                                                                                        LengthUnit unit) const {
     const float mmToUnitScale = getLengthUnitMultiplier(unit) / getLengthUnitMultiplier(LengthUnit::MILLIMETER);
     const float cmToUnitScale = getLengthUnitMultiplier(unit) / getLengthUnitMultiplier(LengthUnit::CENTIMETER);
 
@@ -708,7 +708,7 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingCalibration(Camera
     // These are provided by the calibration data.
     // ------------------------------------------------------------
 
-    std::vector<std::vector<float>> housingToHousingOrigin = getHousingToHousingOrigin(housingCS, useSpecTranslation, housingOriginCamera);
+    std::vector<std::vector<float>> housingToHousingOrigin = getHousingToHousingOriginExtrinsics(housingCS, useSpecTranslation, housingOriginCamera);
 
     std::vector<std::vector<float>> housingOriginToOrigin = getExtrinsicsToOrigin(housingOriginCamera, useSpecTranslation, originCamera1);
 

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -55,6 +55,17 @@ void validateImuCalibrationMatrix(const std::vector<std::vector<float>>& calibra
     }
 }
 
+void validateRotationMatrix3x3(const std::vector<std::vector<float>>& rotationMatrix) {
+    if(rotationMatrix.size() != 3) {
+        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
+    }
+    for(const auto& row : rotationMatrix) {
+        if(row.size() != 3) {
+            throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
+        }
+    }
+}
+
 EepromData validateCBAEepromData(EepromData eepromData) {
     if(eepromData.cameraData.size() != 1) {
         throw std::runtime_error("CBA calibration data must contain exactly one cameraData entry.");
@@ -1125,9 +1136,7 @@ void CalibrationHandler::updateCameraExtrinsics(CameraBoardSocket srcCameraId,
                                                 CameraBoardSocket destCameraId,
                                                 std::vector<std::vector<float>> rotationMatrix,
                                                 std::vector<float> translation) {
-    if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
-        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
-    }
+    validateRotationMatrix3x3(rotationMatrix);
     if(translation.size() != 3) {
         throw std::runtime_error("Translation vector size should always be 3x1");
     }
@@ -1153,9 +1162,7 @@ void CalibrationHandler::setCameraExtrinsics(CameraBoardSocket srcCameraId,
                                              const std::vector<std::vector<float>>& rotationMatrix,
                                              const std::vector<float>& translation,
                                              const std::vector<float>& specTranslation) {
-    if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
-        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
-    }
+    validateRotationMatrix3x3(rotationMatrix);
     if(translation.size() != 3) {
         throw std::runtime_error("Translation vector size should always be 3x1");
     }
@@ -1185,9 +1192,7 @@ void CalibrationHandler::setCameraExtrinsics(CameraBoardSocket srcCameraId,
 }
 
 void CalibrationHandler::setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix, std::vector<float> translation, LengthUnit unit) {
-    if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
-        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
-    }
+    validateRotationMatrix3x3(rotationMatrix);
     if(translation.size() != 3) {
         throw std::runtime_error("Translation vector size should always be 3x1");
     }
@@ -1205,9 +1210,7 @@ void CalibrationHandler::setImuExtrinsics(CameraBoardSocket destCameraId,
                                           const std::vector<std::vector<float>>& rotationMatrix,
                                           const std::vector<float>& translation,
                                           const std::vector<float>& specTranslation) {
-    if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
-        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
-    }
+    validateRotationMatrix3x3(rotationMatrix);
     if(translation.size() != 3) {
         throw std::runtime_error("Translation vector size should always be 3x1");
     }

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1157,12 +1157,18 @@ void CalibrationHandler::setCameraExtrinsics(CameraBoardSocket srcCameraId,
     return;
 }
 
-void CalibrationHandler::setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix, std::vector<float> translation) {
+void CalibrationHandler::setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix, std::vector<float> translation, LengthUnit unit) {
     if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
         throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
     }
     if(translation.size() != 3) {
         throw std::runtime_error("Translation vector size should always be 3x1");
+    }
+    const float scale = getLengthUnitMultiplier(getEepromTranslationUnits()) / getLengthUnitMultiplier(unit);
+    if(scale != 1.0f) {
+        for(auto& value : translation) {
+            value *= scale;
+        }
     }
     eepromData.housingExtrinsics.rotationMatrix = rotationMatrix;
     eepromData.housingExtrinsics.translation = dai::Point3f(translation[0], translation[1], translation[2]);

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1155,6 +1155,17 @@ void CalibrationHandler::setCameraExtrinsics(CameraBoardSocket srcCameraId,
     return;
 }
 
+void CalibrationHandler::setHousingToHousingOriginExtrinsics(std::vector<std::vector<float>> rotationMatrix, std::vector<float> translation) {
+    if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
+        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
+    }
+    if(translation.size() != 3) {
+        throw std::runtime_error("Translation vector size should always be 3x1");
+    }
+    eepromData.housingExtrinsics.rotationMatrix = rotationMatrix;
+    eepromData.housingExtrinsics.translation = dai::Point3f(translation[0], translation[1], translation[2]);
+}
+
 void CalibrationHandler::setImuExtrinsics(CameraBoardSocket destCameraId,
                                           const std::vector<std::vector<float>>& rotationMatrix,
                                           const std::vector<float>& translation,

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -624,9 +624,10 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOriginExt
     HousingCoordinateSystem housingOrigin = static_cast<HousingCoordinateSystem>(static_cast<int32_t>(housingExtrinsics.toCameraSocket));
 
     auto housingRotation = housingExtrinsics.rotationMatrix;
-    auto housingTranslation = Point3f(
-        housingExtrinsics.translation.x * cmToUnitScale, housingExtrinsics.translation.y * cmToUnitScale, housingExtrinsics.translation.z * cmToUnitScale);
-    auto housingSpecTranslation = housingExtrinsics.specTranslation;  // Point3f
+    const auto housingTranslationVector = housingExtrinsics.getTranslationVector(false, unit);
+    auto housingTranslation = Point3f(housingTranslationVector[0], housingTranslationVector[1], housingTranslationVector[2]);
+    const auto housingSpecTranslationVector = housingExtrinsics.getTranslationVector(true, unit);
+    auto housingSpecTranslation = Point3f(housingSpecTranslationVector[0], housingSpecTranslationVector[1], housingSpecTranslationVector[2]);
 
     // ------------------------------------------------------------
     // If using spec translation, try to get it from the database

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -613,9 +613,7 @@ std::vector<std::vector<float>> CalibrationHandler::getHousingToHousingOriginExt
                                                                                         bool useSpecTranslation,
                                                                                         CameraBoardSocket& originSocket,
                                                                                         LengthUnit unit) const {
-    const float mmToUnitScale = getLengthUnitMultiplier(unit) / getLengthUnitMultiplier(LengthUnit::MILLIMETER);
-    const float cmToUnitScale = getLengthUnitMultiplier(unit) / getLengthUnitMultiplier(LengthUnit::CENTIMETER);
-
+    const float mmToUnitScale = getDistanceUnitScale(unit, LengthUnit::MILLIMETER);
     const Extrinsics& housingExtrinsics = eepromData.housingExtrinsics;
 
     originSocket = housingExtrinsics.toCameraSocket;

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -1134,8 +1134,8 @@ void CalibrationHandler::setCameraType(CameraBoardSocket cameraId, CameraModel c
 
 void CalibrationHandler::updateCameraExtrinsics(CameraBoardSocket srcCameraId,
                                                 CameraBoardSocket destCameraId,
-                                                std::vector<std::vector<float>> rotationMatrix,
-                                                std::vector<float> translation) {
+                                                const std::vector<std::vector<float>>& rotationMatrix,
+                                                const std::vector<float>& translation) {
     validateRotationMatrix3x3(rotationMatrix);
     if(translation.size() != 3) {
         throw std::runtime_error("Translation vector size should always be 3x1");

--- a/src/utility/matrixOps.cpp
+++ b/src/utility/matrixOps.cpp
@@ -135,6 +135,17 @@ std::vector<std::vector<float>> matMul(const std::vector<std::vector<float>>& A,
     return res;
 }
 
+void validateRotationMatrix3x3(const std::vector<std::vector<float>>& rotationMatrix) {
+    if(rotationMatrix.size() != 3) {
+        throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
+    }
+    for(const auto& row : rotationMatrix) {
+        if(row.size() != 3) {
+            throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
+        }
+    }
+}
+
 static void getCofactor(std::vector<std::vector<float>>& A, std::vector<std::vector<float>>& temp, size_t p, size_t q, size_t n) {
     size_t i = 0, j = 0;
 

--- a/tests/src/onhost_tests/calibration_handler_test.cpp
+++ b/tests/src/onhost_tests/calibration_handler_test.cpp
@@ -898,6 +898,15 @@ TEST_CASE("updateCameraExtrinsics rejects destination mismatch", "[updateCameraE
                         Catch::Matchers::ContainsSubstring("has different toCameraSocket"));
 }
 
+TEST_CASE("updateCameraExtrinsics rejects sources without an existing link", "[updateCameraExtrinsics]") {
+    auto handler = loadValidHandler();
+    const auto identity = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}};
+    const auto translation = std::vector<float>{0.0f, 0.0f, 0.0f};
+
+    REQUIRE_THROWS_WITH(handler.updateCameraExtrinsics(CameraBoardSocket::CAM_D, CameraBoardSocket::CAM_D, identity, translation),
+                        Catch::Matchers::ContainsSubstring("toCameraSocket is AUTO"));
+}
+
 TEST_CASE("updateCameraExtrinsics rejects ragged rotation matrices", "[updateCameraExtrinsics]") {
     auto handler = loadValidHandler();
     const auto raggedRotation = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f}, {0.0f}};
@@ -917,15 +926,6 @@ TEST_CASE("setCameraExtrinsics rejects ragged rotation matrices", "[setCameraExt
                                                     raggedRotation,
                                                     translation,
                                                     translation),
-                        Catch::Matchers::ContainsSubstring("Rotation Matrix size should always be 3x3"));
-}
-
-TEST_CASE("setHousingToHousingOriginExtrinsics rejects ragged rotation matrices", "[setHousingToHousingOriginExtrinsics]") {
-    auto handler = loadValidHandler();
-    const auto raggedRotation = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f}, {0.0f}};
-    const auto translation = std::vector<float>{0.0f, 0.0f, 0.0f};
-
-    REQUIRE_THROWS_WITH(handler.setHousingToHousingOriginExtrinsics(raggedRotation, translation, LengthUnit::CENTIMETER),
                         Catch::Matchers::ContainsSubstring("Rotation Matrix size should always be 3x3"));
 }
 

--- a/tests/src/onhost_tests/calibration_handler_test.cpp
+++ b/tests/src/onhost_tests/calibration_handler_test.cpp
@@ -898,6 +898,37 @@ TEST_CASE("updateCameraExtrinsics rejects destination mismatch", "[updateCameraE
                         Catch::Matchers::ContainsSubstring("has different toCameraSocket"));
 }
 
+TEST_CASE("updateCameraExtrinsics rejects ragged rotation matrices", "[updateCameraExtrinsics]") {
+    auto handler = loadValidHandler();
+    const auto raggedRotation = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f}, {0.0f}};
+    const auto translation = std::vector<float>{0.0f, 0.0f, 0.0f};
+
+    REQUIRE_THROWS_WITH(handler.updateCameraExtrinsics(CameraBoardSocket::CAM_A, CameraBoardSocket::CAM_B, raggedRotation, translation),
+                        Catch::Matchers::ContainsSubstring("Rotation Matrix size should always be 3x3"));
+}
+
+TEST_CASE("setCameraExtrinsics rejects ragged rotation matrices", "[setCameraExtrinsics]") {
+    auto handler = loadValidHandler();
+    const auto raggedRotation = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f}, {0.0f}};
+    const auto translation = std::vector<float>{0.0f, 0.0f, 0.0f};
+
+    REQUIRE_THROWS_WITH(handler.setCameraExtrinsics(CameraBoardSocket::CAM_A,
+                                                    CameraBoardSocket::CAM_B,
+                                                    raggedRotation,
+                                                    translation,
+                                                    translation),
+                        Catch::Matchers::ContainsSubstring("Rotation Matrix size should always be 3x3"));
+}
+
+TEST_CASE("setHousingToHousingOriginExtrinsics rejects ragged rotation matrices", "[setHousingToHousingOriginExtrinsics]") {
+    auto handler = loadValidHandler();
+    const auto raggedRotation = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f}, {0.0f}};
+    const auto translation = std::vector<float>{0.0f, 0.0f, 0.0f};
+
+    REQUIRE_THROWS_WITH(handler.setHousingToHousingOriginExtrinsics(raggedRotation, translation, LengthUnit::CENTIMETER),
+                        Catch::Matchers::ContainsSubstring("Rotation Matrix size should always be 3x3"));
+}
+
 TEST_CASE("EEPROM data default set fields are present", "[getEepromData]") {
     auto handler = loadInvalidHandler();
     auto eeprom = handler.getEepromData();

--- a/tests/src/onhost_tests/calibration_handler_test.cpp
+++ b/tests/src/onhost_tests/calibration_handler_test.cpp
@@ -852,6 +852,52 @@ TEST_CASE("Rotation matrix matches getCameraExtrinsics", "[getCameraRotationMatr
         for(int j = 0; j < 3; ++j) REQUIRE(R[i][j] == Catch::Approx(M[i][j]).margin(1e-6));
 }
 
+TEST_CASE("updateCameraExtrinsics overwrites calibrated pose and preserves existing link metadata", "[updateCameraExtrinsics]") {
+    auto handler = loadValidHandler();
+
+    const auto specBefore = handler.getCameraTranslationVector(CameraBoardSocket::CAM_A, CameraBoardSocket::CAM_B, true);
+    const auto updatedRotation = std::vector<std::vector<float>>{{0.0f, -1.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f}};
+    const auto updatedTranslation = std::vector<float>{8.0f, -2.0f, 1.5f};
+
+    handler.updateCameraExtrinsics(CameraBoardSocket::CAM_A, CameraBoardSocket::CAM_B, updatedRotation, updatedTranslation);
+
+    const auto calibratedAfter = handler.getCameraTranslationVector(CameraBoardSocket::CAM_A, CameraBoardSocket::CAM_B, false);
+    const auto specAfter = handler.getCameraTranslationVector(CameraBoardSocket::CAM_A, CameraBoardSocket::CAM_B, true);
+    const auto rotationAfter = handler.getCameraRotationMatrix(CameraBoardSocket::CAM_A, CameraBoardSocket::CAM_B);
+
+    REQUIRE(calibratedAfter[0] == Catch::Approx(updatedTranslation[0]).margin(1e-6));
+    REQUIRE(calibratedAfter[1] == Catch::Approx(updatedTranslation[1]).margin(1e-6));
+    REQUIRE(calibratedAfter[2] == Catch::Approx(updatedTranslation[2]).margin(1e-6));
+
+    REQUIRE(specAfter[0] == Catch::Approx(specBefore[0]).margin(1e-6));
+    REQUIRE(specAfter[1] == Catch::Approx(specBefore[1]).margin(1e-6));
+    REQUIRE(specAfter[2] == Catch::Approx(specBefore[2]).margin(1e-6));
+
+    for(size_t row = 0; row < updatedRotation.size(); ++row) {
+        for(size_t col = 0; col < updatedRotation[row].size(); ++col) {
+            REQUIRE(rotationAfter[row][col] == Catch::Approx(updatedRotation[row][col]).margin(1e-6));
+        }
+    }
+}
+
+TEST_CASE("updateCameraExtrinsics rejects missing source camera", "[updateCameraExtrinsics]") {
+    auto handler = loadValidHandler();
+    const auto identity = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}};
+    const auto translation = std::vector<float>{0.0f, 0.0f, 0.0f};
+
+    REQUIRE_THROWS_WITH(handler.updateCameraExtrinsics(CameraBoardSocket::CAM_E, CameraBoardSocket::CAM_B, identity, translation),
+                        Catch::Matchers::ContainsSubstring("No existing extrinsics found for the source camera socket"));
+}
+
+TEST_CASE("updateCameraExtrinsics rejects destination mismatch", "[updateCameraExtrinsics]") {
+    auto handler = loadValidHandler();
+    const auto identity = std::vector<std::vector<float>>{{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}};
+    const auto translation = std::vector<float>{0.0f, 0.0f, 0.0f};
+
+    REQUIRE_THROWS_WITH(handler.updateCameraExtrinsics(CameraBoardSocket::CAM_A, CameraBoardSocket::CAM_C, identity, translation),
+                        Catch::Matchers::ContainsSubstring("has different toCameraSocket"));
+}
+
 TEST_CASE("EEPROM data default set fields are present", "[getEepromData]") {
     auto handler = loadInvalidHandler();
     auto eeprom = handler.getEepromData();
@@ -1340,6 +1386,20 @@ TEST_CASE("getHousingCalibration scales translation for all units", "[getHousing
 
     for(const auto& [unit, scale] : getAllUnitScales(LengthUnit::CENTIMETER)) {
         auto result = handler.getHousingCalibration(CameraBoardSocket::CAM_C, dai::HousingCoordinateSystem::FRONT_CAM_A, false, unit);
+        auto expected = base;
+        expected[0][3] *= scale;
+        expected[1][3] *= scale;
+        expected[2][3] *= scale;
+        requireMatrixApproxEqual(result, expected);
+    }
+}
+
+TEST_CASE("getHousingCalibration scales spec translation for all units", "[getHousingCalibration][units]") {
+    auto handler = loadHandlerWithHousing();
+    auto base = handler.getHousingCalibration(CameraBoardSocket::CAM_C, dai::HousingCoordinateSystem::FRONT_CAM_A, true, LengthUnit::CENTIMETER);
+
+    for(const auto& [unit, scale] : getAllUnitScales(LengthUnit::CENTIMETER)) {
+        auto result = handler.getHousingCalibration(CameraBoardSocket::CAM_C, dai::HousingCoordinateSystem::FRONT_CAM_A, true, unit);
         auto expected = base;
         expected[0][3] *= scale;
         expected[1][3] *= scale;


### PR DESCRIPTION
## Summary

Adds missing CalibrationHandler mutation and housing-calibration coverage on feature/calibrationHandlerFunctions.

## Changes

- add `updateCameraExtrinsics(...)` for overwriting calibrated extrinsics without changing the existing link

- add unit support for housing-origin extrinsics handling
- rename internal housing-origin getter to `getHousingToHousingOriginExtrinsics`
- extend synthetic dynamic calibration coverage for housing-based calibration
- add host-side tests for:
    - updateCameraExtrinsics
    - housing calibration unit scaling
    - related calibration-handler branch behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to overwrite existing camera-to-camera extrinsics (rotation and translation) for a specified source/destination camera link.
  * Added unit-aware support for housing-origin extrinsics updates, accepting caller-provided translation units.
* **Bug Fixes**
  * Corrected housing calibration translation scaling to fully respect the selected length unit, including spec-translation behavior.
  * Improved validation for extrinsics updates by enforcing rotation-matrix dimensions.
* **Tests**
  * Expanded on-device and unit test coverage for extrinsics overwrites, housing-base recalibration/metrics, length-unit scaling, and invalid input cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->