### PR TITLE
Fix timed out Camera FPS config test

### DIFF
--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -1526,7 +1526,11 @@ void DeviceBase::monitorCallback(std::chrono::milliseconds watchdogTimeout, Prev
             if(reconnectionCallback) reconnectionCallback(ReconnectionStatus::RECONNECTED);
             pimpl->logger.warn("Reconnection successful\n");
             if(isCrashDumpCollectionEnabled()) {
-                crashed = hasCrashDump();
+                const bool hasPendingCrashDump = hasCrashDump();
+                crashed = hasPendingCrashDump;
+                if(!hasPendingCrashDump) {
+                    crashDumpHandled.store(false);
+                }
             }
         }
     } catch(const std::exception& ex) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -846,6 +846,10 @@ dai_add_test(camera_fps_config_test src/ondevice_tests/pipeline/node/camera_fps_
 dai_set_test_labels(camera_fps_config_test ondevice rvc2_all rvc4 ci noreplayci)
 set_property(TEST camera_fps_config_test APPEND PROPERTY ENVIRONMENT "DEPTHAI_AUTOCALIBRATION=OFF")
 
+dai_add_test(camera_fps_config_part_2_test src/ondevice_tests/pipeline/node/camera_fps_config_test_part_2.cpp)
+dai_set_test_labels(camera_fps_config_part_2_test ondevice rvc2_all rvc4 ci noreplayci)
+set_property(TEST camera_fps_config_part_2_test APPEND PROPERTY ENVIRONMENT "DEPTHAI_AUTOCALIBRATION=OFF")
+
 # VideoEncoder test
 if(DEPTHAI_FETCH_ARTIFACTS)
     dai_add_test(video_encoder_test src/ondevice_tests/video_encoder_test.cpp)

--- a/tests/src/ondevice_tests/pipeline/node/camera_fps_config_test.cpp
+++ b/tests/src/ondevice_tests/pipeline/node/camera_fps_config_test.cpp
@@ -175,11 +175,18 @@ TEST_CASE("Camera pool sizes") {
         }
         // Check stream still works after script node unblocks the Camera node
         while(std::chrono::duration<double>(std::chrono::steady_clock::now() - startTime).count() < timeToBlock + 30) {
+            bool gotEnoughFrames = true;
             for(int idx = 0; idx < outQueues.size(); ++idx) {
                 auto frame = outQueues[idx]->tryGet();
                 if(frame) {
                     ++outQueuesCounter[idx];
                 }
+                if(outQueuesCounter[idx] <= queueSize + 200) {
+                    gotEnoughFrames = false;
+                }
+            }
+            if(gotEnoughFrames) {
+                break;
             }
         }
         for(const auto& count : outQueuesCounter) {

--- a/tests/src/ondevice_tests/pipeline/node/camera_fps_config_test_part_2.cpp
+++ b/tests/src/ondevice_tests/pipeline/node/camera_fps_config_test_part_2.cpp
@@ -15,70 +15,10 @@
 #include "depthai/pipeline/node/Camera.hpp"
 #include "depthai/xlink/XLinkConnection.hpp"
 
-TEST_CASE("Camera sensor configs configurations") {
-    // Test that cameras can stream at all advertised configs
-    using std::chrono::steady_clock;
-    constexpr auto RESET_REMOTE_TIMEOUT_MS = std::chrono::milliseconds(2000);
-    // Minimum FPS is incorrectly advertised, so this test sets the minimum to 8 FPS.
-    constexpr float MINIMUM_FPS_RVC4 = 8.0f;  // TODO(Jakob) - remove this when fixed on device side
-
-    // Maximum FPS on RVC2 is 120, because of 3A limitations
-    constexpr float MAXIMUM_FPS_RVC2 = 120.0f;
-
-    dai::DeviceInfo connectedDeviceInfo;
-    std::vector<dai::CameraFeatures> connectedCameraFeautres;
-    {
-        auto device = dai::Device();
-        connectedCameraFeautres = device.getConnectedCameraFeatures();
-        connectedDeviceInfo.deviceId = device.getDeviceId();
-        connectedDeviceInfo.platform = device.getDeviceInfo().platform;
-    }
-
-    for(const auto& cameraFeatures : connectedCameraFeautres) {
-        for(const auto& config : cameraFeatures.configs) {
-            auto minimumFps = connectedDeviceInfo.platform == X_LINK_RVC4 ? std::max(MINIMUM_FPS_RVC4, config.minFps) : config.minFps;
-            auto maximumFps = connectedDeviceInfo.platform == X_LINK_MYRIAD_X ? std::min(MAXIMUM_FPS_RVC2, config.maxFps) : config.maxFps;
-            for(const auto& fpsVariant : {maximumFps, minimumFps}) {
-                std::cout << "Testing camera " << cameraFeatures.socket << " with resolution " << config.width << "x" << config.height << " at fps "
-                          << fpsVariant << " on device " << connectedDeviceInfo.getDeviceId() << "\n"
-                          << std::flush;
-
-                auto disappearStart = steady_clock::now();
-                while(steady_clock::now() - disappearStart < RESET_REMOTE_TIMEOUT_MS) {
-                    std::vector<dai::DeviceInfo> devices = dai::XLinkConnection::getAllConnectedDevices(X_LINK_ANY_STATE, true, 50);
-                    bool found = false;
-                    for(const auto& dev : devices) {
-                        if(dev.deviceId == connectedDeviceInfo.deviceId) {
-                            found = true;
-                        }
-                    }
-                    if(!found) {
-                        break;  // Device disappeared and went into reset
-                    }
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                }
-                dai::Pipeline pipeline{std::make_shared<dai::Device>(connectedDeviceInfo)};
-                auto benchmarkIn = pipeline.create<dai::node::BenchmarkIn>();
-                benchmarkIn->sendReportEveryNMessages(static_cast<uint32_t>(std::round(fpsVariant)));
-                auto camera = pipeline.create<dai::node::Camera>()->build(cameraFeatures.socket, std::pair(config.width, config.height), fpsVariant);
-                camera->requestOutput(std::pair(config.width, config.height))->link(benchmarkIn->input);
-                auto benchmarkQueue = benchmarkIn->report.createOutputQueue();
-                pipeline.start();
-                benchmarkQueue->get<dai::BenchmarkReport>();  // Warmup
-                for(int i = 0; i < 3; i++) {
-                    auto benchmarkReport = benchmarkQueue->get<dai::BenchmarkReport>();
-                    // Allow +-10% difference
-                    if(!pipeline.isHolisticReplayEnabled()) REQUIRE(benchmarkReport->fps == Catch::Approx(fpsVariant).margin(fpsVariant * 0.15f));
-                }
-            }
-        }
-    }
-}
-
 TEST_CASE("Camera pool sizes") {
     auto firstDevice = dai::Device::getFirstAvailableDevice();
     auto isRvc4 = std::get<1>(firstDevice).platform == X_LINK_RVC4;
-    for(const int overrideQueueSize : (isRvc4 ? std::vector<int>{-1, 2, 17, 3} : std::vector<int>{-1, 2, 17})) {
+    for(const int overrideQueueSize : (isRvc4 ? std::vector<int>{50, 4, 5} : std::vector<int>{3, 4, 5})) {
         std::cout << "Testing num frames = " << overrideQueueSize << "\n" << std::flush;
         dai::Pipeline pipeline;
         std::map<dai::CameraBoardSocket, std::vector<std::tuple<int, int, float>>> streamsRvc4{


### PR DESCRIPTION
## Purpose
Camera FPS config test often timed out for RVC2 POE devices. This fix adds early stopping when enough frames are collected.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: /

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new on-device camera FPS/config validation test (`camera_fps_config_part_2_test`) to verify camera output queue/frame pool limits across platforms.
  * Updated platform-specific expectations for RVC4 queue size overrides and ensured behavior adapts when `DEPTHAI_AUTOCALIBRATION=OFF`.
* **Bug Fixes**
  * Improved crash-dump state handling after reconnects by correctly preparing the “handled” tracking based on whether a pending crash dump exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->