### PR TITLE
Better cache folder handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The following environment variables can be set to alter default behavior of the 
 | DEPTHAI_BOOTLOADER_BINARY_ETH | Overrides device Network Bootloader binary. Mostly for internal debugging purposes. |
 | DEPTHAI_ALLOW_FACTORY_FLASHING | Internal use only |
 | DEPTHAI_LIBUSB_ANDROID_JAVAVM | JavaVM pointer that is passed to libusb for rootless Android interaction with devices. Interpreted as decimal value of uintptr_t |
-| DEPTHAI_CACHE_DIR | Overrides the default DepthAI cache root directory. |
+| DEPTHAI_CACHE_DIR | Overrides the default DepthAI cache root directory. Default: macOS `~/Library/Caches/depthai`, Windows `%LOCALAPPDATA%\\depthai\\cache`, Linux `${XDG_CACHE_HOME:-~/.cache}/depthai` |
 | DEPTHAI_CRASHDUMP | Directory in which to save the crash dump. Automatic crash dump collection is disabled if set to 0. |
 | DEPTHAI_CRASHDUMP_TIMEOUT | Specifies the duration in milliseconds to wait for device reboot when obtaining a crash dump. Automatic crash dump collection is disabled if set to 0. |
 | DEPTHAI_TELEMETRY | Telemetry is enabled by default. Set to `0` or `false` to disable event capture. |
@@ -231,7 +231,7 @@ The following environment variables can be set to alter default behavior of the 
 | DEPTHAI_HUB_API_KEY | API key for the Luxonis Hub |
 | DEPTHAI_ZOO_INTERNET_CHECK | (Default) 1 - perform internet check, if available, download the newest model version 0 - skip internet check and use cached model |
 | DEPTHAI_ZOO_INTERNET_CHECK_TIMEOUT | (Default) 1000 - timeout in milliseconds for the internet check |
-| DEPTHAI_ZOO_CACHE_PATH | (Default) .depthai_cached_models - Folder where cached zoo models are stored |
+| DEPTHAI_ZOO_CACHE_PATH | (Default) `${DEPTHAI_CACHE_DIR}/models` - Folder where cached zoo models are stored |
 | DEPTHAI_ZOO_MODELS_PATH | (Default) depthai_models - Folder where zoo model description files are stored |
 | DEPTHAI_RECORD | Enables holistic record to the specified directory. |
 | DEPTHAI_REPLAY | Replays holistic replay from the specified file or directory. |

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ The following environment variables can be set to alter default behavior of the 
 | DEPTHAI_BOOTLOADER_BINARY_ETH | Overrides device Network Bootloader binary. Mostly for internal debugging purposes. |
 | DEPTHAI_ALLOW_FACTORY_FLASHING | Internal use only |
 | DEPTHAI_LIBUSB_ANDROID_JAVAVM | JavaVM pointer that is passed to libusb for rootless Android interaction with devices. Interpreted as decimal value of uintptr_t |
+| DEPTHAI_CACHE_DIR | Overrides the default DepthAI cache root directory. |
 | DEPTHAI_CRASHDUMP | Directory in which to save the crash dump. Automatic crash dump collection is disabled if set to 0. |
 | DEPTHAI_CRASHDUMP_TIMEOUT | Specifies the duration in milliseconds to wait for device reboot when obtaining a crash dump. Automatic crash dump collection is disabled if set to 0. |
 | DEPTHAI_TELEMETRY | Telemetry is enabled by default. Set to `0` or `false` to disable event capture. |

--- a/src/modelzoo/Zoo.cpp
+++ b/src/modelzoo/Zoo.cpp
@@ -37,7 +37,7 @@ namespace fs = std::filesystem;
 
 static std::string modelZooHealthEndpoint = "https://easyml.cloud.luxonis.com/models/api/v1/health/";
 static std::string modelZooDownloadEndpoint = "https://easyml.cloud.luxonis.com/models/api/v1/models/download";
-static fs::path modelZooDefaultCachePath = ".depthai_cached_models";  // hidden cache folder
+static fs::path modelZooDefaultCachePath = dai::platform::getDaiCacheDir() / "models";
 static fs::path modelZooDefaultModelsPath = "depthai_models";         // folder
 
 #ifdef DEPTHAI_ENABLE_CURL

--- a/src/utility/LogCollection.cpp
+++ b/src/utility/LogCollection.cpp
@@ -163,7 +163,7 @@ void logCrashDump(const std::optional<PipelineSchema>& pipelineSchema, const Cra
     crashDumpData.sha1Hash = calculateSHA1(crashDumpData.content);
     crashDumpData.name = getCrashDumpFilename(crashDump);
 
-    fs::path logDir = fs::current_path() / ".cache" / "depthai" / "crashdumps";
+    fs::path logDir = dai::platform::getDaiCacheDir() / "crashdumps";
     fs::path crashDumpPathLocal(dirToStoreCrashDumps);
     if(crashDumpPathLocal.empty()) {
         crashDumpPathLocal = logDir / crashDumpData.sha1Hash / crashDumpData.name;

--- a/src/utility/Platform.cpp
+++ b/src/utility/Platform.cpp
@@ -1,5 +1,6 @@
 #include "Platform.hpp"
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -44,6 +45,34 @@
 
 namespace dai {
 namespace platform {
+
+namespace {
+
+std::filesystem::path getEnvPath(const char* name) {
+    if(const char* value = std::getenv(name); value != nullptr && value[0] != '\0') {
+        return std::filesystem::path(value);
+    }
+    return {};
+}
+
+std::filesystem::path getHomePath() {
+#if defined(_WIN32) || defined(__USE_W32_SOCKETS)
+    auto home = getEnvPath("USERPROFILE");
+    if(!home.empty()) {
+        return home;
+    }
+    auto drive = getEnvPath("HOMEDRIVE");
+    auto path = getEnvPath("HOMEPATH");
+    if(!drive.empty() && !path.empty()) {
+        return drive / path.relative_path();
+    }
+    return {};
+#else
+    return getEnvPath("HOME");
+#endif
+}
+
+}  // namespace
 
 uint32_t getIPv4AddressAsBinary(std::string address) {
     uint32_t binary = 0;
@@ -221,6 +250,31 @@ std::string getOSVersion() {
 #else
     return "Other";
 #endif
+}
+
+std::filesystem::path getDaiCacheDir() {
+    if(auto cacheDir = getEnvPath("DEPTHAI_CACHE_DIR"); !cacheDir.empty()) {
+        return cacheDir;
+    }
+
+#ifdef __linux__
+    if(auto xdgCacheHome = getEnvPath("XDG_CACHE_HOME"); !xdgCacheHome.empty()) {
+        return xdgCacheHome / "depthai";
+    }
+    if(auto home = getHomePath(); !home.empty()) {
+        return home / ".cache" / "depthai";
+    }
+#elif defined(__APPLE__)
+    if(auto home = getHomePath(); !home.empty()) {
+        return home / "Library" / "Caches" / "depthai";
+    }
+#elif defined(_WIN32) || defined(__USE_W32_SOCKETS)
+    if(auto localAppData = getEnvPath("LOCALAPPDATA"); !localAppData.empty()) {
+        return localAppData / "depthai" / "cache";
+    }
+#endif
+
+    return std::filesystem::current_path() / ".cache";
 }
 
 void setThreadName(JoiningThread& thread, const std::string& name) {

--- a/src/utility/Platform.hpp
+++ b/src/utility/Platform.hpp
@@ -31,6 +31,7 @@ std::string getLocalIpAddress();
  */
 std::string getOSPlatform();
 std::string getOSVersion();
+std::filesystem::path getDaiCacheDir();
 
 /**
  * @brief Get the temporary path

--- a/src/utility/Telemetry.cpp
+++ b/src/utility/Telemetry.cpp
@@ -881,6 +881,9 @@ void Telemetry::event(std::string eventName, nlohmann::json properties) {
 }
 
 void Telemetry::event(const DeviceBase& device, std::string eventName, nlohmann::json properties) {
+    if(!isTelemetryEnabled()) {
+        return;
+    }
     addDeviceTelemetryProperties(device, properties);
     if(impl) {
         impl->event(std::move(eventName), std::move(properties));
@@ -888,6 +891,9 @@ void Telemetry::event(const DeviceBase& device, std::string eventName, nlohmann:
 }
 
 void Telemetry::event(const Pipeline& pipeline, std::string eventName, nlohmann::json properties) {
+    if(!isTelemetryEnabled()) {
+        return;
+    }
     addPipelineTelemetryProperties(pipeline, properties);
     if(impl) {
         impl->event(std::move(eventName), std::move(properties));

--- a/src/utility/Telemetry.cpp
+++ b/src/utility/Telemetry.cpp
@@ -103,7 +103,7 @@ std::string lowercase(std::string value) {
 }
 
 std::filesystem::path defaultTelemetryBaseDir() {
-    return std::filesystem::current_path() / ".cache" / "depthai" / DEFAULT_TELEMETRY_ROOT_DIR;
+    return dai::platform::getDaiCacheDir() / DEFAULT_TELEMETRY_ROOT_DIR;
 }
 
 std::string generateUuidV4() {

--- a/src/utility/Telemetry.cpp
+++ b/src/utility/Telemetry.cpp
@@ -429,7 +429,7 @@ TelemetrySharedState::TelemetrySharedState() {
         std::filesystem::create_directories(queueDir);
         loadQueueFromDisk();
     } catch(const std::exception& ex) {
-        logger::warn("Failed to initialize telemetry storage at '{}': {}", queueDir.string(), ex.what());
+        logger::info("Failed to initialize telemetry storage at '{}': {}", queueDir.string(), ex.what());
         return;
     }
 


### PR DESCRIPTION
enable setting custom cache folder locations and fallback to better default location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DEPTHAI_CACHE_DIR environment variable to customize the cache directory.

* **Improvements**
  * Consolidated models, crash dumps, and telemetry into a centralized cache directory.
  * Telemetry events now exit early when disabled and log-level for telemetry storage failures lowered to info.

* **Documentation**
  * README updated to document DEPTHAI_CACHE_DIR and adjusted default model cache path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->