### PR TITLE
Clang lints: pass by value and const methods

### DIFF
--- a/bindings/python/src/CalibrationHandlerBindings.cpp
+++ b/bindings/python/src/CalibrationHandlerBindings.cpp
@@ -69,7 +69,7 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack) {
              py::arg("keepAspectRatio") = true,
              DOC(dai, CalibrationHandler, getCameraIntrinsics, 2))
         .def("getCameraIntrinsics",
-             py::overload_cast<CameraBoardSocket, std::tuple<int, int>, Point2f, Point2f, bool>(&CalibrationHandler::getCameraIntrinsics, py::const_),
+             py::overload_cast<CameraBoardSocket, const std::tuple<int, int>&, Point2f, Point2f, bool>(&CalibrationHandler::getCameraIntrinsics, py::const_),
              py::arg("cameraId"),
              py::arg("destShape"),
              py::arg("topLeftPixelId") = Point2f(),
@@ -155,12 +155,12 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("eepromToJson", &CalibrationHandler::eepromToJson, DOC(dai, CalibrationHandler, eepromToJson))
 
         .def("setBoardInfo",
-             py::overload_cast<std::string, std::string>(&CalibrationHandler::setBoardInfo),
+             py::overload_cast<const std::string&, const std::string&>(&CalibrationHandler::setBoardInfo),
              py::arg("boardName"),
              py::arg("boardRev"),
              DOC(dai, CalibrationHandler, setBoardInfo))
         .def("setBoardInfo",
-             py::overload_cast<std::string, std::string, std::string, std::string, std::string, std::string, uint64_t, uint32_t, std::string>(
+             py::overload_cast<const std::string&, const std::string&, const std::string&, const std::string&, const std::string&, const std::string&, uint64_t, uint32_t, const std::string&>(
                  &CalibrationHandler::setBoardInfo),
              py::arg("productName"),
              py::arg("boardName"),
@@ -173,7 +173,7 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack) {
              py::arg("boardCustom") = "",
              DOC(dai, CalibrationHandler, setBoardInfo, 2))
         .def("setBoardInfo",
-             py::overload_cast<std::string, std::string, std::string, std::string, std::string, std::string, std::string, uint64_t, uint32_t, std::string>(
+             py::overload_cast<const std::string&, const std::string&, const std::string&, const std::string&, const std::string&, const std::string&, const std::string&, uint64_t, uint32_t, const std::string&>(
                  &CalibrationHandler::setBoardInfo),
              py::arg("deviceName"),
              py::arg("productName"),
@@ -191,20 +191,20 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack) {
         .def("setProductName", &CalibrationHandler::setProductName, py::arg("productName"), DOC(dai, CalibrationHandler, setProductName))
 
         .def("setCameraIntrinsics",
-             py::overload_cast<CameraBoardSocket, std::vector<std::vector<float>>, Size2f>(&CalibrationHandler::setCameraIntrinsics),
+             py::overload_cast<CameraBoardSocket, const std::vector<std::vector<float>>&, Size2f>(&CalibrationHandler::setCameraIntrinsics),
              py::arg("cameraId"),
              py::arg("intrinsics"),
              py::arg("frameSize"),
              DOC(dai, CalibrationHandler, setCameraIntrinsics))
         .def("setCameraIntrinsics",
-             py::overload_cast<CameraBoardSocket, std::vector<std::vector<float>>, int, int>(&CalibrationHandler::setCameraIntrinsics),
+             py::overload_cast<CameraBoardSocket, const std::vector<std::vector<float>>&, int, int>(&CalibrationHandler::setCameraIntrinsics),
              py::arg("cameraId"),
              py::arg("intrinsics"),
              py::arg("width"),
              py::arg("height"),
              DOC(dai, CalibrationHandler, setCameraIntrinsics, 2))
         .def("setCameraIntrinsics",
-             py::overload_cast<CameraBoardSocket, std::vector<std::vector<float>>, std::tuple<int, int>>(&CalibrationHandler::setCameraIntrinsics),
+             py::overload_cast<CameraBoardSocket, const std::vector<std::vector<float>>&, const std::tuple<int, int>&>(&CalibrationHandler::setCameraIntrinsics),
              py::arg("cameraId"),
              py::arg("intrinsics"),
              py::arg("frameSize"),
@@ -307,7 +307,7 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack) {
              py::arg("keepAspectRatio") = true,
              DOC(dai, CBACalibrationHandler, getCameraIntrinsics, 2))
         .def("getCameraIntrinsics",
-             py::overload_cast<std::tuple<int, int>, Point2f, Point2f, bool>(&CBACalibrationHandler::getCameraIntrinsics, py::const_),
+             py::overload_cast<const std::tuple<int, int>&, Point2f, Point2f, bool>(&CBACalibrationHandler::getCameraIntrinsics, py::const_),
              py::arg("destShape"),
              py::arg("topLeftPixelId") = Point2f(),
              py::arg("bottomRightPixelId") = Point2f(),
@@ -328,23 +328,23 @@ void CalibrationHandlerBindings::bind(pybind11::module& m, void* pCallstack) {
              DOC(dai, CBACalibrationHandler, getDistortionModel))
 
         .def("setCameraIntrinsics",
-             py::overload_cast<std::vector<std::vector<float>>, Size2f>(&CBACalibrationHandler::setCameraIntrinsics),
+             py::overload_cast<const std::vector<std::vector<float>>&, Size2f>(&CBACalibrationHandler::setCameraIntrinsics),
              py::arg("intrinsics"),
              py::arg("frameSize"),
              DOC(dai, CBACalibrationHandler, setCameraIntrinsics))
         .def("setCameraIntrinsics",
-             py::overload_cast<std::vector<std::vector<float>>, int, int>(&CBACalibrationHandler::setCameraIntrinsics),
+             py::overload_cast<const std::vector<std::vector<float>>&, int, int>(&CBACalibrationHandler::setCameraIntrinsics),
              py::arg("intrinsics"),
              py::arg("width"),
              py::arg("height"),
              DOC(dai, CBACalibrationHandler, setCameraIntrinsics, 2))
         .def("setCameraIntrinsics",
-             py::overload_cast<std::vector<std::vector<float>>, std::tuple<int, int>>(&CBACalibrationHandler::setCameraIntrinsics),
+             py::overload_cast<const std::vector<std::vector<float>>&, const std::tuple<int, int>&>(&CBACalibrationHandler::setCameraIntrinsics),
              py::arg("intrinsics"),
              py::arg("frameSize"),
              DOC(dai, CBACalibrationHandler, setCameraIntrinsics, 3))
         .def("setDistortionCoefficients",
-             py::overload_cast<std::vector<float>>(&CBACalibrationHandler::setDistortionCoefficients),
+             py::overload_cast<const std::vector<float>&>(&CBACalibrationHandler::setDistortionCoefficients),
              py::arg("distortionCoefficients"),
              DOC(dai, CBACalibrationHandler, setDistortionCoefficients))
         .def("setFov", py::overload_cast<float>(&CBACalibrationHandler::setFov), py::arg("hfov"), DOC(dai, CBACalibrationHandler, setFov))

--- a/bindings/python/src/DeviceBindings.cpp
+++ b/bindings/python/src/DeviceBindings.cpp
@@ -333,7 +333,7 @@ void DeviceBindings::bind(pybind11::module& m, void* pCallstack) {
                     py::arg("version") = OpenVINO::VERSION_UNIVERSAL,
                     DOC(dai, DeviceBase, getEmbeddedDeviceBinary))
         .def_static("getEmbeddedDeviceBinary",
-                    py::overload_cast<DeviceBase::Config>(&DeviceBase::getEmbeddedDeviceBinary),
+                    py::overload_cast<const DeviceBase::Config&>(&DeviceBase::getEmbeddedDeviceBinary),
                     py::arg("config"),
                     DOC(dai, DeviceBase, getEmbeddedDeviceBinary, 2))
         .def_static("getDeviceById", &DeviceBase::getDeviceById, py::arg("deviceId"), DOC(dai, DeviceBase, getDeviceById))

--- a/bindings/python/src/DeviceBootloaderBindings.cpp
+++ b/bindings/python/src/DeviceBootloaderBindings.cpp
@@ -108,7 +108,7 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
         .def_static("getFirstAvailableDevice", &DeviceBootloader::getFirstAvailableDevice, DOC(dai, DeviceBootloader, getFirstAvailableDevice))
         .def_static("getAllAvailableDevices", &DeviceBootloader::getAllAvailableDevices, DOC(dai, DeviceBootloader, getAllAvailableDevices))
         .def_static("saveDepthaiApplicationPackage",
-                    py::overload_cast<const std::filesystem::path&, const Pipeline&, const std::filesystem::path&, bool, std::string, bool>(
+                    py::overload_cast<const std::filesystem::path&, const Pipeline&, const std::filesystem::path&, bool, const std::string&, bool>(
                         &DeviceBootloader::saveDepthaiApplicationPackage),
                     py::arg("path"),
                     py::arg("pipeline"),
@@ -118,7 +118,7 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
                     py::arg("checkChecksum") = false,
                     DOC(dai, DeviceBootloader, saveDepthaiApplicationPackage))
         .def_static("saveDepthaiApplicationPackage",
-                    py::overload_cast<const std::filesystem::path&, const Pipeline&, bool, std::string, bool>(&DeviceBootloader::saveDepthaiApplicationPackage),
+                    py::overload_cast<const std::filesystem::path&, const Pipeline&, bool, const std::string&, bool>(&DeviceBootloader::saveDepthaiApplicationPackage),
                     py::arg("path"),
                     py::arg("pipeline"),
                     py::arg("compress"),
@@ -135,7 +135,7 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
             py::arg("checkChecksum") = false,
             DOC(dai, DeviceBootloader, createDepthaiApplicationPackage))
         .def_static("createDepthaiApplicationPackage",
-                    py::overload_cast<const Pipeline&, bool, std::string, bool>(&DeviceBootloader::createDepthaiApplicationPackage),
+                    py::overload_cast<const Pipeline&, bool, const std::string&, bool>(&DeviceBootloader::createDepthaiApplicationPackage),
                     py::arg("pipeline"),
                     py::arg("compress"),
                     py::arg("applicationName") = "",

--- a/bindings/python/src/pipeline/datatype/CameraControlBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/CameraControlBindings.cpp
@@ -264,9 +264,9 @@ void bind_cameracontrol(pybind11::module& m, void* pCallstack) {
              py::arg("control"),
              py::arg("value"),
              DOC(dai, CameraControl, setMisc))
-        .def("setMisc", py::overload_cast<std::string, int>(&CameraControl::setMisc), py::arg("control"), py::arg("value"), DOC(dai, CameraControl, setMisc, 2))
+        .def("setMisc", py::overload_cast<const std::string&, int>(&CameraControl::setMisc), py::arg("control"), py::arg("value"), DOC(dai, CameraControl, setMisc, 2))
         .def("setMisc",
-             py::overload_cast<std::string, float>(&CameraControl::setMisc),
+             py::overload_cast<const std::string&, float>(&CameraControl::setMisc),
              py::arg("control"),
              py::arg("value"),
              DOC(dai, CameraControl, setMisc, 3))

--- a/bindings/python/src/pipeline/datatype/FeatureTrackerConfigBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/FeatureTrackerConfigBindings.cpp
@@ -126,7 +126,7 @@ void bind_featuretrackerconfig(pybind11::module& m, void* pCallstack) {
              py::arg("cornerDetector"),
              DOC(dai, FeatureTrackerConfig, setCornerDetector))
         .def("setCornerDetector",
-             static_cast<FeatureTrackerConfig& (FeatureTrackerConfig::*)(dai::FeatureTrackerConfig::CornerDetector)>(&FeatureTrackerConfig::setCornerDetector),
+             static_cast<FeatureTrackerConfig& (FeatureTrackerConfig::*)(const dai::FeatureTrackerConfig::CornerDetector&)>(&FeatureTrackerConfig::setCornerDetector),
              py::arg("config"),
              DOC(dai, FeatureTrackerConfig, setCornerDetector, 2))
         .def("setMotionEstimator",
@@ -135,14 +135,14 @@ void bind_featuretrackerconfig(pybind11::module& m, void* pCallstack) {
              DOC(dai, FeatureTrackerConfig, setMotionEstimator))
         .def(
             "setMotionEstimator",
-            static_cast<FeatureTrackerConfig& (FeatureTrackerConfig::*)(dai::FeatureTrackerConfig::MotionEstimator)>(&FeatureTrackerConfig::setMotionEstimator),
+            static_cast<FeatureTrackerConfig& (FeatureTrackerConfig::*)(const dai::FeatureTrackerConfig::MotionEstimator&)>(&FeatureTrackerConfig::setMotionEstimator),
             py::arg("config"),
             DOC(dai, FeatureTrackerConfig, setMotionEstimator, 2))
         .def("setOpticalFlow",
              static_cast<FeatureTrackerConfig& (FeatureTrackerConfig::*)()>(&FeatureTrackerConfig::setOpticalFlow),
              DOC(dai, FeatureTrackerConfig, setOpticalFlow))
         .def("setOpticalFlow",
-             static_cast<FeatureTrackerConfig& (FeatureTrackerConfig::*)(dai::FeatureTrackerConfig::MotionEstimator::OpticalFlow)>(
+             static_cast<FeatureTrackerConfig& (FeatureTrackerConfig::*)(const dai::FeatureTrackerConfig::MotionEstimator::OpticalFlow&)>(
                  &FeatureTrackerConfig::setOpticalFlow),
              py::arg("config"),
              DOC(dai, FeatureTrackerConfig, setOpticalFlow, 2))

--- a/bindings/python/src/pipeline/datatype/ImageManipConfigBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImageManipConfigBindings.cpp
@@ -53,7 +53,7 @@ void bind_imagemanipconfig(pybind11::module& m, void* pCallstack) {
              py::arg("h"),
              DOC(dai, ImageManipConfig, addCrop))
         .def("addCrop",
-             static_cast<ImageManipConfig& (ImageManipConfig::*)(dai::Rect, bool)>(&ImageManipConfig::addCrop),
+             static_cast<ImageManipConfig& (ImageManipConfig::*)(const dai::Rect&, bool)>(&ImageManipConfig::addCrop),
              py::arg("rect"),
              py::arg("normalizedCoords"),
              DOC(dai, ImageManipConfig, addCrop))

--- a/bindings/python/src/pipeline/node/CameraBindings.cpp
+++ b/bindings/python/src/pipeline/node/CameraBindings.cpp
@@ -25,7 +25,7 @@ void bind_camera(pybind11::module& m, void* pCallstack) {
         .def_readonly("mockIsp", &Camera::mockIsp, DOC(dai, node, Camera, mockIsp))
         .def_readonly("raw", &Camera::raw, DOC(dai, node, Camera, raw))
         .def("build",
-             py::overload_cast<dai::CameraBoardSocket, std::optional<std::pair<uint32_t, uint32_t>>, std::optional<float>>(&Camera::build),
+             py::overload_cast<dai::CameraBoardSocket, const std::optional<std::pair<uint32_t, uint32_t>>&, std::optional<float>>(&Camera::build),
              "boardSocket"_a = CameraBoardSocket::AUTO,
              "sensorResolution"_a = std::nullopt,
              "sensorFps"_a = std::nullopt,
@@ -62,7 +62,7 @@ void bind_camera(pybind11::module& m, void* pCallstack) {
         // .def("setCamera", &Camera::setCamera, "name"_a, DOC(dai, node, Camera, setCamera))
         // .def("getCamera", &Camera::getCamera, DOC(dai, node, Camera, getCamera))
         .def("requestOutput",
-             py::overload_cast<std::pair<uint32_t, uint32_t>, std::optional<ImgFrame::Type>, ImgResizeMode, std::optional<float>, std::optional<bool>>(
+             py::overload_cast<const std::pair<uint32_t, uint32_t>&, std::optional<ImgFrame::Type>, ImgResizeMode, std::optional<float>, std::optional<bool>>(
                  &Camera::requestOutput),
              "size"_a,
              "type"_a = std::nullopt,

--- a/bindings/python/src/pipeline/node/ColorCameraBindings.cpp
+++ b/bindings/python/src/pipeline/node/ColorCameraBindings.cpp
@@ -138,7 +138,7 @@ void bind_colorcamera(pybind11::module& m, void* pCallstack) {
              py::arg("height"),
              DOC(dai, node, ColorCamera, setPreviewSize))
         .def("setPreviewSize",
-             static_cast<void (ColorCamera::*)(std::tuple<int, int>)>(&ColorCamera::setPreviewSize),
+             static_cast<void (ColorCamera::*)(const std::tuple<int, int>&)>(&ColorCamera::setPreviewSize),
              py::arg("size"),
              DOC(dai, node, ColorCamera, setPreviewSize, 2))
         .def("setVideoSize",
@@ -147,7 +147,7 @@ void bind_colorcamera(pybind11::module& m, void* pCallstack) {
              py::arg("height"),
              DOC(dai, node, ColorCamera, setVideoSize))
         .def("setVideoSize",
-             static_cast<void (ColorCamera::*)(std::tuple<int, int>)>(&ColorCamera::setVideoSize),
+             static_cast<void (ColorCamera::*)(const std::tuple<int, int>&)>(&ColorCamera::setVideoSize),
              py::arg("size"),
              DOC(dai, node, ColorCamera, setVideoSize, 2))
         .def("setStillSize",
@@ -156,7 +156,7 @@ void bind_colorcamera(pybind11::module& m, void* pCallstack) {
              py::arg("height"),
              DOC(dai, node, ColorCamera, setStillSize))
         .def("setStillSize",
-             static_cast<void (ColorCamera::*)(std::tuple<int, int>)>(&ColorCamera::setStillSize),
+             static_cast<void (ColorCamera::*)(const std::tuple<int, int>&)>(&ColorCamera::setStillSize),
              py::arg("size"),
              DOC(dai, node, ColorCamera, setStillSize, 2))
         .def("setResolution", &ColorCamera::setResolution, py::arg("resolution"), DOC(dai, node, ColorCamera, setResolution))
@@ -192,7 +192,7 @@ void bind_colorcamera(pybind11::module& m, void* pCallstack) {
              py::arg("denominator"),
              DOC(dai, node, ColorCamera, setIspScale))
         .def("setIspScale",
-             static_cast<void (ColorCamera::*)(std::tuple<int, int>)>(&ColorCamera::setIspScale),
+             static_cast<void (ColorCamera::*)(const std::tuple<int, int>&)>(&ColorCamera::setIspScale),
              py::arg("scale"),
              DOC(dai, node, ColorCamera, setIspScale, 2))
         .def("setIspScale",
@@ -203,7 +203,7 @@ void bind_colorcamera(pybind11::module& m, void* pCallstack) {
              py::arg("vertDenom"),
              DOC(dai, node, ColorCamera, setIspScale, 3))
         .def("setIspScale",
-             static_cast<void (ColorCamera::*)(std::tuple<int, int>, std::tuple<int, int>)>(&ColorCamera::setIspScale),
+             static_cast<void (ColorCamera::*)(const std::tuple<int, int>&, const std::tuple<int, int>&)>(&ColorCamera::setIspScale),
              py::arg("horizScale"),
              py::arg("vertScale"),
              DOC(dai, node, ColorCamera, setIspScale, 4))

--- a/bindings/python/src/pipeline/node/DetectionNetworkBindings.cpp
+++ b/bindings/python/src/pipeline/node/DetectionNetworkBindings.cpp
@@ -160,7 +160,7 @@ void bind_detectionnetwork(pybind11::module& m, void* pCallstack) {
              py::arg("description"),
              py::arg("useCached") = false,
              DOC(dai, node, DetectionNetwork, setFromModelZoo))
-        .def("setBlob", py::overload_cast<dai::OpenVINO::Blob>(&DetectionNetwork::setBlob), py::arg("blob"), DOC(dai, node, DetectionNetwork, setBlob))
+        .def("setBlob", py::overload_cast<const dai::OpenVINO::Blob&>(&DetectionNetwork::setBlob), py::arg("blob"), DOC(dai, node, DetectionNetwork, setBlob))
         .def("setBlob",
              py::overload_cast<const std::filesystem::path&>(&DetectionNetwork::setBlob),
              py::arg("path"),

--- a/bindings/python/src/pipeline/node/DetectionParserBindings.cpp
+++ b/bindings/python/src/pipeline/node/DetectionParserBindings.cpp
@@ -33,7 +33,7 @@ void bind_detectionparser(pybind11::module& m, void* pCallstack) {
         .def("setBlobPath", &DetectionParser::setBlobPath, py::arg("path"), DOC(dai, node, DetectionParser, setBlobPath))
         .def("setNumFramesPool", &DetectionParser::setNumFramesPool, py::arg("numFramesPool"), DOC(dai, node, DetectionParser, setNumFramesPool))
         .def("getNumFramesPool", &DetectionParser::getNumFramesPool, DOC(dai, node, DetectionParser, getNumFramesPool))
-        .def("setBlob", py::overload_cast<dai::OpenVINO::Blob>(&DetectionParser::setBlob), py::arg("blob"), DOC(dai, node, DetectionParser, setBlob))
+        .def("setBlob", py::overload_cast<const dai::OpenVINO::Blob&>(&DetectionParser::setBlob), py::arg("blob"), DOC(dai, node, DetectionParser, setBlob))
         .def(
             "setBlob", py::overload_cast<const std::filesystem::path&>(&DetectionParser::setBlob), py::arg("path"), DOC(dai, node, DetectionParser, setBlob, 2))
         .def("setNNArchive",
@@ -46,7 +46,7 @@ void bind_detectionparser(pybind11::module& m, void* pCallstack) {
              py::arg("height"),
              DOC(dai, node, DetectionParser, setInputImageSize))
         .def("setInputImageSize",
-             static_cast<void (DetectionParser::*)(std::tuple<int, int>)>(&DetectionParser::setInputImageSize),
+             static_cast<void (DetectionParser::*)(const std::tuple<int, int>&)>(&DetectionParser::setInputImageSize),
              py::arg("size"),
              DOC(dai, node, DetectionParser, setInputImageSize, 2))
         .def("setNNFamily", &DetectionParser::setNNFamily, py::arg("type"), DOC(dai, node, DetectionParser, setNNFamily))
@@ -60,7 +60,7 @@ void bind_detectionparser(pybind11::module& m, void* pCallstack) {
              py::arg("anchors"),
              DOC(dai, node, DetectionParser, setAnchors))
         .def("setAnchors",
-             py::overload_cast<std::vector<float>>(&DetectionParser::setAnchors),
+             py::overload_cast<const std::vector<float>&>(&DetectionParser::setAnchors),
              py::arg("anchors"),
              DOC(dai, node, DetectionParser, setAnchors, 2))
         .def("setAnchorMasks", &DetectionParser::setAnchorMasks, py::arg("anchorMasks"), DOC(dai, node, DetectionParser, setAnchorMasks))

--- a/bindings/python/src/pipeline/node/RGBDBindings.cpp
+++ b/bindings/python/src/pipeline/node/RGBDBindings.cpp
@@ -37,7 +37,7 @@ void bind_rgbd(pybind11::module& m, void* pCallstack) {
         .def_readonly("rgbd", &RGBD::rgbd, DOC(dai, node, RGBD, rgbd))
         .def("build", static_cast<std::shared_ptr<RGBD> (RGBD::*)()>(&RGBD::build))
         .def("build",
-             static_cast<std::shared_ptr<RGBD> (RGBD::*)(bool, StereoDepth::PresetMode, std::pair<int, int>, std::optional<float>)>(&RGBD::build),
+             static_cast<std::shared_ptr<RGBD> (RGBD::*)(bool, StereoDepth::PresetMode, const std::pair<int, int>&, std::optional<float>)>(&RGBD::build),
              py::arg("autocreate"),
              py::arg("mode") = StereoDepth::PresetMode::DEFAULT,
              py::arg("size") = std::make_pair(640, 400),
@@ -45,7 +45,7 @@ void bind_rgbd(pybind11::module& m, void* pCallstack) {
              DOC(dai, node, RGBD, build, 2))
         // Build method with DepthSource variant
         .def("build",
-             py::overload_cast<const std::shared_ptr<Camera>&, const node::DepthSource&, std::pair<int, int>, std::optional<float>>(&RGBD::build),
+             py::overload_cast<const std::shared_ptr<Camera>&, const node::DepthSource&, const std::pair<int, int>&, std::optional<float>>(&RGBD::build),
              py::arg("camera"),
              py::arg("depthSource"),
              py::arg("size") = std::make_pair(640, 400),

--- a/bindings/python/src/pipeline/node/SpatialDetectionNetworkBindings.cpp
+++ b/bindings/python/src/pipeline/node/SpatialDetectionNetworkBindings.cpp
@@ -119,7 +119,7 @@ void bind_spatialdetectionnetwork(pybind11::module& m, void* pCallstack) {
              py::arg("useCached"),
              DOC(dai, node, SpatialDetectionNetwork, setFromModelZoo))
         .def("setBlob",
-             py::overload_cast<dai::OpenVINO::Blob>(&SpatialDetectionNetwork::setBlob),
+             py::overload_cast<const dai::OpenVINO::Blob&>(&SpatialDetectionNetwork::setBlob),
              py::arg("blob"),
              DOC(dai, node, SpatialDetectionNetwork, setBlob))
         .def("setBlob",

--- a/bindings/python/src/pipeline/node/StereoDepthBindings.cpp
+++ b/bindings/python/src/pipeline/node/StereoDepthBindings.cpp
@@ -107,7 +107,7 @@ void bind_stereodepth(pybind11::module& m, void* pCallstack) {
              DOC(dai, node, StereoDepth, build))
         .def("build",
              static_cast<std::shared_ptr<StereoDepth> (StereoDepth::*)(
-                 bool autoCreate, StereoDepth::PresetMode, std::pair<int, int> size, std::optional<float> fps)>(&StereoDepth::build),
+                 bool autoCreate, StereoDepth::PresetMode, const std::pair<int, int>& size, std::optional<float> fps)>(&StereoDepth::build),
              py::arg("autoCreateCameras"),
              py::arg("presetMode") = StereoDepth::PresetMode::DEFAULT,
              py::arg("size") = std::pair<int, int>{640, 400},
@@ -143,7 +143,7 @@ void bind_stereodepth(pybind11::module& m, void* pCallstack) {
              py::arg("height"),
              DOC(dai, node, StereoDepth, setInputResolution))
         .def("setInputResolution",
-             static_cast<void (StereoDepth::*)(std::tuple<int, int>)>(&StereoDepth::setInputResolution),
+             static_cast<void (StereoDepth::*)(const std::tuple<int, int>&)>(&StereoDepth::setInputResolution),
              py::arg("resolution"),
              DOC(dai, node, StereoDepth, setInputResolution, 2))
         .def("setOutputSize", &StereoDepth::setOutputSize, py::arg("width"), py::arg("height"), DOC(dai, node, StereoDepth, setOutputSize))

--- a/bindings/python/src/pipeline/node/WarpBindings.cpp
+++ b/bindings/python/src/pipeline/node/WarpBindings.cpp
@@ -36,7 +36,7 @@ void bind_warp(pybind11::module& m, void* pCallstack) {
         // setters
 
         .def("setOutputSize", py::overload_cast<int, int>(&Warp::setOutputSize), DOC(dai, node, Warp, setOutputSize))
-        .def("setOutputSize", py::overload_cast<std::tuple<int, int>>(&Warp::setOutputSize), DOC(dai, node, Warp, setOutputSize, 2))
+        .def("setOutputSize", py::overload_cast<const std::tuple<int, int>&>(&Warp::setOutputSize), DOC(dai, node, Warp, setOutputSize, 2))
         // .def("setOutputWidth", &Warp::setOutputWidth, DOC(dai, node, Warp, setOutputWidth))
         // .def("setOutputHeight", &Warp::setOutputHeight, DOC(dai, node, Warp, setOutputHeight))
 

--- a/include/depthai/common/ImgTransformations.hpp
+++ b/include/depthai/common/ImgTransformations.hpp
@@ -90,7 +90,7 @@ struct ImgTransformation {
      * @param rect Rectangle to transform
      * @return Transformed rectangle
      */
-    dai::RotatedRect transformRect(dai::RotatedRect rect) const;
+    dai::RotatedRect transformRect(const dai::RotatedRect& rect) const;
     /**
      * Transform a point from the current frame to the source frame.
      * @param point Point to transform
@@ -102,7 +102,7 @@ struct ImgTransformation {
      * @param rect Rectangle to transform
      * @return Transformed rectangle
      */
-    dai::RotatedRect invTransformRect(dai::RotatedRect rect) const;
+    dai::RotatedRect invTransformRect(const dai::RotatedRect& rect) const;
 
     /**
      * Retrieve the size of the frame. Should be equal to the size of the corresponding ImgFrame message.
@@ -210,7 +210,7 @@ struct ImgTransformation {
      * Add a new transformation.
      * @param matrix Transformation matrix
      */
-    ImgTransformation& addTransformation(std::array<std::array<float, 3>, 3> matrix);
+    ImgTransformation& addTransformation(const std::array<std::array<float, 3>, 3>& matrix);
     /**
      * Add a crop transformation.
      * @param x X coordinate of the top-left corner of the crop
@@ -251,9 +251,9 @@ struct ImgTransformation {
     ImgTransformation& setSize(size_t width, size_t height);
     ImgTransformation& setSourceSize(size_t width, size_t height);
     ImgTransformation& setExtrinsics(const Extrinsics& extrinsics);
-    ImgTransformation& setIntrinsicMatrix(std::array<std::array<float, 3>, 3> intrinsicMatrix);
+    ImgTransformation& setIntrinsicMatrix(const std::array<std::array<float, 3>, 3>& intrinsicMatrix);
     ImgTransformation& setDistortionModel(CameraModel model);
-    ImgTransformation& setDistortionCoefficients(std::vector<float> coefficients);
+    ImgTransformation& setDistortionCoefficients(const std::vector<float>& coefficients);
 
     /**
      * Remap a point from this transformation to another. If the intrinsics are different (e.g. different camera), the function will also use the
@@ -283,7 +283,7 @@ struct ImgTransformation {
      * @param from Transformation to remap from
      * @param rect RotatedRect to remap
      */
-    dai::RotatedRect remapRectFrom(const ImgTransformation& from, dai::RotatedRect rect) const;
+    dai::RotatedRect remapRectFrom(const ImgTransformation& from, const dai::RotatedRect& rect) const;
 
     /**
      * Project a 3D spatial point into 2D point in the current frame defined by this transformation.

--- a/include/depthai/device/CalibrationHandler.hpp
+++ b/include/depthai/device/CalibrationHandler.hpp
@@ -58,7 +58,7 @@ class CalibrationHandler {
      * @param eepromData EepromData data structure containing the calibration data.
      * @param validateCalibration Enable internal check for extrinsics cycling links or dangling references.
      */
-    explicit CalibrationHandler(EepromData eepromData, std::optional<bool> validateCalibration = std::nullopt);
+    explicit CalibrationHandler(const EepromData& eepromData, std::optional<bool> validateCalibration = std::nullopt);
 
     /**
      * Construct a new Calibration Handler object from JSON EepromData.
@@ -66,7 +66,7 @@ class CalibrationHandler {
      * @param eepromDataJson EepromData as JSON
      * @param validateCalibration Enable internal check for extrinsics cycling links or dangling references.
      */
-    static CalibrationHandler fromJson(nlohmann::json eepromDataJson, std::optional<bool> validateCalibration = std::nullopt);
+    static CalibrationHandler fromJson(const nlohmann::json& eepromDataJson, std::optional<bool> validateCalibration = std::nullopt);
 
     /**
      * Get the Eeprom Data object
@@ -171,7 +171,7 @@ class CalibrationHandler {
      *
      */
     std::vector<std::vector<float>> getCameraIntrinsics(CameraBoardSocket cameraId,
-                                                        std::tuple<int, int> destShape,
+                                                        const std::tuple<int, int>& destShape,
                                                         Point2f topLeftPixelId = Point2f(),
                                                         Point2f bottomRightPixelId = Point2f(),
                                                         bool keepAspectRatio = true) const;
@@ -484,7 +484,7 @@ class CalibrationHandler {
      * @param boardName Sets your board name.
      * @param boardRev set your board revision id.
      */
-    void setBoardInfo(std::string boardName, std::string boardRev);
+    void setBoardInfo(const std::string& boardName, const std::string& boardRev);
 
     /**
      * Set the Board Info object. Creates version 7 EEPROM data
@@ -498,15 +498,15 @@ class CalibrationHandler {
      * @param batchTime Sets batch time (unix timestamp).
      * @param boardCustom Sets a custom board (Default empty string).
      */
-    void setBoardInfo(std::string productName,
-                      std::string boardName,
-                      std::string boardRev,
-                      std::string boardConf,
-                      std::string hardwareConf,
-                      std::string batchName,
+    void setBoardInfo(const std::string& productName,
+                      const std::string& boardName,
+                      const std::string& boardRev,
+                      const std::string& boardConf,
+                      const std::string& hardwareConf,
+                      const std::string& batchName,
                       uint64_t batchTime,
                       uint32_t boardOptions,
-                      std::string boardCustom = "");
+                      const std::string& boardCustom = "");
 
     /**
      * Set the Board Info object. Creates version 7 EEPROM data
@@ -521,23 +521,23 @@ class CalibrationHandler {
      * @param batchTime Sets batch time (unix timestamp).
      * @param boardCustom Sets a custom board (Default empty string).
      */
-    void setBoardInfo(std::string deviceName,
-                      std::string productName,
-                      std::string boardName,
-                      std::string boardRev,
-                      std::string boardConf,
-                      std::string hardwareConf,
-                      std::string batchName,
+    void setBoardInfo(const std::string& deviceName,
+                      const std::string& productName,
+                      const std::string& boardName,
+                      const std::string& boardRev,
+                      const std::string& boardConf,
+                      const std::string& hardwareConf,
+                      const std::string& batchName,
                       uint64_t batchTime,
                       uint32_t boardOptions,
-                      std::string boardCustom = "");
+                      const std::string& boardCustom = "");
 
     /**
      * Set the deviceName which responses to getDeviceName of Device
      *
      * @param deviceName Sets device name.
      */
-    void setDeviceName(std::string deviceName);
+    void setDeviceName(const std::string& deviceName);
 
     /**
      * Set the productName which acts as alisas for users to identify the device
@@ -545,7 +545,7 @@ class CalibrationHandler {
      * @param productName Sets product name (alias).
      */
 
-    void setProductName(std::string productName);
+    void setProductName(const std::string& productName);
 
     /**
      * Set the Camera Intrinsics object
@@ -562,7 +562,7 @@ class CalibrationHandler {
      *                                      \end{matrix} \right ] \f]
      *
      */
-    void setCameraIntrinsics(CameraBoardSocket cameraId, std::vector<std::vector<float>> intrinsics, Size2f frameSize);
+    void setCameraIntrinsics(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& intrinsics, Size2f frameSize);
 
     /**
      * Set the Camera Intrinsics object
@@ -580,7 +580,7 @@ class CalibrationHandler {
      *                                      \end{matrix} \right ] \f]
      *
      */
-    void setCameraIntrinsics(CameraBoardSocket cameraId, std::vector<std::vector<float>> intrinsics, int width, int height);
+    void setCameraIntrinsics(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& intrinsics, int width, int height);
 
     /**
      * Set the Camera Intrinsics object
@@ -597,7 +597,7 @@ class CalibrationHandler {
      *                                      \end{matrix} \right ] \f]
      *
      */
-    void setCameraIntrinsics(CameraBoardSocket cameraId, std::vector<std::vector<float>> intrinsics, std::tuple<int, int> frameSize);
+    void setCameraIntrinsics(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& intrinsics, const std::tuple<int, int>& frameSize);
 
     /**
      * Sets the distortion Coefficients obtained from camera calibration
@@ -642,9 +642,9 @@ class CalibrationHandler {
      */
     void setCameraExtrinsics(CameraBoardSocket srcCameraId,
                              CameraBoardSocket destCameraId,
-                             std::vector<std::vector<float>> rotationMatrix,
-                             std::vector<float> translation,
-                             std::vector<float> specTranslation = {0, 0, 0});
+                             const std::vector<std::vector<float>>& rotationMatrix,
+                             const std::vector<float>& translation,
+                             const std::vector<float>& specTranslation = {0, 0, 0});
 
     /**
      * Set the Imu to Camera Extrinsics object
@@ -655,9 +655,9 @@ class CalibrationHandler {
      * @param specTranslation Translation between IMU and destCameraId origins from the design.
      */
     void setImuExtrinsics(CameraBoardSocket destCameraId,
-                          std::vector<std::vector<float>> rotationMatrix,
-                          std::vector<float> translation,
-                          std::vector<float> specTranslation = {0, 0, 0});
+                          const std::vector<std::vector<float>>& rotationMatrix,
+                          const std::vector<float>& translation,
+                          const std::vector<float>& specTranslation = {0, 0, 0});
 
     /**
      * Set the Stereo Left Rectification object
@@ -667,7 +667,7 @@ class CalibrationHandler {
      *
      * Homography of the Left Rectification = Intrinsics_right * rectifiedRotation * inv(Intrinsics_left)
      */
-    void setStereoLeft(CameraBoardSocket cameraId, std::vector<std::vector<float>> rectifiedRotation);
+    void setStereoLeft(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& rectifiedRotation);
 
     /**
      * Set the Stereo Right Rectification object
@@ -677,7 +677,7 @@ class CalibrationHandler {
      *
      * Homography of the Right Rectification = Intrinsics_right * rectifiedRotation * inv(Intrinsics_right)
      */
-    void setStereoRight(CameraBoardSocket cameraId, std::vector<std::vector<float>> rectifiedRotation);
+    void setStereoRight(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& rectifiedRotation);
 
     /**
      * Using left camera as the head it iterates over the camera extrinsics connection
@@ -778,9 +778,9 @@ class CalibrationHandler {
 class CBACalibrationHandler : private CalibrationHandler {
    public:
     CBACalibrationHandler();
-    explicit CBACalibrationHandler(EepromData eepromData, std::optional<bool> validateCalibration = std::nullopt);
+    explicit CBACalibrationHandler(const EepromData& eepromData, std::optional<bool> validateCalibration = std::nullopt);
 
-    static CBACalibrationHandler fromJson(nlohmann::json eepromDataJson, std::optional<bool> validateCalibration = std::nullopt);
+    static CBACalibrationHandler fromJson(const nlohmann::json& eepromDataJson, std::optional<bool> validateCalibration = std::nullopt);
 
     using CalibrationHandler::eepromToJson;
     using CalibrationHandler::eepromToJsonFile;
@@ -799,7 +799,7 @@ class CBACalibrationHandler : private CalibrationHandler {
                                                         Point2f topLeftPixelId = Point2f(),
                                                         Point2f bottomRightPixelId = Point2f(),
                                                         bool keepAspectRatio = true) const;
-    std::vector<std::vector<float>> getCameraIntrinsics(std::tuple<int, int> destShape,
+    std::vector<std::vector<float>> getCameraIntrinsics(const std::tuple<int, int>& destShape,
                                                         Point2f topLeftPixelId = Point2f(),
                                                         Point2f bottomRightPixelId = Point2f(),
                                                         bool keepAspectRatio = true) const;
@@ -811,10 +811,10 @@ class CBACalibrationHandler : private CalibrationHandler {
     uint8_t getLensPosition() const;
     CameraModel getDistortionModel() const;
 
-    void setCameraIntrinsics(std::vector<std::vector<float>> intrinsics, Size2f frameSize);
-    void setCameraIntrinsics(std::vector<std::vector<float>> intrinsics, int width, int height);
-    void setCameraIntrinsics(std::vector<std::vector<float>> intrinsics, std::tuple<int, int> frameSize);
-    void setDistortionCoefficients(std::vector<float> distortionCoefficients);
+    void setCameraIntrinsics(const std::vector<std::vector<float>>& intrinsics, Size2f frameSize);
+    void setCameraIntrinsics(const std::vector<std::vector<float>>& intrinsics, int width, int height);
+    void setCameraIntrinsics(const std::vector<std::vector<float>>& intrinsics, const std::tuple<int, int>& frameSize);
+    void setDistortionCoefficients(const std::vector<float>& distortionCoefficients);
     void setFov(float hfov);
     void setLensPosition(uint8_t lensPosition);
     void setCameraType(CameraModel cameraModel);

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -116,7 +116,7 @@ class DeviceBase {
      * @param cb callback function called between pooling intervals
      * @returns Tuple of bool and DeviceInfo. Bool specifies if device was found. DeviceInfo specifies the found device
      */
-    static std::tuple<bool, DeviceInfo> getAnyAvailableDevice(std::chrono::milliseconds timeout, std::function<void()> cb);
+    static std::tuple<bool, DeviceInfo> getAnyAvailableDevice(std::chrono::milliseconds timeout, const std::function<void()>& cb);
 
     /**
      * Gets first available device. Device can be either in XLINK_UNBOOTED or XLINK_BOOTLOADER state
@@ -129,7 +129,7 @@ class DeviceBase {
      * @param deviceId Device ID which uniquely specifies a device
      * @returns Tuple of bool and DeviceInfo. Bool specifies if device was found. DeviceInfo specifies the found device
      */
-    static std::tuple<bool, DeviceInfo> getDeviceById(std::string deviceId);
+    static std::tuple<bool, DeviceInfo> getDeviceById(const std::string& deviceId);
 
     /**
      * Returns all available devices
@@ -158,7 +158,7 @@ class DeviceBase {
      * @param config FW with applied configuration
      * @returns Firmware binary
      */
-    static std::vector<std::uint8_t> getEmbeddedDeviceBinary(Config config);
+    static std::vector<std::uint8_t> getEmbeddedDeviceBinary(const Config& config);
 
     /**
      * Get current global accumulated profiling data
@@ -197,14 +197,14 @@ class DeviceBase {
      * Connects to any available device with custom config.
      * @param config Device custom configuration to boot with
      */
-    explicit DeviceBase(Config config);
+    explicit DeviceBase(const Config& config);
 
     /**
      * Connects to device 'devInfo' with custom config.
      * @param config Device custom configuration to boot with
      * @param devInfo DeviceInfo which specifies which device to connect to
      */
-    DeviceBase(Config config, const DeviceInfo& devInfo);
+    DeviceBase(const Config& config, const DeviceInfo& devInfo);
 
     /**
      * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
@@ -236,14 +236,14 @@ class DeviceBase {
      * @param config Config with which the device will be booted with
      * @param maxUsbSpeed Maximum allowed USB speed
      */
-    DeviceBase(Config config, UsbSpeed maxUsbSpeed);
+    DeviceBase(const Config& config, UsbSpeed maxUsbSpeed);
 
     /**
      * Connects to any available device with a DEFAULT_SEARCH_TIME timeout.
      * @param config Config with which the device will be booted with
      * @param pathToCmd Path to custom device firmware
      */
-    DeviceBase(Config config, const std::filesystem::path& pathToCmd);
+    DeviceBase(const Config& config, const std::filesystem::path& pathToCmd);
 
     /**
      * Connects to device specified by devInfo.
@@ -251,7 +251,7 @@ class DeviceBase {
      * @param devInfo DeviceInfo which specifies which device to connect to
      * @param maxUsbSpeed Maximum allowed USB speed
      */
-    DeviceBase(Config config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed);
+    DeviceBase(const Config& config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed);
 
     /**
      * Connects to device specified by devInfo.
@@ -260,7 +260,7 @@ class DeviceBase {
      * @param pathToCmd Path to custom device firmware
      * @param dumpOnly If true only the minimal connection is established to retrieve the crash dump
      */
-    DeviceBase(Config config, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd, bool dumpOnly = false);
+    DeviceBase(const Config& config, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd, bool dumpOnly = false);
 
     /**
      * Device destructor
@@ -534,7 +534,7 @@ class DeviceBase {
      * @param callback Callback to call whenever a log message arrives
      * @returns Id which can be used to later remove the callback
      */
-    int addLogCallback(std::function<void(LogMessage)> callback);
+    int addLogCallback(const std::function<void(LogMessage)>& callback);
 
     /**
      * Removes a callback
@@ -730,7 +730,7 @@ class DeviceBase {
      *
      * @return true on successful flash, false on failure
      */
-    bool tryFlashCalibration(CalibrationHandler calibrationDataHandler);
+    bool tryFlashCalibration(const CalibrationHandler& calibrationDataHandler);
 
     /**
      * Stores the Calibration and Device information to the CBA EEPROM
@@ -740,7 +740,7 @@ class DeviceBase {
      *
      * @return true on successful flash, false on failure
      */
-    bool tryFlashCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket);
+    bool tryFlashCBACalibration(const CBACalibrationHandler& calibrationDataHandler, CameraBoardSocket camSocket);
 
     /**
      * Stores the Calibration and Device information to the Device EEPROM
@@ -748,7 +748,7 @@ class DeviceBase {
      * @throws std::runtime_error if failed to flash the calibration
      * @param calibrationObj CalibrationHandler object which is loaded with calibration information.
      */
-    void flashCalibration(CalibrationHandler calibrationDataHandler);
+    void flashCalibration(const CalibrationHandler& calibrationDataHandler);
 
     /**
      * Stores the Calibration and Device information to the CBA EEPROM
@@ -757,7 +757,7 @@ class DeviceBase {
      * @param calibrationObj CBACalibrationHandler object which is loaded with calibration information.
      * @param camSocket CameraBoardSocket of the CBA (Camera Board Assembly)
      */
-    void flashCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket);
+    void flashCBACalibration(const CBACalibrationHandler& calibrationDataHandler, CameraBoardSocket camSocket);
 
     /**
      * Sets the Calibration at runtime. This is not persistent and will be lost after device reset.
@@ -766,7 +766,7 @@ class DeviceBase {
      * @param calibrationObj CalibrationHandler object which is loaded with calibration information.
      *
      */
-    void setCalibration(CalibrationHandler calibrationDataHandler);
+    void setCalibration(const CalibrationHandler& calibrationDataHandler);
 
     /**
      * Sets the Calibration at runtime using EepromData. This is not persistent and will be lost after device reset.
@@ -869,7 +869,7 @@ class DeviceBase {
      * @throws std::runtime_error if failed to flash the calibration
      * @return True on successful flash, false on failure
      */
-    void flashFactoryCalibration(CalibrationHandler calibrationHandler);
+    void flashFactoryCalibration(const CalibrationHandler& calibrationHandler);
 
     /**
      * Stores the Calibration and Device information to the CBA EEPROM in Factory area
@@ -881,7 +881,7 @@ class DeviceBase {
      * @throws std::runtime_error if failed to flash the calibration
      * @return True on successful flash, false on failure
      */
-    void flashFactoryCBACalibration(CBACalibrationHandler calibrationHandler, CameraBoardSocket camSocket);
+    void flashFactoryCBACalibration(const CBACalibrationHandler& calibrationHandler, CameraBoardSocket camSocket);
 
     /**
      * Destructive action, deletes User area EEPROM contents
@@ -1204,11 +1204,11 @@ class DeviceBase {
     void init(const Pipeline& pipeline, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed);
     void init(const Pipeline& pipeline, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd);
     void init(const Pipeline& pipeline, UsbSpeed maxUsbSpeed, const std::filesystem::path& pathToMvcmd);
-    void init(Config config, UsbSpeed maxUsbSpeed, const std::filesystem::path& pathToMvcmd);
-    void init(Config config, UsbSpeed maxUsbSpeed);
-    void init(Config config, const std::filesystem::path& pathToCmd);
-    void init(Config config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed);
-    void init(Config config, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd);
+    void init(const Config& config, UsbSpeed maxUsbSpeed, const std::filesystem::path& pathToMvcmd);
+    void init(const Config& config, UsbSpeed maxUsbSpeed);
+    void init(const Config& config, const std::filesystem::path& pathToCmd);
+    void init(const Config& config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed);
+    void init(const Config& config, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd);
 
    private:
     // private functions
@@ -1224,7 +1224,7 @@ class DeviceBase {
         std::filesystem::path pathToMvcmd;
         bool hasPipeline;
     };
-    void monitorCallback(std::chrono::milliseconds watchdogTimeout, PrevInfo prev);
+    void monitorCallback(std::chrono::milliseconds watchdogTimeout, const PrevInfo& prev);
     void collectAndLogCrashDump(DeviceBase* device = nullptr);
     void waitForRebootAndCollectCrashDump();
     void waitForGateAndCollectCrashDump();

--- a/include/depthai/device/DeviceBootloader.hpp
+++ b/include/depthai/device/DeviceBootloader.hpp
@@ -39,9 +39,9 @@ class DeviceBootloader {
     // Derive and extend bootloader::Config for easier usage
     struct Config : public bootloader::Config {
         /// Setting a static IPv4 won't start DHCP client
-        void setStaticIPv4(std::string ip, std::string mask, std::string gateway);
+        void setStaticIPv4(const std::string& ip, const std::string& mask, const std::string& gateway);
         /// Setting a dynamic IPv4 will set that IP as well as start DHCP client
-        void setDynamicIPv4(std::string ip, std::string mask, std::string gateway);
+        void setDynamicIPv4(const std::string& ip, const std::string& mask, const std::string& gateway);
         /// Get if static IPv4 configuration is set
         bool isStaticIPV4();
         /// Get IPv4
@@ -51,7 +51,7 @@ class DeviceBootloader {
         /// Get IPv4 gateway
         std::string getIPv4Gateway();
         /// Set IPv4 DNS options
-        void setDnsIPv4(std::string dns, std::string dnsAlt = "");
+        void setDnsIPv4(const std::string& dns, const std::string& dnsAlt = "");
         /// Get primary IPv4 DNS server
         std::string getDnsIPv4();
         /// Get alternate IPv4 DNS server
@@ -68,7 +68,7 @@ class DeviceBootloader {
         std::chrono::milliseconds getNetworkTimeout();
 
         /// Set MAC address if not flashed on controller
-        void setMacAddress(std::string mac);
+        void setMacAddress(const std::string& mac);
         /// Get MAC address if not flashed on controller
         std::string getMacAddress();
 
@@ -81,7 +81,7 @@ class DeviceBootloader {
         nlohmann::json toJson() const;
 
         /// from JSON
-        static Config fromJson(nlohmann::json);
+        static Config fromJson(const nlohmann::json&);
 
        private:
         nlohmann::json data;
@@ -141,7 +141,7 @@ class DeviceBootloader {
      */
     static std::vector<uint8_t> createDepthaiApplicationPackage(const Pipeline& pipeline,
                                                                 bool compress,
-                                                                std::string applicationName = "",
+                                                                const std::string& applicationName = "",
                                                                 bool checkChecksum = false);
 
     /**
@@ -156,7 +156,7 @@ class DeviceBootloader {
                                               const Pipeline& pipeline,
                                               const fs::path& pathToCmd = {},
                                               bool compress = false,
-                                              std::string applicationName = "",
+                                              const std::string& applicationName = "",
                                               bool checkChecksum = false);
 
     /**
@@ -167,7 +167,7 @@ class DeviceBootloader {
      * @param applicationName Optional name the application that is flashed
      */
     static void saveDepthaiApplicationPackage(
-        const fs::path& path, const Pipeline& pipeline, bool compress, std::string applicationName = "", bool checkChecksum = false);
+        const fs::path& path, const Pipeline& pipeline, bool compress, const std::string& applicationName = "", bool checkChecksum = false);
 
     /**
      * @returns Embedded bootloader version
@@ -233,10 +233,10 @@ class DeviceBootloader {
      * @param compress Compresses application to reduce needed memory size
      * @param applicationName Name the application that is flashed
      */
-    std::tuple<bool, std::string> flash(std::function<void(float)> progressCallback,
+    std::tuple<bool, std::string> flash(const std::function<void(float)>& progressCallback,
                                         const Pipeline& pipeline,
                                         bool compress = false,
-                                        std::string applicationName = "",
+                                        const std::string& applicationName = "",
                                         Memory memory = Memory::AUTO,
                                         bool checkChecksum = false);
 
@@ -247,7 +247,7 @@ class DeviceBootloader {
      * @param applicationName Optional name the application that is flashed
      */
     std::tuple<bool, std::string> flash(
-        const Pipeline& pipeline, bool compress = false, std::string applicationName = "", Memory memory = Memory::AUTO, bool checkChecksum = false);
+        const Pipeline& pipeline, bool compress = false, const std::string& applicationName = "", Memory memory = Memory::AUTO, bool checkChecksum = false);
 
     /**
      * Reads information about flashed application in specified memory from device
@@ -260,15 +260,15 @@ class DeviceBootloader {
      * @param progressCallback Callback that sends back a value between 0..1 which signifies current flashing progress
      * @param package Depthai application package to flash to the board
      */
-    std::tuple<bool, std::string> flashDepthaiApplicationPackage(std::function<void(float)> progressCallback,
-                                                                 std::vector<uint8_t> package,
+    std::tuple<bool, std::string> flashDepthaiApplicationPackage(const std::function<void(float)>& progressCallback,
+                                                                 const std::vector<uint8_t>& package,
                                                                  Memory memory = Memory::AUTO);
 
     /**
      * Flashes a specific depthai application package that was generated using createDepthaiApplicationPackage or saveDepthaiApplicationPackage
      * @param package Depthai application package to flash to the board
      */
-    std::tuple<bool, std::string> flashDepthaiApplicationPackage(std::vector<uint8_t> package, Memory memory = Memory::AUTO);
+    std::tuple<bool, std::string> flashDepthaiApplicationPackage(const std::vector<uint8_t>& package, Memory memory = Memory::AUTO);
 
     /**
      * Clears flashed application on the device, by removing SBR boot structure
@@ -281,7 +281,7 @@ class DeviceBootloader {
      * @param progressCallback Callback that sends back a value between 0..1 which signifies current flashing progress
      * @param path Optional parameter to custom bootloader to flash
      */
-    std::tuple<bool, std::string> flashBootloader(std::function<void(float)> progressCallback, const fs::path& path = {});
+    std::tuple<bool, std::string> flashBootloader(const std::function<void(float)>& progressCallback, const fs::path& path = {});
 
     /**
      * Flash selected bootloader to the current board
@@ -342,9 +342,12 @@ class DeviceBootloader {
      * @param progressCallback Callback that sends back a value between 0..1 which signifies current flashing progress
      * @param data Data to flash
      */
-    std::tuple<bool, std::string> flashCustom(Memory memory, size_t offset, const std::vector<uint8_t>& data, std::function<void(float)> progressCb = nullptr);
-    std::tuple<bool, std::string> flashCustom(Memory memory, size_t offset, const uint8_t* data, size_t size, std::function<void(float)> progressCb = nullptr);
-    std::tuple<bool, std::string> flashCustom(Memory memory, size_t offset, std::string filename, std::function<void(float)> progressCb = nullptr);
+    std::tuple<bool, std::string> flashCustom(Memory memory, size_t offset, const std::vector<uint8_t>& data,
+                                              const std::function<void(float)>& progressCb = nullptr);
+    std::tuple<bool, std::string> flashCustom(Memory memory, size_t offset, const uint8_t* data, size_t size, const std::function<void(float)>& progressCb = nullptr);
+    std::tuple<bool, std::string> flashCustom(Memory memory, size_t offset,
+                                              const std::string& filename,
+                                              const std::function<void(float)>& progressCb = nullptr);
 
     /**
      * Reads arbitrary data at custom offset in specified memory
@@ -355,10 +358,11 @@ class DeviceBootloader {
      * @param progressCallback Callback that sends back a value between 0..1 which signifies current reading progress
      */
     std::tuple<bool, std::string> readCustom(
-        Memory memory, size_t offset, size_t size, std::vector<uint8_t>& data, std::function<void(float)> progressCb = nullptr);
-    std::tuple<bool, std::string> readCustom(Memory memory, size_t offset, size_t size, uint8_t* data, std::function<void(float)> progressCb = nullptr);
-    std::tuple<bool, std::string> readCustom(Memory memory, size_t offset, size_t size, std::string filename, std::function<void(float)> progressCb = nullptr);
-    std::tuple<bool, std::string, std::vector<uint8_t>> readCustom(Memory memory, size_t offset, size_t size, std::function<void(float)> progressCb = nullptr);
+        Memory memory, size_t offset, size_t size, std::vector<uint8_t>& data, const std::function<void(float)>& progressCb = nullptr);
+    std::tuple<bool, std::string> readCustom(Memory memory, size_t offset, size_t size, uint8_t* data, const std::function<void(float)>& progressCb = nullptr);
+    std::tuple<bool, std::string> readCustom(Memory memory, size_t offset, size_t size, const std::string& filename, const std::function<void(float)>& progressCb = nullptr);
+    std::tuple<bool, std::string, std::vector<uint8_t>> readCustom(Memory memory, size_t offset, size_t size,
+                                                                   const std::function<void(float)>& progressCb = nullptr);
 
     /**
      * Reads configuration data from bootloader
@@ -374,7 +378,7 @@ class DeviceBootloader {
      * @param memory Optional - to which memory flash configuration
      * @param type Optional - for which type of bootloader to flash configuration
      */
-    std::tuple<bool, std::string> flashConfigData(nlohmann::json configData, Memory memory = Memory::AUTO, Type type = Type::AUTO);
+    std::tuple<bool, std::string> flashConfigData(const nlohmann::json& configData, Memory memory = Memory::AUTO, Type type = Type::AUTO);
 
     /**
      * Flashes configuration data to bootloader

--- a/include/depthai/device/DeviceGate.hpp
+++ b/include/depthai/device/DeviceGate.hpp
@@ -72,7 +72,7 @@ class DeviceGate {
 
     class USBImpl : public GateImpl {
        public:
-        USBImpl(DeviceInfo deviceInfo, int timeout);
+        USBImpl(const DeviceInfo& deviceInfo, int timeout);
         ~USBImpl() = default;
         bool isOkay() override;
         bool createSession(std::string version, bool exclusive, XLinkPlatform_t platform, std::string& sessionId, std::atomic_bool& sessionCreated) override;

--- a/include/depthai/pipeline/AssetManager.hpp
+++ b/include/depthai/pipeline/AssetManager.hpp
@@ -23,7 +23,7 @@ struct Asset {
 
 class AssetsMutable : public Assets {
    public:
-    void set(std::string, std::uint32_t offset, std::uint32_t size, std::uint32_t alignment);
+    void set(const std::string&, std::uint32_t offset, std::uint32_t size, std::uint32_t alignment);
 };
 
 // Subclass which has its own storage
@@ -34,16 +34,16 @@ class AssetManager /*: public Assets*/ {
     std::map<std::string, std::shared_ptr<Asset>> assetMap;
     std::string rootPath;
 
-    std::string getRelativeKey(std::string key) const;
+    std::string getRelativeKey(const std::string& key) const;
 
    public:
     AssetManager();
-    AssetManager(std::string rootPath);
+    AssetManager(const std::string& rootPath);
     /**
      * Adds all assets in an array to the AssetManager
      * @param assets Vector of assets to add
      */
-    void addExisting(std::vector<std::shared_ptr<Asset>> assets);
+    void addExisting(const std::vector<std::shared_ptr<Asset>>& assets);
 
     /**
      * Get root path of the asset manager

--- a/include/depthai/pipeline/DeviceNode.hpp
+++ b/include/depthai/pipeline/DeviceNode.hpp
@@ -52,7 +52,7 @@ class DeviceNode : public ThreadedNode {
      *
      * @param device: shared pointer to device
      */
-    void setDevice(std::shared_ptr<Device> device);
+    void setDevice(const std::shared_ptr<Device>& device);
 };
 
 // Node CRTP class

--- a/include/depthai/pipeline/MessageQueue.hpp
+++ b/include/depthai/pipeline/MessageQueue.hpp
@@ -44,7 +44,7 @@ class MessageQueue : public std::enable_shared_from_this<MessageQueue> {
     CallbackId uniqueCallbackId{0};
 
    private:
-    void callCallbacks(std::shared_ptr<ADatatype> msg);
+    void callCallbacks(const std::shared_ptr<ADatatype>& msg);
     void notifyListeners();
     utility::PipelineEventDispatcherInterface* pipelineEventDispatcher = nullptr;
 

--- a/include/depthai/pipeline/Node.hpp
+++ b/include/depthai/pipeline/Node.hpp
@@ -351,7 +351,7 @@ class Node : public std::enable_shared_from_this<Node> {
 
        public:
         std::string name;
-        OutputMap(Node& parent, std::string name, OutputDescription defaultOutput, bool ref = true);
+        OutputMap(Node& parent, std::string name, const OutputDescription& defaultOutput, bool ref = true);
         OutputMap(Node& parent, OutputDescription defaultOutput, bool ref = true);
         /// Create or modify an output
         Output& operator[](const std::string& key);
@@ -544,7 +544,7 @@ class Node : public std::enable_shared_from_this<Node> {
     struct Connection {
         friend struct std::hash<Connection>;
         Connection(Output out, Input in);
-        Connection(ConnectionInternal c);
+        Connection(const ConnectionInternal& c);
         Id outputId;
         std::string outputName;
         std::string outputGroup;
@@ -653,18 +653,18 @@ class Node : public std::enable_shared_from_this<Node> {
     std::vector<InputMap*> getInputMapRefs();
 
     /// Retrieves reference to specific output
-    Output* getOutputRef(std::string name);
-    Output* getOutputRef(std::string group, std::string name);
+    Output* getOutputRef(const std::string& name);
+    Output* getOutputRef(const std::string& group, const std::string& name);
 
     /// Retrieves reference to specific input
-    Input* getInputRef(std::string name);
-    Input* getInputRef(std::string group, std::string name);
+    Input* getInputRef(const std::string& name);
+    Input* getInputRef(const std::string& group, const std::string& name);
 
     /// Retrieves reference to specific output map
-    OutputMap* getOutputMapRef(std::string group);
+    OutputMap* getOutputMapRef(const std::string& group);
 
     /// Retrieves reference to specific input map
-    InputMap* getInputMapRef(std::string group);
+    InputMap* getInputMapRef(const std::string& group);
 
     // For record and replay
     virtual bool isSourceNode() const;
@@ -672,7 +672,7 @@ class Node : public std::enable_shared_from_this<Node> {
    protected:
     Node() = default;
     Node(bool conf);
-    void removeConnectionToNode(std::shared_ptr<Node> node);
+    void removeConnectionToNode(const std::shared_ptr<Node>& node);
 
    public:
     virtual ~Node() = default;
@@ -684,10 +684,10 @@ class Node : public std::enable_shared_from_this<Node> {
     AssetManager& getAssetManager();
 
     /// Loads resource specified by URI and returns its data
-    std::vector<uint8_t> loadResource(std::filesystem::path uri);
+    std::vector<uint8_t> loadResource(const std::filesystem::path& uri);
 
     /// Moves the resource out
-    std::vector<uint8_t> moveResource(std::filesystem::path uri);
+    std::vector<uint8_t> moveResource(const std::filesystem::path& uri);
 
     /// Create and place Node to this Node
     template <class N>
@@ -703,13 +703,13 @@ class Node : public std::enable_shared_from_this<Node> {
     }
 
     /// Add existing node to nodeMap
-    void add(std::shared_ptr<Node> node);
+    void add(const std::shared_ptr<Node>& node);
 
     // Access to nodes
     std::vector<std::shared_ptr<Node>> getAllNodes() const;
     std::shared_ptr<const Node> getNode(Node::Id id) const;
     std::shared_ptr<Node> getNode(Node::Id id);
-    void remove(std::shared_ptr<Node> node);
+    void remove(const std::shared_ptr<Node>& node);
     ConnectionMap getConnectionMap();
     void link(const Node::Output& out, const Node::Input& in);
     void unlink(const Node::Output& out, const Node::Input& in);

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -101,13 +101,13 @@ class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
     void setCameraTuningBlobPath(CameraBoardSocket socket, const fs::path& path);
     void setXLinkChunkSize(int sizeBytes);
     GlobalProperties getGlobalProperties() const;
-    void setGlobalProperties(GlobalProperties globalProperties);
+    void setGlobalProperties(const GlobalProperties& globalProperties);
     void setDefaultDeviceProperties(const DeviceProperties& deviceProperties);
     void setDefaultDevicePropertiesRef(DeviceProperties* deviceProperties);
     std::optional<DeviceProperties> getDefaultDeviceProperties() const;
     void setSippBufferSize(int sizeBytes);
     void setSippDmaBufferSize(int sizeBytes);
-    void setBoardConfig(BoardConfig board);
+    void setBoardConfig(const BoardConfig& board);
     void setAutoCalibrationMode(PipelineAutoCalibrationMode mode);
     std::pair<std::shared_ptr<dai::node::Camera>, std::shared_ptr<dai::node::Camera>> getStereoPair() const;
     bool hasDynamicCalibration() const;
@@ -117,16 +117,16 @@ class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
 
     void serialize(PipelineSchema& schema, Assets& assets, std::vector<std::uint8_t>& assetStorage, SerializationType type = DEFAULT_SERIALIZATION_TYPE) const;
     nlohmann::json serializeToJson(bool includeAssets) const;
-    void remove(std::shared_ptr<Node> node);
+    void remove(const std::shared_ptr<Node>& node);
 
     std::vector<Node::Connection> getConnections() const;
     std::vector<Node::ConnectionInternal> getConnectionsInternal() const;
     void link(const Node::Output& out, const Node::Input& in);
     void unlink(const Node::Output& out, const Node::Input& in);
-    void setCalibrationData(CalibrationHandler calibrationDataHandler);
+    void setCalibrationData(const CalibrationHandler& calibrationDataHandler);
     bool isCalibrationDataAvailable() const;
     CalibrationHandler getCalibrationData() const;
-    void setEepromData(std::optional<EepromData> eepromData);
+    void setEepromData(const std::optional<EepromData>& eepromData);
     std::optional<EepromData> getEepromData() const;
     uint32_t getEepromId() const;
     bool isHostOnly() const;
@@ -262,7 +262,7 @@ class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
     }
 
     // Add a node to nodeMap
-    void add(std::shared_ptr<Node> node);
+    void add(const std::shared_ptr<Node>& node);
 
     // Run only host side, if any device nodes are present, error out
     bool isRunning() const;
@@ -279,7 +279,7 @@ class PipelineImpl : public std::enable_shared_from_this<PipelineImpl> {
 
    private:
     // Resource
-    std::vector<uint8_t> loadResource(fs::path uri);
+    std::vector<uint8_t> loadResource(const fs::path& uri);
     std::vector<uint8_t> loadResourceCwd(fs::path uri, fs::path cwd, bool moveAsset = false);
 };
 

--- a/include/depthai/pipeline/PipelineStateApi.hpp
+++ b/include/depthai/pipeline/PipelineStateApi.hpp
@@ -91,7 +91,7 @@ class PipelineStateApi {
     NodeStateApi nodes(Node::Id nodeId) {
         return NodeStateApi(nodeId, pipelineStateOut, pipelineStateRequest);
     }
-    void stateAsync(std::function<void(const PipelineState&)> callback, std::optional<PipelineEventAggregationConfig> config = std::nullopt);
+    void stateAsync(std::function<void(const PipelineState&)> callback, const std::optional<PipelineEventAggregationConfig>& config = std::nullopt);
 };
 
 }  // namespace dai

--- a/include/depthai/pipeline/datatype/CameraControl.hpp
+++ b/include/depthai/pipeline/datatype/CameraControl.hpp
@@ -670,7 +670,7 @@ class CameraControl : public Buffer {
      * @param control Control name
      * @param value Value as an integer number
      */
-    CameraControl& setMisc(std::string control, int value);
+    CameraControl& setMisc(const std::string& control, int value);
 
     /**
      * Set a miscellaneous control. The controls set by this function get appended
@@ -678,7 +678,7 @@ class CameraControl : public Buffer {
      * @param control Control name
      * @param value Value as a floating point number
      */
-    CameraControl& setMisc(std::string control, float value);
+    CameraControl& setMisc(const std::string& control, float value);
 
     /**
      * Clear the list of miscellaneous controls set by `setControl`
@@ -689,7 +689,7 @@ class CameraControl : public Buffer {
      * Get the list of miscellaneous controls set by `setControl`
      * @returns A list of <key, value> pairs as strings
      */
-    std::vector<std::pair<std::string, std::string>> getMiscControls();
+    std::vector<std::pair<std::string, std::string>> getMiscControls() const;
 
     /**
      * Set a command to specify control mode

--- a/include/depthai/pipeline/datatype/FeatureTrackerConfig.hpp
+++ b/include/depthai/pipeline/datatype/FeatureTrackerConfig.hpp
@@ -246,7 +246,7 @@ class FeatureTrackerConfig : public Buffer {
      * Set corner detector full configuration.
      * @param config Corner detector configuration
      */
-    FeatureTrackerConfig& setCornerDetector(CornerDetector config);
+    FeatureTrackerConfig& setCornerDetector(const CornerDetector& config);
 
     /**
      * Set optical flow as motion estimation algorithm type.
@@ -257,7 +257,7 @@ class FeatureTrackerConfig : public Buffer {
      * Set optical flow full configuration.
      * @param config Optical flow configuration
      */
-    FeatureTrackerConfig& setOpticalFlow(MotionEstimator::OpticalFlow config);
+    FeatureTrackerConfig& setOpticalFlow(const MotionEstimator::OpticalFlow& config);
 
     /**
      * Set hardware accelerated motion estimation using block matching.
@@ -281,7 +281,7 @@ class FeatureTrackerConfig : public Buffer {
      * Set motion estimator full configuration.
      * @param config Motion estimator configuration
      */
-    FeatureTrackerConfig& setMotionEstimator(MotionEstimator config);
+    FeatureTrackerConfig& setMotionEstimator(const MotionEstimator& config);
 
     /**
      * Enable or disable feature maintainer.

--- a/include/depthai/pipeline/datatype/ImageFiltersConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageFiltersConfig.hpp
@@ -43,13 +43,13 @@ class ImageFiltersConfig : public Buffer {
      * @param index Index of the filter to be inserted
      * @param params Parameters of the filter to be inserted
      */
-    ImageFiltersConfig& updateFilterAtIndex(std::int32_t index, FilterParams params);
+    ImageFiltersConfig& updateFilterAtIndex(std::int32_t index, const FilterParams& params);
 
     /**
      * Insert filter parameters describing how a new filter should be inserted
      * @param params Parameters of the filter to be inserted
      */
-    ImageFiltersConfig& insertFilter(FilterParams params);
+    ImageFiltersConfig& insertFilter(const FilterParams& params);
 
     /**
      * Index of the filter to be applied

--- a/include/depthai/pipeline/datatype/ImageManipConfig.hpp
+++ b/include/depthai/pipeline/datatype/ImageManipConfig.hpp
@@ -456,13 +456,13 @@ class ImageManipConfig : public Buffer {
      * @param rect Rect to crop
      * @param normalizedCoords If true, the coordinates are normalized to range [0, 1] where 1 maps to the width/height of the image
      */
-    ImageManipConfig& addCrop(dai::Rect rect, bool normalizedCoords = false);
+    ImageManipConfig& addCrop(const dai::Rect& rect, bool normalizedCoords = false);
     /**
      * Crops the image to the specified (rotated) rectangle
      * @param rect RotatedRect to crop
      * @param normalizedCoords If true, the coordinates are normalized to range [0, 1] where 1 maps to the width/height of the image
      */
-    ImageManipConfig& addCropRotatedRect(dai::RotatedRect rotatedRect, bool normalizedCoords = false);
+    ImageManipConfig& addCropRotatedRect(const dai::RotatedRect& rotatedRect, bool normalizedCoords = false);
     /**
      * Rescales the image using the specified factors
      * @param scaleX Scale factor for the X axis
@@ -497,14 +497,14 @@ class ImageManipConfig : public Buffer {
      * Applies a perspective transformation to the image
      * @param matrix an array containing a 3x3 matrix representing the perspective transformation
      */
-    ImageManipConfig& addTransformPerspective(std::array<float, 9> matrix);
+    ImageManipConfig& addTransformPerspective(const std::array<float, 9>& matrix);
     /**
      * Applies a perspective transformation to the image
      * @param src Source points
      * @param dst Destination points
      * @param normalizedCoords If true, the coordinates are normalized to range [0, 1] where 1 maps to the width/height of the image
      */
-    ImageManipConfig& addTransformFourPoints(std::array<dai::Point2f, 4> src, std::array<dai::Point2f, 4> dst, bool normalizedCoords = false);
+    ImageManipConfig& addTransformFourPoints(const std::array<dai::Point2f, 4>& src, const std::array<dai::Point2f, 4>& dst, bool normalizedCoords = false);
     /**
      * Sets the output size of the image
      * @param w Width of the output image

--- a/include/depthai/pipeline/datatype/SpatialLocationCalculatorConfig.hpp
+++ b/include/depthai/pipeline/datatype/SpatialLocationCalculatorConfig.hpp
@@ -112,7 +112,7 @@ class SpatialLocationCalculatorConfig : public Buffer {
      SpatialLocationCalculatorData output.
      * @param ROIs Vector of configuration parameters for ROIs (region of interests)
      */
-    void setROIs(std::vector<SpatialLocationCalculatorConfigData> ROIs);
+    void setROIs(const std::vector<SpatialLocationCalculatorConfigData>& ROIs);
 
     /**
      * Add a new region of interest (ROI) to configuration data.

--- a/include/depthai/pipeline/node/AutoCalibration.hpp
+++ b/include/depthai/pipeline/node/AutoCalibration.hpp
@@ -103,7 +103,7 @@ class AutoCalibration : public DeviceNodeCRTP<DeviceNode, AutoCalibration, AutoC
 
     void loadData(unsigned int numImages);
 
-    std::shared_ptr<dai::CalibrationMetrics> getMetrics(std::shared_ptr<dai::CalibrationHandler> calibration);
+    std::shared_ptr<dai::CalibrationMetrics> getMetrics(const std::shared_ptr<dai::CalibrationHandler>& calibration);
 
     AutoCalibrationProperties properties;
 

--- a/include/depthai/pipeline/node/Camera.hpp
+++ b/include/depthai/pipeline/node/Camera.hpp
@@ -23,7 +23,7 @@ class Camera : public DeviceNodeCRTP<DeviceNode, Camera, CameraProperties>, publ
     /**
      * Get video output with specified size.
      */
-    Node::Output* requestOutput(std::pair<uint32_t, uint32_t> size,
+    Node::Output* requestOutput(const std::pair<uint32_t, uint32_t>& size,
                                 std::optional<ImgFrame::Type> type = std::nullopt,
                                 ImgResizeMode resizeMode = ImgResizeMode::CROP,
                                 std::optional<float> fps = std::nullopt,
@@ -56,7 +56,7 @@ class Camera : public DeviceNodeCRTP<DeviceNode, Camera, CameraProperties>, publ
      * @param sensorFps Sensor FPS to use - by default it's auto-detected from the requested outputs (maximum is used)
      */
     std::shared_ptr<Camera> build(dai::CameraBoardSocket boardSocket = dai::CameraBoardSocket::AUTO,
-                                  std::optional<std::pair<uint32_t, uint32_t>> sensorResolution = std::nullopt,
+                                  const std::optional<std::pair<uint32_t, uint32_t>>& sensorResolution = std::nullopt,
                                   std::optional<float> sensorFps = std::nullopt);
 
     /**

--- a/include/depthai/pipeline/node/ColorCamera.hpp
+++ b/include/depthai/pipeline/node/ColorCamera.hpp
@@ -113,7 +113,7 @@ class [[deprecated("Use Camera node instead")]] ColorCamera : public DeviceNodeC
      * Specify which camera to use by name
      * @param name Name of the camera to use
      */
-    void setCamera(std::string name);
+    void setCamera(const std::string& name);
 
     /**
      * Retrieves which camera to use by name
@@ -161,7 +161,7 @@ class [[deprecated("Use Camera node instead")]] ColorCamera : public DeviceNodeC
     void setPreviewSize(int width, int height);
 
     /// Set preview output size, as a tuple <width, height>
-    void setPreviewSize(std::tuple<int, int> size);
+    void setPreviewSize(const std::tuple<int, int>& size);
 
     /// Set number of frames in preview pool
     void setPreviewNumFramesPool(int num);
@@ -170,7 +170,7 @@ class [[deprecated("Use Camera node instead")]] ColorCamera : public DeviceNodeC
     void setVideoSize(int width, int height);
 
     /// Set video output size, as a tuple <width, height>
-    void setVideoSize(std::tuple<int, int> size);
+    void setVideoSize(const std::tuple<int, int>& size);
 
     /// Set number of frames in preview pool
     void setVideoNumFramesPool(int num);
@@ -179,7 +179,7 @@ class [[deprecated("Use Camera node instead")]] ColorCamera : public DeviceNodeC
     void setStillSize(int width, int height);
 
     /// Set still output size, as a tuple <width, height>
-    void setStillSize(std::tuple<int, int> size);
+    void setStillSize(const std::tuple<int, int>& size);
 
     void setMockIspSize(int width, int height);
 
@@ -210,7 +210,7 @@ class [[deprecated("Use Camera node instead")]] ColorCamera : public DeviceNodeC
     void setIspScale(int numerator, int denominator);
 
     /// Set 'isp' output scaling, as a tuple <numerator, denominator>
-    void setIspScale(std::tuple<int, int> scale);
+    void setIspScale(const std::tuple<int, int>& scale);
 
     /**
      * Set 'isp' output scaling, per each direction. If the horizontal scaling factor
@@ -220,7 +220,7 @@ class [[deprecated("Use Camera node instead")]] ColorCamera : public DeviceNodeC
     void setIspScale(int horizNum, int horizDenom, int vertNum, int vertDenom);
 
     /// Set 'isp' output scaling, per each direction, as <numerator, denominator> tuples
-    void setIspScale(std::tuple<int, int> horizScale, std::tuple<int, int> vertScale);
+    void setIspScale(const std::tuple<int, int>& horizScale, const std::tuple<int, int>& vertScale);
 
     /**
      * Set rate at which camera should produce frames

--- a/include/depthai/pipeline/node/DetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/DetectionNetwork.hpp
@@ -139,7 +139,7 @@ class DetectionNetwork : public DeviceNodeGroup {
      *
      * @param blob Network blob
      */
-    void setBlob(OpenVINO::Blob blob);
+    void setBlob(const OpenVINO::Blob& blob);
 
     /**
      * Same functionality as the setBlobPath(). Load network blob into assets and use once pipeline is started.
@@ -183,19 +183,19 @@ class DetectionNetwork : public DeviceNodeGroup {
      * Specifies backend to use
      * @param backend String specifying backend to use
      */
-    void setBackend(std::string backend);
+    void setBackend(const std::string& backend);
 
     /**
      * Set backend properties
      * @param backendProperties backend properties map
      */
-    void setBackendProperties(std::map<std::string, std::string> properties);
+    void setBackendProperties(const std::map<std::string, std::string>& properties);
 
     /**
      * How many inference threads will be used to run the network
      * @returns Number of threads, 0, 1 or 2. Zero means AUTO
      */
-    int getNumInferenceThreads();
+    int getNumInferenceThreads() const;
 
     /**
      * Specifies confidence threshold at which to filter the rest of the detections.

--- a/include/depthai/pipeline/node/DetectionParser.hpp
+++ b/include/depthai/pipeline/node/DetectionParser.hpp
@@ -56,7 +56,7 @@ class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, Detec
      * Returns number of frames in pool
      *
      */
-    int getNumFramesPool();
+    int getNumFramesPool() const;
 
     /**
      * @brief Set NNArchive for this Node. If the archive's type is SUPERBLOB, use default number of shaves.
@@ -84,7 +84,7 @@ class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, Detec
      *
      * @param blob OpenVINO blob to retrieve the information from
      */
-    void setBlob(OpenVINO::Blob blob);
+    void setBlob(const OpenVINO::Blob& blob);
 
     /**
      * Same functionality as the setBlobPath(). Load network blob into assets and use once pipeline is started.
@@ -104,7 +104,7 @@ class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, Detec
     /**
      * Set preview output size, as a tuple<width, height>
      */
-    void setInputImageSize(std::tuple<int, int> size);
+    void setInputImageSize(const std::tuple<int, int>& size);
 
     /**
      * Sets NN Family to parse. Possible values are:
@@ -119,7 +119,7 @@ class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, Detec
     /**
      * Gets NN Family to parse
      */
-    DetectionNetworkType getNNFamily();
+    DetectionNetworkType getNNFamily() const;
 
     /**
      * Specifies confidence threshold at which to filter the rest of the detections.
@@ -156,13 +156,13 @@ class DetectionParser : public DeviceNodeCRTP<DeviceNode, DetectionParser, Detec
      * @param anchors Flattened vector of anchors
      * @warning This method is deprecated, use setAnchorsV2 instead.
      */
-    void setAnchors(std::vector<float> anchors);
+    void setAnchors(const std::vector<float>& anchors);
 
     /**
      * Set anchor masks for anchor-based yolo models
      * @param anchorMasks Map of anchor masks
      */
-    void setAnchorMasks(std::map<std::string, std::vector<int>> anchorMasks);
+    void setAnchorMasks(const std::map<std::string, std::vector<int>>& anchorMasks);
 
     /**
      * Set anchors for anchor-based yolo models (v2)

--- a/include/depthai/pipeline/node/DynamicCalibrationNode.hpp
+++ b/include/depthai/pipeline/node/DynamicCalibrationNode.hpp
@@ -158,7 +158,7 @@ class DynamicCalibration : public DeviceNodeCRTP<DeviceNode, DynamicCalibration,
 #endif
     ErrorCode computeCoverage();
 
-    ErrorCode initializePipeline(const std::shared_ptr<dai::Device> daiDevice);
+    ErrorCode initializePipeline(const std::shared_ptr<dai::Device>& daiDevice);
 
     ErrorCode doWork(std::chrono::steady_clock::time_point& previousLoadingAndCalibrationTime);
 

--- a/include/depthai/pipeline/node/MonoCamera.hpp
+++ b/include/depthai/pipeline/node/MonoCamera.hpp
@@ -92,7 +92,7 @@ class [[deprecated("Use Camera node instead")]] MonoCamera : public DeviceNodeCR
      * Specify which camera to use by name
      * @param name Name of the camera to use
      */
-    void setCamera(std::string name);
+    void setCamera(const std::string& name);
 
     /**
      * Retrieves which camera to use by name

--- a/include/depthai/pipeline/node/NeuralNetwork.hpp
+++ b/include/depthai/pipeline/node/NeuralNetwork.hpp
@@ -202,19 +202,19 @@ class NeuralNetwork : public DeviceNodeCRTP<DeviceNode, NeuralNetwork, NeuralNet
      * Specifies backend to use
      * @param backend String specifying backend to use
      */
-    void setBackend(std::string backend);
+    void setBackend(const std::string& backend);
 
     /**
      * Set backend properties
      * @param backendProperties backend properties map
      */
-    void setBackendProperties(std::map<std::string, std::string> properties);
+    void setBackendProperties(const std::map<std::string, std::string>& properties);
 
     /**
      * How many inference threads will be used to run the network
      * @returns Number of threads, 0, 1 or 2. Zero means AUTO
      */
-    int getNumInferenceThreads();
+    int getNumInferenceThreads() const;
 
     /**
      * Set model from Device Model Zoo
@@ -230,7 +230,7 @@ class NeuralNetwork : public DeviceNodeCRTP<DeviceNode, NeuralNetwork, NeuralNet
     NNArchive createNNArchive(NNModelDescription& modelDesc);
     void decodeModel(const Model& model);
 
-    ImgFrameCapability getFrameCapability(const NNArchive& nnArchive, std::optional<ImgFrameCapability> expectedCapability = std::nullopt);
+    ImgFrameCapability getFrameCapability(const NNArchive& nnArchive, const std::optional<ImgFrameCapability>& expectedCapability = std::nullopt);
     std::optional<NNArchive> nnArchive;
 };
 

--- a/include/depthai/pipeline/node/ObjectTracker.hpp
+++ b/include/depthai/pipeline/node/ObjectTracker.hpp
@@ -86,7 +86,7 @@ class ObjectTracker : public DeviceNodeCRTP<DeviceNode, ObjectTracker, ObjectTra
      * Specify detection labels to track.
      * @param labels Detection labels to track. Default every label is tracked from image detection network output.
      */
-    void setDetectionLabelsToTrack(std::vector<std::uint32_t> labels);
+    void setDetectionLabelsToTrack(const std::vector<std::uint32_t>& labels);
 
     /**
      * Specify tracker type algorithm.

--- a/include/depthai/pipeline/node/PointCloud.hpp
+++ b/include/depthai/pipeline/node/PointCloud.hpp
@@ -40,7 +40,7 @@ class PointCloud : public DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudPrope
        public:
         Impl() = default;
 
-        void setLogger(std::shared_ptr<::spdlog::logger> log);
+        void setLogger(const std::shared_ptr<::spdlog::logger>& log);
 
         // Compute DENSE point cloud (width * height points, includes invalid z=0 or negative)
         void computePointCloudDense(const uint8_t* depthData, std::vector<Point3f>& points);
@@ -236,8 +236,10 @@ class PointCloud : public DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudPrope
     void setCoordinateTransformation(const ImgFrame& depthFrame, const PointCloudConfig& config);
 
     // Processing methods for the two code paths
-    void processDepthOnly(std::shared_ptr<ImgFrame> depthFrame, std::shared_ptr<PointCloudData> pc, bool organized);
-    void processColorized(std::shared_ptr<ImgFrame> depthFrame, std::shared_ptr<ImgFrame> colorFrame, std::shared_ptr<PointCloudData> pc, bool organized);
+    void processDepthOnly(const std::shared_ptr<ImgFrame>& depthFrame, const std::shared_ptr<PointCloudData>& pc, bool organized);
+    void processColorized(const std::shared_ptr<ImgFrame>& depthFrame,
+                          const std::shared_ptr<ImgFrame>& colorFrame,
+                          const std::shared_ptr<PointCloudData>& pc, bool organized);
 
     bool runOnHostVar = true;
     bool initialized = false;

--- a/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
+++ b/include/depthai/pipeline/node/SpatialDetectionNetwork.hpp
@@ -171,7 +171,7 @@ class SpatialDetectionNetwork : public DeviceNodeGroup {
      *
      * @param blob Network blob
      */
-    void setBlob(OpenVINO::Blob blob);
+    void setBlob(const OpenVINO::Blob& blob);
 
     /**
      * Same functionality as the setBlobPath(). Load network blob into assets and use once pipeline is started.
@@ -215,13 +215,13 @@ class SpatialDetectionNetwork : public DeviceNodeGroup {
      * Specifies backend to use
      * @param backend String specifying backend to use
      */
-    void setBackend(std::string backend);
+    void setBackend(const std::string& backend);
 
     /**
      * Set backend properties
      * @param backendProperties backend properties map
      */
-    void setBackendProperties(std::map<std::string, std::string> properties);
+    void setBackendProperties(const std::map<std::string, std::string>& properties);
 
     /**
      * How many inference threads will be used to run the network

--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -56,7 +56,7 @@ class StereoDepth : public DeviceNodeCRTP<DeviceNode, StereoDepth, StereoDepthPr
      */
     std::shared_ptr<StereoDepth> build(bool autoCreateCameras,
                                        PresetMode presetMode = PresetMode::DEFAULT,
-                                       std::pair<int, int> size = {640, 400},
+                                       const std::pair<int, int>& size = {640, 400},
                                        std::optional<float> fps = std::nullopt);
 
    protected:
@@ -219,7 +219,7 @@ class StereoDepth : public DeviceNodeCRTP<DeviceNode, StereoDepth, StereoDepthPr
      *
      * Optional if MonoCamera exists, otherwise necessary
      */
-    void setInputResolution(std::tuple<int, int> resolution);
+    void setInputResolution(const std::tuple<int, int>& resolution);
 
     /**
      * Specify disparity/depth output resolution size, implemented by scaling.

--- a/include/depthai/pipeline/node/UVC.hpp
+++ b/include/depthai/pipeline/node/UVC.hpp
@@ -29,13 +29,13 @@ class UVC : public DeviceNodeCRTP<DeviceNode, UVC, UVCProperties> {
     Input input{*this, {"in", DEFAULT_GROUP, true, 8, {{{DatatypeEnum::Buffer, true}}}, true}};
 
     /// Set GPIO list <gpio_number, value> for GPIOs to set (on/off) at init
-    void setGpiosOnInit(std::unordered_map<int, int> list);
+    void setGpiosOnInit(const std::unordered_map<int, int>& list);
 
     /// Set GPIO list <gpio_number, value> for GPIOs to set when streaming is enabled
-    void setGpiosOnStreamOn(std::unordered_map<int, int> list);
+    void setGpiosOnStreamOn(const std::unordered_map<int, int>& list);
 
     /// Set GPIO list <gpio_number, value> for GPIOs to set when streaming is disabled
-    void setGpiosOnStreamOff(std::unordered_map<int, int> list);
+    void setGpiosOnStreamOff(const std::unordered_map<int, int>& list);
 };
 
 }  // namespace node

--- a/include/depthai/pipeline/node/Warp.hpp
+++ b/include/depthai/pipeline/node/Warp.hpp
@@ -38,7 +38,7 @@ class Warp : public DeviceNodeCRTP<DeviceNode, Warp, WarpProperties> {
      *
      * @param size width and height in pixels
      */
-    void setOutputSize(std::tuple<int, int> size);
+    void setOutputSize(const std::tuple<int, int>& size);
     void setOutputSize(int width, int height);
 
     /**
@@ -66,7 +66,7 @@ class Warp : public DeviceNodeCRTP<DeviceNode, Warp, WarpProperties> {
      * Specify which hardware warp engines to use
      * @param ids Which warp engines to use (0, 1, 2)
      */
-    void setHwIds(std::vector<int> ids);
+    void setHwIds(const std::vector<int>& ids);
     /// Retrieve which hardware warp engines to use
     std::vector<int> getHwIds() const;
 

--- a/include/depthai/pipeline/node/host/RGBD.hpp
+++ b/include/depthai/pipeline/node/host/RGBD.hpp
@@ -58,7 +58,7 @@ class RGBD : public NodeCRTP<ThreadedHostNode, RGBD> {
      */
     std::shared_ptr<RGBD> build(bool autocreate,
                                 StereoDepth::PresetMode mode = StereoDepth::PresetMode::DEFAULT,
-                                std::pair<int, int> frameSize = std::make_pair(640, 400),
+                                const std::pair<int, int>& frameSize = std::make_pair(640, 400),
                                 std::optional<float> fps = std::nullopt);
 
     /**
@@ -70,7 +70,7 @@ class RGBD : public NodeCRTP<ThreadedHostNode, RGBD> {
      */
     std::shared_ptr<RGBD> build(const std::shared_ptr<Camera>& camera,
                                 const DepthSource& depthSource,
-                                std::pair<int, int> frameSize = std::make_pair(640, 400),
+                                const std::pair<int, int>& frameSize = std::make_pair(640, 400),
                                 std::optional<float> fps = std::nullopt);
 
     void setDepthUnit(StereoDepthConfig::AlgorithmControl::DepthUnit depthUnit);
@@ -98,7 +98,7 @@ class RGBD : public NodeCRTP<ThreadedHostNode, RGBD> {
     class Impl;
     Pimpl<Impl> pimpl;
     void run() override;
-    void initialize(std::shared_ptr<MessageGroup> frames);
+    void initialize(const std::shared_ptr<MessageGroup>& frames);
 
     // Unified depth alignment helper
     void alignDepth(const DepthSource& depthSource, const std::shared_ptr<Camera>& camera, std::pair<int, int> frameSize, std::optional<float> fps);
@@ -106,13 +106,13 @@ class RGBD : public NodeCRTP<ThreadedHostNode, RGBD> {
     // Type-specific alignment implementations
     void alignDepthImpl(const std::shared_ptr<StereoDepth>& stereo,
                         const std::shared_ptr<Camera>& camera,
-                        std::pair<int, int> frameSize,
+                        const std::pair<int, int>& frameSize,
                         std::optional<float> fps);
     void alignDepthImpl(const std::shared_ptr<NeuralDepth>& neuralDepth,
                         const std::shared_ptr<Camera>& camera,
-                        std::pair<int, int> frameSize,
+                        const std::pair<int, int>& frameSize,
                         std::optional<float> fps);
-    void alignDepthImpl(const std::shared_ptr<ToF>& tof, const std::shared_ptr<Camera>& camera, std::pair<int, int> frameSize, std::optional<float> fps);
+    void alignDepthImpl(const std::shared_ptr<ToF>& tof, const std::shared_ptr<Camera>& camera, const std::pair<int, int>& frameSize, std::optional<float> fps);
 
     Input inSync{*this, {"inSync", DEFAULT_GROUP, false, 0, {{DatatypeEnum::MessageGroup, true}}}};
     bool initialized = false;

--- a/include/depthai/utility/ImageManipImpl.hpp
+++ b/include/depthai/utility/ImageManipImpl.hpp
@@ -282,7 +282,7 @@ class UndistortOpenCvImpl {
     uint32_t dstWidth;
     uint32_t dstHeight;
 
-    bool validMatrix(std::array<float, 9> matrix) const;
+    bool validMatrix(const std::array<float, 9>& matrix) const;
     void initMaps(std::array<float, 9> cameraMatrix,
                   std::array<float, 9> newCameraMatrix,
                   std::vector<float> distCoeffs,
@@ -370,7 +370,7 @@ class WarpH : public Warp {
 #endif
 
     void transform(const std::shared_ptr<OffsetMemory>& srcData,
-                   std::shared_ptr<OffsetMemory> dstData,
+                   const std::shared_ptr<OffsetMemory>& dstData,
                    const size_t srcWidth,
                    const size_t srcHeight,
                    const size_t srcStride,
@@ -379,7 +379,7 @@ class WarpH : public Warp {
                    const size_t dstStride,
                    const uint16_t numChannels,
                    const uint16_t bpp,
-                   const std::array<std::array<float, 3>, 3> matrix,
+                   const std::array<std::array<float, 3>, 3>& matrix,
                    const std::vector<uint32_t>& backgroundColor);
 
    public:
@@ -523,7 +523,7 @@ struct ColorChangeArgs {
     std::shared_ptr<OffsetMemory> auxFrame;
 };
 FrameSpecs getSrcFrameSpecs(dai::ImgFrame::Specs srcSpecs);
-FrameSpecs getCcDstFrameSpecs(FrameSpecs srcSpecs, dai::ImgFrame::Type from, dai::ImgFrame::Type to);
+FrameSpecs getCcDstFrameSpecs(const FrameSpecs& srcSpecs, dai::ImgFrame::Type from, dai::ImgFrame::Type to);
 FrameSpecs getDstFrameSpecs(size_t width, size_t height, dai::ImgFrame::Type type);
 size_t getAlignedOutputFrameSize(ImgFrame::Type type, size_t width, size_t height);
 void printSpecs(spdlog::async_logger& logger, FrameSpecs specs);
@@ -540,12 +540,12 @@ bool colorConvertToNV12(const ColorChangeArgs& args);
 bool colorConvertToYUV420p(const ColorChangeArgs& args);
 bool colorConvertToGRAY8(const ColorChangeArgs& args);
 
-std::tuple<float, float, float, float> getOuterRect(const std::vector<std::array<float, 2>> points);
+std::tuple<float, float, float, float> getOuterRect(const std::vector<std::array<float, 2>>& points);
 dai::RotatedRect getOuterRotatedRect(const std::vector<std::array<float, 2>>& points);
 std::array<std::array<float, 3>, 3> getResizeMat(Resize o, float width, float height, uint32_t outputWidth, uint32_t outputHeight);
 void getOutputSizeFromCorners(const std::array<std::array<float, 2>, 4>& corners,
                               const bool center,
-                              const std::array<std::array<float, 3>, 3> transformInv,
+                              const std::array<std::array<float, 3>, 3>& transformInv,
                               const uint32_t srcWidth,
                               const uint32_t srcHeight,
                               uint32_t& outputWidth,

--- a/include/depthai/utility/Initialization.hpp
+++ b/include/depthai/utility/Initialization.hpp
@@ -6,7 +6,7 @@
 namespace dai {
 
 bool initialize();
-bool initialize(std::string additionalInfo, bool installSignalHandler = true, void* javavm = nullptr);
+bool initialize(const std::string& additionalInfo, bool installSignalHandler = true, void* javavm = nullptr);
 bool initialize(const char* additionalInfo, bool installSignalHandler = true, void* javavm = nullptr);
 bool initialize(void* javavm);
 

--- a/include/depthai/xlink/XLinkConnection.hpp
+++ b/include/depthai/xlink/XLinkConnection.hpp
@@ -78,7 +78,7 @@ class XLinkConnection {
      * @param skipInvalidDevices Whether or not to skip devices that cannot be fully detected
      * @returns Tuple of bool and DeviceInfo. Bool specifies if device was found. DeviceInfo specifies the found device
      */
-    static std::tuple<bool, DeviceInfo> getDeviceById(std::string deviceId, XLinkDeviceState_t state = X_LINK_ANY_STATE, bool skipInvalidDevice = true);
+    static std::tuple<bool, DeviceInfo> getDeviceById(const std::string& deviceId, XLinkDeviceState_t state = X_LINK_ANY_STATE, bool skipInvalidDevice = true);
 
     /**
      * Tries booting the given device into bootloader state

--- a/include/depthai/xlink/XLinkStream.hpp
+++ b/include/depthai/xlink/XLinkStream.hpp
@@ -60,7 +60,7 @@ class XLinkStream {
     streamId_t streamId{INVALID_STREAM_ID};
 
    public:
-    XLinkStream(const std::shared_ptr<XLinkConnection> conn, const std::string& name, std::size_t maxWriteSize);
+    XLinkStream(const std::shared_ptr<XLinkConnection>& conn, const std::string& name, std::size_t maxWriteSize);
     XLinkStream(const XLinkStream&) = delete;
     XLinkStream(XLinkStream&& stream);
     XLinkStream& operator=(const XLinkStream&) = delete;

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -173,7 +173,7 @@ CalibrationHandler::CalibrationHandler(std::filesystem::path eepromDataPath, std
     }
 }
 
-CalibrationHandler CalibrationHandler::fromJson(nlohmann::json eepromDataJson, std::optional<bool> validateCalibration) {
+CalibrationHandler CalibrationHandler::fromJson(const nlohmann::json& eepromDataJson, std::optional<bool> validateCalibration) {
     CalibrationHandler calib;
     calib.eepromData = eepromDataJson;
     if(validateCalibration.value_or(false)) {
@@ -312,7 +312,7 @@ CalibrationHandler::CalibrationHandler(std::filesystem::path calibrationDataPath
     }
 }
 
-CalibrationHandler::CalibrationHandler(EepromData newEepromData, std::optional<bool> validateCalibration) {
+CalibrationHandler::CalibrationHandler(const EepromData& newEepromData, std::optional<bool> validateCalibration) {
     eepromData = newEepromData;
     if(validateCalibration.value_or(false)) {
         validateCalibrationHandler();
@@ -426,7 +426,7 @@ std::vector<std::vector<float>> CalibrationHandler::getCameraIntrinsics(
 }
 
 std::vector<std::vector<float>> CalibrationHandler::getCameraIntrinsics(
-    CameraBoardSocket cameraId, std::tuple<int, int> destShape, Point2f topLeftPixelId, Point2f bottomRightPixelId, bool keepAspectRatio) const {
+    CameraBoardSocket cameraId, const std::tuple<int, int>& destShape, Point2f topLeftPixelId, Point2f bottomRightPixelId, bool keepAspectRatio) const {
     return getCameraIntrinsics(cameraId, std::get<0>(destShape), std::get<1>(destShape), topLeftPixelId, bottomRightPixelId, keepAspectRatio);
 }
 
@@ -952,20 +952,20 @@ bool CalibrationHandler::checkExtrinsicsLink(CameraBoardSocket srcCamera, Camera
     return isConnectionFound;
 }
 
-void CalibrationHandler::setBoardInfo(std::string boardName, std::string boardRev) {
+void CalibrationHandler::setBoardInfo(const std::string& boardName, const std::string& boardRev) {
     eepromData.boardName = boardName;
     eepromData.boardRev = boardRev;
 }
 
-void CalibrationHandler::setBoardInfo(std::string productName,
-                                      std::string boardName,
-                                      std::string boardRev,
-                                      std::string boardConf,
-                                      std::string hardwareConf,
-                                      std::string batchName,
+void CalibrationHandler::setBoardInfo(const std::string& productName,
+                                      const std::string& boardName,
+                                      const std::string& boardRev,
+                                      const std::string& boardConf,
+                                      const std::string& hardwareConf,
+                                      const std::string& batchName,
                                       uint64_t batchTime,
                                       uint32_t boardOptions,
-                                      std::string boardCustom) {
+                                      const std::string& boardCustom) {
     eepromData.productName = productName;
     eepromData.boardName = boardName;
     eepromData.boardRev = boardRev;
@@ -983,16 +983,16 @@ void CalibrationHandler::setBoardInfo(std::string productName,
     eepromData.version = 7;
 }
 
-void CalibrationHandler::setBoardInfo(std::string deviceName,
-                                      std::string productName,
-                                      std::string boardName,
-                                      std::string boardRev,
-                                      std::string boardConf,
-                                      std::string hardwareConf,
-                                      std::string batchName,
+void CalibrationHandler::setBoardInfo(const std::string& deviceName,
+                                      const std::string& productName,
+                                      const std::string& boardName,
+                                      const std::string& boardRev,
+                                      const std::string& boardConf,
+                                      const std::string& hardwareConf,
+                                      const std::string& batchName,
                                       uint64_t batchTime,
                                       uint32_t boardOptions,
-                                      std::string boardCustom) {
+                                      const std::string& boardCustom) {
     eepromData.productName = productName;
     eepromData.boardName = boardName;
     eepromData.boardRev = boardRev;
@@ -1011,21 +1011,21 @@ void CalibrationHandler::setBoardInfo(std::string deviceName,
     eepromData.version = 7;
 }
 
-void CalibrationHandler::setDeviceName(std::string deviceName) {
+void CalibrationHandler::setDeviceName(const std::string& deviceName) {
     eepromData.deviceName = deviceName;
 
     // Bump version to V7
     eepromData.version = 7;
 }
 
-void CalibrationHandler::setProductName(std::string productName) {
+void CalibrationHandler::setProductName(const std::string& productName) {
     eepromData.productName = productName;
 
     // Bump version to V7
     eepromData.version = 7;
 }
 
-void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, std::vector<std::vector<float>> intrinsics, int width, int height) {
+void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& intrinsics, int width, int height) {
     if(intrinsics.size() != 3 || intrinsics[0].size() != 3) {
         throw std::runtime_error("Intrinsic Matrix size should always be 3x3 ");
     }
@@ -1048,12 +1048,14 @@ void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, std::ve
     return;
 }
 
-void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, std::vector<std::vector<float>> intrinsics, Size2f frameSize) {
+void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& intrinsics, Size2f frameSize) {
     setCameraIntrinsics(cameraId, intrinsics, static_cast<int>(frameSize.width), static_cast<int>(frameSize.height));
     return;
 }
 
-void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, std::vector<std::vector<float>> intrinsics, std::tuple<int, int> frameSize) {
+void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId,
+                                             const std::vector<std::vector<float>>& intrinsics,
+                                             const std::tuple<int, int>& frameSize) {
     setCameraIntrinsics(cameraId, intrinsics, std::get<0>(frameSize), std::get<1>(frameSize));
     return;
 }
@@ -1119,9 +1121,9 @@ void CalibrationHandler::setCameraType(CameraBoardSocket cameraId, CameraModel c
 
 void CalibrationHandler::setCameraExtrinsics(CameraBoardSocket srcCameraId,
                                              CameraBoardSocket destCameraId,
-                                             std::vector<std::vector<float>> rotationMatrix,
-                                             std::vector<float> translation,
-                                             std::vector<float> specTranslation) {
+                                             const std::vector<std::vector<float>>& rotationMatrix,
+                                             const std::vector<float>& translation,
+                                             const std::vector<float>& specTranslation) {
     if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
         throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
     }
@@ -1154,9 +1156,9 @@ void CalibrationHandler::setCameraExtrinsics(CameraBoardSocket srcCameraId,
 }
 
 void CalibrationHandler::setImuExtrinsics(CameraBoardSocket destCameraId,
-                                          std::vector<std::vector<float>> rotationMatrix,
-                                          std::vector<float> translation,
-                                          std::vector<float> specTranslation) {
+                                          const std::vector<std::vector<float>>& rotationMatrix,
+                                          const std::vector<float>& translation,
+                                          const std::vector<float>& specTranslation) {
     if(rotationMatrix.size() != 3 || rotationMatrix[0].size() != 3) {
         throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
     }
@@ -1176,7 +1178,7 @@ void CalibrationHandler::setImuExtrinsics(CameraBoardSocket destCameraId,
     return;
 }
 
-void CalibrationHandler::setStereoLeft(CameraBoardSocket cameraId, std::vector<std::vector<float>> rectifiedRotation) {
+void CalibrationHandler::setStereoLeft(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& rectifiedRotation) {
     if(rectifiedRotation.size() != 3 || rectifiedRotation[0].size() != 3) {
         throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
     }
@@ -1185,7 +1187,7 @@ void CalibrationHandler::setStereoLeft(CameraBoardSocket cameraId, std::vector<s
     return;
 }
 
-void CalibrationHandler::setStereoRight(CameraBoardSocket cameraId, std::vector<std::vector<float>> rectifiedRotation) {
+void CalibrationHandler::setStereoRight(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& rectifiedRotation) {
     if(rectifiedRotation.size() != 3 || rectifiedRotation[0].size() != 3) {
         throw std::runtime_error("Rotation Matrix size should always be 3x3 ");
     }
@@ -1257,10 +1259,10 @@ bool CalibrationHandler::checkSrcLinks(CameraBoardSocket headSocket) const {
 
 CBACalibrationHandler::CBACalibrationHandler() = default;
 
-CBACalibrationHandler::CBACalibrationHandler(EepromData newEepromData, std::optional<bool> validateCalibration)
+CBACalibrationHandler::CBACalibrationHandler(const EepromData& newEepromData, std::optional<bool> validateCalibration)
     : CalibrationHandler(validateCBAEepromData(newEepromData), validateCalibration) {}
 
-CBACalibrationHandler CBACalibrationHandler::fromJson(nlohmann::json eepromDataJson, std::optional<bool> validateCalibration) {
+CBACalibrationHandler CBACalibrationHandler::fromJson(const nlohmann::json& eepromDataJson, std::optional<bool> validateCalibration) {
     EepromData eepromData = eepromDataJson;
     return CBACalibrationHandler(eepromData, validateCalibration);
 }
@@ -1281,7 +1283,7 @@ std::vector<std::vector<float>> CBACalibrationHandler::getCameraIntrinsics(Size2
     return CalibrationHandler::getCameraIntrinsics(cameraDataSocket, destShape, topLeftPixelId, bottomRightPixelId, keepAspectRatio);
 }
 
-std::vector<std::vector<float>> CBACalibrationHandler::getCameraIntrinsics(std::tuple<int, int> destShape,
+std::vector<std::vector<float>> CBACalibrationHandler::getCameraIntrinsics(const std::tuple<int, int>& destShape,
                                                                            Point2f topLeftPixelId,
                                                                            Point2f bottomRightPixelId,
                                                                            bool keepAspectRatio) const {
@@ -1316,19 +1318,19 @@ CameraModel CBACalibrationHandler::getDistortionModel() const {
     return CalibrationHandler::getDistortionModel(cameraDataSocket);
 }
 
-void CBACalibrationHandler::setCameraIntrinsics(std::vector<std::vector<float>> intrinsics, Size2f frameSize) {
+void CBACalibrationHandler::setCameraIntrinsics(const std::vector<std::vector<float>>& intrinsics, Size2f frameSize) {
     CalibrationHandler::setCameraIntrinsics(cameraDataSocket, intrinsics, frameSize);
 }
 
-void CBACalibrationHandler::setCameraIntrinsics(std::vector<std::vector<float>> intrinsics, int width, int height) {
+void CBACalibrationHandler::setCameraIntrinsics(const std::vector<std::vector<float>>& intrinsics, int width, int height) {
     CalibrationHandler::setCameraIntrinsics(cameraDataSocket, intrinsics, width, height);
 }
 
-void CBACalibrationHandler::setCameraIntrinsics(std::vector<std::vector<float>> intrinsics, std::tuple<int, int> frameSize) {
+void CBACalibrationHandler::setCameraIntrinsics(const std::vector<std::vector<float>>& intrinsics, const std::tuple<int, int>& frameSize) {
     CalibrationHandler::setCameraIntrinsics(cameraDataSocket, intrinsics, frameSize);
 }
 
-void CBACalibrationHandler::setDistortionCoefficients(std::vector<float> distortionCoefficients) {
+void CBACalibrationHandler::setDistortionCoefficients(const std::vector<float>& distortionCoefficients) {
     CalibrationHandler::setDistortionCoefficients(cameraDataSocket, distortionCoefficients);
 }
 

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -210,7 +210,7 @@ std::tuple<bool, DeviceInfo> DeviceBase::getAnyAvailableDevice(std::chrono::mill
     return getAnyAvailableDevice(timeout, nullptr);
 }
 
-std::tuple<bool, DeviceInfo> DeviceBase::getAnyAvailableDevice(std::chrono::milliseconds timeout, std::function<void()> cb) {
+std::tuple<bool, DeviceInfo> DeviceBase::getAnyAvailableDevice(std::chrono::milliseconds timeout, const std::function<void()>& cb) {
     using namespace std::chrono;
     constexpr auto POOL_SLEEP_TIME = milliseconds(100);
 
@@ -315,7 +315,7 @@ std::vector<DeviceInfo> DeviceBase::getAllConnectedDevices() {
 }
 
 // First tries to find UNBOOTED device with deviceId, then BOOTLOADER device with deviceId
-std::tuple<bool, DeviceInfo> DeviceBase::getDeviceById(std::string deviceId) {
+std::tuple<bool, DeviceInfo> DeviceBase::getDeviceById(const std::string& deviceId) {
     std::vector<DeviceInfo> availableDevices;
     auto states = {X_LINK_UNBOOTED, X_LINK_BOOTLOADER, X_LINK_GATE, X_LINK_GATE_SETUP};
     bool found;
@@ -331,7 +331,7 @@ std::vector<std::uint8_t> DeviceBase::getEmbeddedDeviceBinary(bool usb2Mode, Ope
     return Resources::getInstance().getDeviceFirmware(usb2Mode, version);
 }
 
-std::vector<std::uint8_t> DeviceBase::getEmbeddedDeviceBinary(Config config) {
+std::vector<std::uint8_t> DeviceBase::getEmbeddedDeviceBinary(const Config& config) {
     return Resources::getInstance().getDeviceFirmware(config);
 }
 
@@ -485,20 +485,20 @@ DeviceBase::DeviceBase(UsbSpeed maxUsbSpeed) {
     init(maxUsbSpeed);
 }
 
-DeviceBase::DeviceBase(Config config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) : deviceInfo(devInfo) {
+DeviceBase::DeviceBase(const Config& config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) : deviceInfo(devInfo) {
     init(config, maxUsbSpeed, "");
 }
 
-DeviceBase::DeviceBase(Config config, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd, bool dumpOnly)
+DeviceBase::DeviceBase(const Config& config, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd, bool dumpOnly)
     : deviceInfo(devInfo), dumpOnly(dumpOnly) {
     init2(config, pathToCmd, false);
 }
 
-DeviceBase::DeviceBase(Config config, const std::filesystem::path& pathToCmd) {
+DeviceBase::DeviceBase(const Config& config, const std::filesystem::path& pathToCmd) {
     init(config, pathToCmd);
 }
 
-DeviceBase::DeviceBase(Config config, UsbSpeed maxUsbSpeed) {
+DeviceBase::DeviceBase(const Config& config, UsbSpeed maxUsbSpeed) {
     init(config, maxUsbSpeed);
 }
 
@@ -521,32 +521,32 @@ void DeviceBase::init(UsbSpeed maxUsbSpeed) {
     init(maxUsbSpeed, "");
 }
 
-void DeviceBase::init(Config config, UsbSpeed maxUsbSpeed) {
+void DeviceBase::init(const Config& config, UsbSpeed maxUsbSpeed) {
     tryGetDevice();
     init(config, maxUsbSpeed, "");
 }
 
-void DeviceBase::init(Config config, const std::filesystem::path& pathToCmd) {
+void DeviceBase::init(const Config& config, const std::filesystem::path& pathToCmd) {
     tryGetDevice();
     init2(config, pathToCmd, false);
 }
 
-void DeviceBase::init(Config config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) {
+void DeviceBase::init(const Config& config, const DeviceInfo& devInfo, UsbSpeed maxUsbSpeed) {
     deviceInfo = devInfo;
     init(config, maxUsbSpeed, "");
 }
 
-void DeviceBase::init(Config config, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd) {
+void DeviceBase::init(const Config& config, const DeviceInfo& devInfo, const std::filesystem::path& pathToCmd) {
     deviceInfo = devInfo;
     init2(config, pathToCmd, false);
 }
 
-DeviceBase::DeviceBase(Config config) {
+DeviceBase::DeviceBase(const Config& config) {
     tryGetDevice();
     init2(config, {}, false);
 }
 
-DeviceBase::DeviceBase(Config config, const DeviceInfo& devInfo) : deviceInfo(devInfo) {
+DeviceBase::DeviceBase(const Config& config, const DeviceInfo& devInfo) : deviceInfo(devInfo) {
     init2(config, {}, false);
 }
 
@@ -986,7 +986,7 @@ void DeviceBase::init(const Pipeline& pipeline, UsbSpeed maxUsbSpeed, const std:
     cfg.board.usb.maxSpeed = maxUsbSpeed;
     init2(cfg, pathToMvcmd, true);
 }
-void DeviceBase::init(Config config, UsbSpeed maxUsbSpeed, const std::filesystem::path& pathToMvcmd) {
+void DeviceBase::init(const Config& config, UsbSpeed maxUsbSpeed, const std::filesystem::path& pathToMvcmd) {
     Config cfg = config;
     // Modify usb speed
     cfg.board.usb.maxSpeed = maxUsbSpeed;
@@ -1414,7 +1414,7 @@ void DeviceBase::init2(Config cfg, const std::filesystem::path& pathToMvcmd, boo
     }
 }
 
-void DeviceBase::monitorCallback(std::chrono::milliseconds watchdogTimeout, PrevInfo prev) {
+void DeviceBase::monitorCallback(std::chrono::milliseconds watchdogTimeout, const PrevInfo& prev) {
     try {
         while(true) {
             while(watchdogRunning) {
@@ -1917,7 +1917,7 @@ ProfilingData DeviceBase::getProfilingData() {
     return connection->getProfilingData();
 }
 
-int DeviceBase::addLogCallback(std::function<void(LogMessage)> callback) {
+int DeviceBase::addLogCallback(const std::function<void(LogMessage)>& callback) {
     // Lock first
     std::unique_lock<std::mutex> l(logCallbackMapMtx);
 
@@ -1996,7 +1996,7 @@ bool DeviceBase::isCalibrationAvailable() {
     return pimpl->rpcCallChecked<bool>("isCalibrationAvailable");
 }
 
-bool DeviceBase::tryFlashCalibration(CalibrationHandler calibrationDataHandler) {
+bool DeviceBase::tryFlashCalibration(const CalibrationHandler& calibrationDataHandler) {
     try {
         flashCalibration(calibrationDataHandler);
     } catch(const EepromError& e) {
@@ -2006,7 +2006,7 @@ bool DeviceBase::tryFlashCalibration(CalibrationHandler calibrationDataHandler) 
     return true;
 }
 
-bool DeviceBase::tryFlashCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket) {
+bool DeviceBase::tryFlashCBACalibration(const CBACalibrationHandler& calibrationDataHandler, CameraBoardSocket camSocket) {
     if(!validateCBACalibrationData(calibrationDataHandler)) {
         return false;
     }
@@ -2020,7 +2020,7 @@ bool DeviceBase::tryFlashCBACalibration(CBACalibrationHandler calibrationDataHan
     return true;
 }
 
-void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
+void DeviceBase::flashCalibration(const CalibrationHandler& calibrationDataHandler) {
     bool factoryPermissions = false;
     bool protectedPermissions = false;
     getFlashingPermissions(factoryPermissions, protectedPermissions);
@@ -2036,7 +2036,7 @@ void DeviceBase::flashCalibration(CalibrationHandler calibrationDataHandler) {
     }
 }
 
-void DeviceBase::flashCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket) {
+void DeviceBase::flashCBACalibration(const CBACalibrationHandler& calibrationDataHandler, CameraBoardSocket camSocket) {
     camSocket = validatePhysicalCBASocket(camSocket);
     if(!validateCBACalibrationData(calibrationDataHandler)) {
         throw std::runtime_error("CBA calibration data must contain exactly one CameraBoardSocket::CBA cameraData entry.");
@@ -2070,7 +2070,7 @@ void DeviceBase::setCalibration(const std::optional<EepromData>& eepromData) {
     }
 }
 
-void DeviceBase::setCalibration(CalibrationHandler calibrationDataHandler) {
+void DeviceBase::setCalibration(const CalibrationHandler& calibrationDataHandler) {
     setCalibration(calibrationDataHandler.getEepromData());
 }
 
@@ -2150,7 +2150,7 @@ CBACalibrationHandler DeviceBase::readCBACalibrationOrDefault(CameraBoardSocket 
     return readCBACalibration(camSocket);
 }
 
-void DeviceBase::flashFactoryCalibration(CalibrationHandler calibrationDataHandler) {
+void DeviceBase::flashFactoryCalibration(const CalibrationHandler& calibrationDataHandler) {
     bool factoryPermissions = false;
     bool protectedPermissions = false;
     getFlashingPermissions(factoryPermissions, protectedPermissions);
@@ -2169,7 +2169,7 @@ void DeviceBase::flashFactoryCalibration(CalibrationHandler calibrationDataHandl
     }
 }
 
-void DeviceBase::flashFactoryCBACalibration(CBACalibrationHandler calibrationDataHandler, CameraBoardSocket camSocket) {
+void DeviceBase::flashFactoryCBACalibration(const CBACalibrationHandler& calibrationDataHandler, CameraBoardSocket camSocket) {
     camSocket = validatePhysicalCBASocket(camSocket);
     if(!validateCBACalibrationData(calibrationDataHandler)) {
         throw std::runtime_error("CBA calibration data must contain exactly one CameraBoardSocket::CBA cameraData entry.");

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -226,20 +226,20 @@ std::vector<uint8_t> DeviceBootloader::createDepthaiApplicationPackage(
 
 std::vector<uint8_t> DeviceBootloader::createDepthaiApplicationPackage(const Pipeline& pipeline,
                                                                        bool compress,
-                                                                       std::string applicationName,
+                                                                       const std::string& applicationName,
                                                                        bool checkChecksum) {
     return createDepthaiApplicationPackage(pipeline, "", compress, applicationName, checkChecksum);
 }
 
 void DeviceBootloader::saveDepthaiApplicationPackage(
-    const fs::path& path, const Pipeline& pipeline, const fs::path& pathToCmd, bool compress, std::string applicationName, bool checkChecksum) {
+    const fs::path& path, const Pipeline& pipeline, const fs::path& pathToCmd, bool compress, const std::string& applicationName, bool checkChecksum) {
     auto dap = createDepthaiApplicationPackage(pipeline, pathToCmd, compress, applicationName, checkChecksum);
     std::ofstream outfile(path, std::ios::binary);
     outfile.write(reinterpret_cast<const char*>(dap.data()), dap.size());
 }
 
 void DeviceBootloader::saveDepthaiApplicationPackage(
-    const fs::path& path, const Pipeline& pipeline, bool compress, std::string applicationName, bool checkChecksum) {
+    const fs::path& path, const Pipeline& pipeline, bool compress, const std::string& applicationName, bool checkChecksum) {
     auto dap = createDepthaiApplicationPackage(pipeline, compress, applicationName, checkChecksum);
     std::ofstream outfile(path, std::ios::binary);
     outfile.write(reinterpret_cast<const char*>(dap.data()), dap.size());
@@ -618,12 +618,12 @@ bool DeviceBootloader::isAllowedFlashingBootloader() const {
     return allowFlashingBootloader;
 }
 
-std::tuple<bool, std::string> DeviceBootloader::flash(
-    std::function<void(float)> progressCb, const Pipeline& pipeline, bool compress, std::string applicationName, Memory memory, bool checkCheksum) {
+std::tuple<bool, std::string> DeviceBootloader::flash(const std::function<void(float)>& progressCb, const Pipeline& pipeline, bool compress,
+                                                      const std::string& applicationName, Memory memory, bool checkCheksum) {
     return flashDepthaiApplicationPackage(progressCb, createDepthaiApplicationPackage(pipeline, compress, applicationName, checkCheksum), memory);
 }
 
-std::tuple<bool, std::string> DeviceBootloader::flash(const Pipeline& pipeline, bool compress, std::string applicationName, Memory memory, bool checkCheksum) {
+std::tuple<bool, std::string> DeviceBootloader::flash(const Pipeline& pipeline, bool compress, const std::string& applicationName, Memory memory, bool checkCheksum) {
     return flashDepthaiApplicationPackage(createDepthaiApplicationPackage(pipeline, compress, applicationName, checkCheksum), memory);
 }
 
@@ -714,8 +714,8 @@ bool DeviceBootloader::isUserBootloader() {
     return user.isUserBootloader;
 }
 
-std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(std::function<void(float)> progressCb,
-                                                                               std::vector<uint8_t> package,
+std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(const std::function<void(float)>& progressCb,
+                                                                               const std::vector<uint8_t>& package,
                                                                                Memory memory) {
     // Bug in NETWORK bootloader in version 0.0.12 < 0.0.14 - flashing can cause a soft brick
     auto bootloaderVersion = getVersion();
@@ -807,7 +807,7 @@ std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(s
     return ret;
 }
 
-std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(std::vector<uint8_t> package, Memory memory) {
+std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(const std::vector<uint8_t>& package, Memory memory) {
     return flashDepthaiApplicationPackage(nullptr, package, memory);
 }
 
@@ -819,7 +819,7 @@ std::tuple<bool, std::string> DeviceBootloader::flashClear(Memory memory) {
     return flashCustom(memory, bootloader::getStructure(getType()).offset.at(Section::APPLICATION), clear);
 }
 
-std::tuple<bool, std::string> DeviceBootloader::flashBootloader(std::function<void(float)> progressCb, const fs::path& path) {
+std::tuple<bool, std::string> DeviceBootloader::flashBootloader(const std::function<void(float)>& progressCb, const fs::path& path) {
     return flashBootloader(Memory::FLASH, bootloaderType, progressCb, path);
 }
 
@@ -1074,20 +1074,22 @@ std::tuple<bool, std::string> DeviceBootloader::flashFastBootHeader(Memory memor
 std::tuple<bool, std::string> DeviceBootloader::flashCustom(Memory memory,
                                                             size_t offset,
                                                             const std::vector<uint8_t>& data,
-                                                            std::function<void(float)> progressCb) {
+                                                            const std::function<void(float)>& progressCb) {
     if(data.size() == 0) {
         throw std::invalid_argument("Size to flash is zero");
     }
     return flashCustom(memory, offset, data.data(), data.size(), "", progressCb);
 }
 std::tuple<bool, std::string> DeviceBootloader::flashCustom(
-    Memory memory, size_t offset, const uint8_t* data, size_t size, std::function<void(float)> progressCb) {
+    Memory memory, size_t offset, const uint8_t* data, size_t size, const std::function<void(float)>& progressCb) {
     if(data == nullptr || size == 0) {
         throw std::invalid_argument("Data is nullptr or size is zero");
     }
     return flashCustom(memory, offset, data, size, "", progressCb);
 }
-std::tuple<bool, std::string> DeviceBootloader::flashCustom(Memory memory, size_t offset, std::string filename, std::function<void(float)> progressCb) {
+std::tuple<bool, std::string> DeviceBootloader::flashCustom(Memory memory, size_t offset,
+                                                            const std::string& filename,
+                                                            const std::function<void(float)>& progressCb) {
     return flashCustom(memory, offset, nullptr, 0, filename, progressCb);
 }
 std::tuple<bool, std::string> DeviceBootloader::flashCustom(
@@ -1150,24 +1152,24 @@ std::tuple<bool, std::string> DeviceBootloader::flashCustom(
 }
 
 std::tuple<bool, std::string> DeviceBootloader::readCustom(
-    Memory memory, size_t offset, size_t size, std::vector<uint8_t>& data, std::function<void(float)> progressCb) {
+    Memory memory, size_t offset, size_t size, std::vector<uint8_t>& data, const std::function<void(float)>& progressCb) {
     // Resize container if not too small
     if(data.size() < size) {
         data.resize(size);
     }
     return readCustom(memory, offset, size, data.data(), "", progressCb);
 }
-std::tuple<bool, std::string> DeviceBootloader::readCustom(Memory memory, size_t offset, size_t size, uint8_t* data, std::function<void(float)> progressCb) {
+std::tuple<bool, std::string> DeviceBootloader::readCustom(Memory memory, size_t offset, size_t size, uint8_t* data, const std::function<void(float)>& progressCb) {
     return readCustom(memory, offset, size, data, "", progressCb);
 }
 std::tuple<bool, std::string> DeviceBootloader::readCustom(
-    Memory memory, size_t offset, size_t size, std::string filename, std::function<void(float)> progressCb) {
+    Memory memory, size_t offset, size_t size, const std::string& filename, const std::function<void(float)>& progressCb) {
     return readCustom(memory, offset, size, nullptr, filename, progressCb);
 }
 std::tuple<bool, std::string, std::vector<uint8_t>> DeviceBootloader::readCustom(Memory memory,
                                                                                  size_t offset,
                                                                                  size_t size,
-                                                                                 std::function<void(float)> progressCb) {
+                                                                                 const std::function<void(float)>& progressCb) {
     std::vector<uint8_t> data;
     auto ret = readCustom(memory, offset, size, data, progressCb);
     return {std::get<0>(ret), std::get<1>(ret), data};
@@ -1274,7 +1276,7 @@ std::tuple<bool, std::string> DeviceBootloader::flashConfigClear(Memory memory, 
     return {result.success, result.errorMsg};
 }
 
-std::tuple<bool, std::string> DeviceBootloader::flashConfigData(nlohmann::json configData, Memory memory, Type type) {
+std::tuple<bool, std::string> DeviceBootloader::flashConfigData(const nlohmann::json& configData, Memory memory, Type type) {
     // Parse to BSON
     auto bson = nlohmann::json::to_bson(configData);
 
@@ -1452,13 +1454,13 @@ void DeviceBootloader::receiveResponseThrow(T& response) {
 }
 
 // Config functions
-void DeviceBootloader::Config::setStaticIPv4(std::string ip, std::string mask, std::string gateway) {
+void DeviceBootloader::Config::setStaticIPv4(const std::string& ip, const std::string& mask, const std::string& gateway) {
     network.ipv4 = platform::getIPv4AddressAsBinary(ip);
     network.ipv4Mask = platform::getIPv4AddressAsBinary(mask);
     network.ipv4Gateway = platform::getIPv4AddressAsBinary(gateway);
     network.staticIpv4 = true;
 }
-void DeviceBootloader::Config::setDynamicIPv4(std::string ip, std::string mask, std::string gateway) {
+void DeviceBootloader::Config::setDynamicIPv4(const std::string& ip, const std::string& mask, const std::string& gateway) {
     network.ipv4 = platform::getIPv4AddressAsBinary(ip);
     network.ipv4Mask = platform::getIPv4AddressAsBinary(mask);
     network.ipv4Gateway = platform::getIPv4AddressAsBinary(gateway);
@@ -1479,7 +1481,7 @@ std::string DeviceBootloader::Config::getIPv4Gateway() {
     return platform::getIPv4AddressAsString(network.ipv4Gateway);
 }
 
-void DeviceBootloader::Config::setDnsIPv4(std::string dns, std::string dnsAlt) {
+void DeviceBootloader::Config::setDnsIPv4(const std::string& dns, const std::string& dnsAlt) {
     network.ipv4Dns = platform::getIPv4AddressAsBinary(dns);
     network.ipv4DnsAlt = platform::getIPv4AddressAsBinary(dnsAlt);
 }
@@ -1516,7 +1518,7 @@ UsbSpeed DeviceBootloader::Config::getUsbMaxSpeed() {
     return static_cast<UsbSpeed>(usb.maxUsbSpeed);
 }
 
-void DeviceBootloader::Config::setMacAddress(std::string mac) {
+void DeviceBootloader::Config::setMacAddress(const std::string& mac) {
     std::array<uint8_t, 6> a = {0, 0, 0, 0, 0, 0};
     if(mac != "") {
         int last = -1;
@@ -1553,7 +1555,7 @@ nlohmann::json DeviceBootloader::Config::toJson() const {
     return dataCopy;
 }
 
-DeviceBootloader::Config DeviceBootloader::Config::fromJson(nlohmann::json json) {
+DeviceBootloader::Config DeviceBootloader::Config::fromJson(const nlohmann::json& json) {
     // Parse out json (implicitly) and
     Config cfg = json;
     // save json data as is (to retain unknown values)

--- a/src/device/DeviceGate.cpp
+++ b/src/device/DeviceGate.cpp
@@ -92,7 +92,7 @@ DeviceGate::HTTPImpl::HTTPImpl(DeviceInfo deviceInfo) {
     // pimpl->cli->set_connection_timeout(2);
 }
 
-DeviceGate::USBImpl::USBImpl(DeviceInfo deviceInfo, int timeout) : deviceInfo(deviceInfo), timeout(timeout) {}
+DeviceGate::USBImpl::USBImpl(const DeviceInfo& deviceInfo, int timeout) : deviceInfo(deviceInfo), timeout(timeout) {}
 
 bool DeviceGate::isOkay() {
     return impl->isOkay();

--- a/src/nn_archive/v1/helper.hpp
+++ b/src/nn_archive/v1/helper.hpp
@@ -28,7 +28,7 @@ inline json get_untyped(const json& j, const char* property) {
     return json();
 }
 
-inline json get_untyped(const json& j, std::string property) {
+inline json get_untyped(const json& j, const std::string& property) {
     return get_untyped(j, property.data());
 }
 #endif

--- a/src/opencv/HolisticRecordReplay.cpp
+++ b/src/opencv/HolisticRecordReplay.cpp
@@ -48,7 +48,7 @@ inline size_t roundUp(size_t numToRound, size_t multiple) {
     return roundDown(numToRound + multiple - 1UL, multiple);
 }
 
-void getCameraRecordSize(std::shared_ptr<dai::node::Camera> cam, Pipeline& pipeline, bool legacy, size_t& camWidth, size_t& camHeight) {
+void getCameraRecordSize(const std::shared_ptr<dai::node::Camera>& cam, Pipeline& pipeline, bool legacy, size_t& camWidth, size_t& camHeight) {
     size_t requestWidth = cam->getMaxRequestedWidth();
     size_t requestHeight = cam->getMaxRequestedHeight();
     size_t width = cam->getMaxWidth();
@@ -94,7 +94,7 @@ void getCameraRecordSize(std::shared_ptr<dai::node::Camera> cam, Pipeline& pipel
 }
 
 Node::Output* setupHolisticRecordCamera(
-    std::shared_ptr<dai::node::Camera> cam, Pipeline& pipeline, bool legacy, float recordingFps, size_t& camWidth, size_t& camHeight) {
+    const std::shared_ptr<dai::node::Camera>& cam, Pipeline& pipeline, bool legacy, float recordingFps, size_t& camWidth, size_t& camHeight) {
     getCameraRecordSize(cam, pipeline, legacy, camWidth, camHeight);
     if(recordingFps > 0.0f) {
         return cam->requestOutput(std::pair<uint32_t, uint32_t>(camWidth, camHeight), dai::ImgFrame::Type::NV12, dai::ImgResizeMode::CROP, recordingFps);

--- a/src/openvino/BlobReader.cpp
+++ b/src/openvino/BlobReader.cpp
@@ -36,7 +36,7 @@ T readFromBlob(const std::vector<std::uint8_t>& blob, uint32_t& offset) {
     return *reinterpret_cast<const T*>(srcPtr);
 }
 
-bool isIOShapeName(std::string name) {
+bool isIOShapeName(const std::string& name) {
     return name.find("@shape") != std::string::npos;
 }
 

--- a/src/pipeline/AssetManager.cpp
+++ b/src/pipeline/AssetManager.cpp
@@ -15,7 +15,7 @@ std::string Asset::getRelativeUri() {
 }
 
 AssetManager::AssetManager() {}
-AssetManager::AssetManager(std::string rootPath) : rootPath{rootPath} {}
+AssetManager::AssetManager(const std::string& rootPath) : rootPath{rootPath} {}
 
 std::string AssetManager::getRootPath() {
     return rootPath;
@@ -25,7 +25,7 @@ void AssetManager::setRootPath(const std::string& rootPath) {
     this->rootPath = rootPath;
 }
 
-std::string AssetManager::getRelativeKey(std::string key) const {
+std::string AssetManager::getRelativeKey(const std::string& key) const {
     // Check if asset key is absolute or relative
     std::string relativeKey = "";
     if(key.size() == 0) {
@@ -111,7 +111,7 @@ std::shared_ptr<Asset> AssetManager::get(const std::string& key) {
     return assetMap.at(relativeKey);
 }
 
-void AssetManager::addExisting(std::vector<std::shared_ptr<Asset>> assets) {
+void AssetManager::addExisting(const std::vector<std::shared_ptr<Asset>>& assets) {
     // make sure that key doesn't exist already
     for(const auto& asset : assets) {
         if(assetMap.count(asset->key) > 0) throw std::logic_error("An Asset with the key: " + asset->key + " already exists.");
@@ -174,7 +174,7 @@ void AssetManager::serialize(AssetsMutable& mutableAssets, std::vector<std::uint
     }
 }
 
-void AssetsMutable::set(std::string key, std::uint32_t offset, std::uint32_t size, std::uint32_t alignment) {
+void AssetsMutable::set(const std::string& key, std::uint32_t offset, std::uint32_t size, std::uint32_t alignment) {
     AssetInternal internal = {};
     internal.offset = offset;
     internal.size = size;

--- a/src/pipeline/DeviceNode.cpp
+++ b/src/pipeline/DeviceNode.cpp
@@ -17,7 +17,7 @@ DeviceNode::DeviceNode(const std::shared_ptr<Device>& device, std::unique_ptr<Pr
     configureMode = conf;
 }
 
-void DeviceNode::setDevice(std::shared_ptr<Device> device) {
+void DeviceNode::setDevice(const std::shared_ptr<Device>& device) {
     this->device = device;
 }
 

--- a/src/pipeline/MessageQueue.cpp
+++ b/src/pipeline/MessageQueue.cpp
@@ -195,7 +195,7 @@ bool MessageQueue::trySend(const std::shared_ptr<ADatatype>& msg) {
     return send(msg, std::chrono::milliseconds(0));
 }
 
-void MessageQueue::callCallbacks(std::shared_ptr<ADatatype> message) {
+void MessageQueue::callCallbacks(const std::shared_ptr<ADatatype>& message) {
     // Lock first
     std::lock_guard<std::mutex> lock(callbacksMtx);
 

--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -38,7 +38,7 @@ Node::Connection::Connection(Output out, Input in) {
     inputGroup = in.getGroup();
 }
 
-Node::Connection::Connection(ConnectionInternal c) {
+Node::Connection::Connection(const ConnectionInternal& c) {
     auto out = c.outputNode.lock();
     auto in = c.inputNode.lock();
     if(out == nullptr || in == nullptr) {
@@ -316,17 +316,17 @@ AssetManager& Node::getAssetManager() {
     return assetManager;
 }
 
-std::vector<uint8_t> Node::loadResource(std::filesystem::path uri) {
+std::vector<uint8_t> Node::loadResource(const std::filesystem::path& uri) {
     std::string cwd = fmt::format("/node/{}/", id);
     return parent.lock()->loadResourceCwd(uri, cwd);
 }
 
-std::vector<uint8_t> Node::moveResource(std::filesystem::path uri) {
+std::vector<uint8_t> Node::moveResource(const std::filesystem::path& uri) {
     std::string cwd = fmt::format("/node/{}/", id);
     return parent.lock()->loadResourceCwd(uri, cwd, true);
 }
 
-Node::OutputMap::OutputMap(Node& parent, std::string name, Node::OutputDescription defaultOutput, bool ref)
+Node::OutputMap::OutputMap(Node& parent, std::string name, const Node::OutputDescription& defaultOutput, bool ref)
     : defaultOutput(defaultOutput), parent(parent), name(std::move(name)) {
     if(ref) {
         parent.setOutputMapRefs(this);
@@ -489,10 +489,10 @@ std::vector<const Node::Input*> Node::getInputRefs() const {
     return tmpInputRefs;
 }
 
-Node::Output* Node::getOutputRef(std::string name) {
+Node::Output* Node::getOutputRef(const std::string& name) {
     return getOutputRef("", name);
 }
-Node::Output* Node::getOutputRef(std::string group, std::string name) {
+Node::Output* Node::getOutputRef(const std::string& group, const std::string& name) {
     auto refs = getOutputRefs();
     for(auto& out : refs) {
         if(out->getGroup() == group && out->getName() == name) {
@@ -502,10 +502,10 @@ Node::Output* Node::getOutputRef(std::string group, std::string name) {
     return nullptr;
 }
 
-Node::Input* Node::getInputRef(std::string name) {
+Node::Input* Node::getInputRef(const std::string& name) {
     return getInputRef("", name);
 }
-Node::Input* Node::getInputRef(std::string group, std::string name) {
+Node::Input* Node::getInputRef(const std::string& group, const std::string& name) {
     auto refs = getInputRefs();
     for(auto& input : refs) {
         if(input->getGroup() == group && input->getName() == name) {
@@ -537,7 +537,7 @@ std::vector<Node::OutputMap*> Node::getOutputMapRefs() {
     return tmpOutputMapRefs;
 }
 
-Node::InputMap* Node::getInputMapRef(std::string group) {
+Node::InputMap* Node::getInputMapRef(const std::string& group) {
     for(auto* inMapRef : inputMapRefs) {
         if(inMapRef->name == group) {
             return inMapRef;
@@ -546,7 +546,7 @@ Node::InputMap* Node::getInputMapRef(std::string group) {
     return nullptr;
 }
 
-Node::OutputMap* Node::getOutputMapRef(std::string group) {
+Node::OutputMap* Node::getOutputMapRef(const std::string& group) {
     for(auto* outMapRef : outputMapRefs) {
         if(outMapRef->name == group) {
             return outMapRef;
@@ -612,13 +612,13 @@ void Node::setNodeRefs(std::string alias, std::shared_ptr<Node>* nodeRef) {
     setNodeRefs({alias, nodeRef});
 }
 
-void Node::add(std::shared_ptr<Node> node) {
+void Node::add(const std::shared_ptr<Node>& node) {
     // TODO(themarpe) - check if node is already added somewhere else, etc... (as in Pipeline)
     node->parentId = this->id;
     nodeMap.push_back(node);
 }
 
-void Node::remove(std::shared_ptr<Node> node) {
+void Node::remove(const std::shared_ptr<Node>& node) {
     // Remove the connection to the removed node and all it's children from all the nodes in the pipeline
     auto pipeline = parent.lock();
 
@@ -636,7 +636,7 @@ void Node::remove(std::shared_ptr<Node> node) {
     nodeMap.erase(std::remove(nodeMap.begin(), nodeMap.end(), node), nodeMap.end());
 }
 
-void Node::removeConnectionToNode(std::shared_ptr<Node> node) {
+void Node::removeConnectionToNode(const std::shared_ptr<Node>& node) {
     // Remove all connections to this node
     for(auto it = connections.begin(); it != connections.end();) {
         if(it->inputNode.lock() == node || it->outputNode.lock() == node) {

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -232,7 +232,7 @@ GlobalProperties PipelineImpl::getGlobalProperties() const {
     return globalProperties;
 }
 
-void PipelineImpl::setGlobalProperties(GlobalProperties globalProperties) {
+void PipelineImpl::setGlobalProperties(const GlobalProperties& globalProperties) {
     this->globalProperties = globalProperties;
 }
 
@@ -633,7 +633,7 @@ void PipelineImpl::setSippDmaBufferSize(int sizeBytes) {
     }
 }
 
-void PipelineImpl::setBoardConfig(BoardConfig boardCfg) {
+void PipelineImpl::setBoardConfig(const BoardConfig& boardCfg) {
     board = boardCfg;
 }
 
@@ -652,7 +652,7 @@ BoardConfig PipelineImpl::getBoardConfig() const {
 }
 
 // Remove node capability
-void PipelineImpl::remove(std::shared_ptr<Node> toRemove) {
+void PipelineImpl::remove(const std::shared_ptr<Node>& toRemove) {
     DAI_CHECK_V(!isBuilt(), "Cannot remove node from pipeline once it is built.");
     DAI_CHECK_V(toRemove->parent.lock() != nullptr, "Cannot remove a node that is not a part of any pipeline");
     DAI_CHECK_V(toRemove->parent.lock() == shared_from_this(), "Cannot remove a node that is not a part of this pipeline");
@@ -706,7 +706,7 @@ bool PipelineImpl::canConnect(const Node::Output& out, const Node::Input& in) {
     return false;
 }
 
-void PipelineImpl::setCalibrationData(CalibrationHandler calibrationDataHandler) {
+void PipelineImpl::setCalibrationData(const CalibrationHandler& calibrationDataHandler) {
     setEepromData(calibrationDataHandler.getEepromData());
 }
 
@@ -734,7 +734,7 @@ CalibrationHandler PipelineImpl::getCalibrationData() const {
     throw std::runtime_error("No default device properties set in pipeline");
 }
 
-void PipelineImpl::setEepromData(std::optional<EepromData> eepromData) {
+void PipelineImpl::setEepromData(const std::optional<EepromData>& eepromData) {
     if(defaultDevice) {
         defaultDevice->setCalibration(eepromData);
     } else if(defaultDeviceProperties != nullptr) {
@@ -805,7 +805,7 @@ PipelineStateApi PipelineImpl::getPipelineState() {
     return PipelineStateApi(pipelineStateOut, pipelineStateRequest, getAllNodes());
 }
 
-void PipelineImpl::add(std::shared_ptr<Node> node) {
+void PipelineImpl::add(const std::shared_ptr<Node>& node) {
     if(node == nullptr) {
         throw std::invalid_argument(fmt::format("Given node pointer is null"));
     }
@@ -1348,7 +1348,7 @@ void PipelineImpl::run() {
     wait();
 }
 
-std::vector<uint8_t> PipelineImpl::loadResource(fs::path uri) {
+std::vector<uint8_t> PipelineImpl::loadResource(const fs::path& uri) {
     return loadResourceCwd(uri, "/pipeline");
 }
 

--- a/src/pipeline/PipelineStateApi.cpp
+++ b/src/pipeline/PipelineStateApi.cpp
@@ -255,7 +255,7 @@ NodeState::Timing NodeStateApi::otherTimings(const std::string& statName) {
     }
     return state->nodeStates[nodeId].otherTimings[statName];
 }
-void PipelineStateApi::stateAsync(std::function<void(const PipelineState&)> callback, std::optional<PipelineEventAggregationConfig> config) {
+void PipelineStateApi::stateAsync(std::function<void(const PipelineState&)> callback, const std::optional<PipelineEventAggregationConfig>& config) {
     PipelineEventAggregationConfig cfg;
     if(config.has_value()) {
         cfg = *config;

--- a/src/pipeline/datatype/CameraControl.cpp
+++ b/src/pipeline/datatype/CameraControl.cpp
@@ -217,16 +217,16 @@ CameraControl& CameraControl::setMisc(std::string control, std::string value) {
     miscControls.push_back(std::make_pair(control, value));
     return *this;
 }
-CameraControl& CameraControl::setMisc(std::string control, int value) {
+CameraControl& CameraControl::setMisc(const std::string& control, int value) {
     return setMisc(control, std::to_string(value));
 }
-CameraControl& CameraControl::setMisc(std::string control, float value) {
+CameraControl& CameraControl::setMisc(const std::string& control, float value) {
     return setMisc(control, std::to_string(value));
 }
 void CameraControl::clearMiscControls() {
     miscControls.clear();
 }
-std::vector<std::pair<std::string, std::string>> CameraControl::getMiscControls() {
+std::vector<std::pair<std::string, std::string>> CameraControl::getMiscControls() const {
     return miscControls;
 }
 

--- a/src/pipeline/datatype/FeatureTrackerConfig.cpp
+++ b/src/pipeline/datatype/FeatureTrackerConfig.cpp
@@ -14,7 +14,7 @@ FeatureTrackerConfig& FeatureTrackerConfig::setCornerDetector(FeatureTrackerConf
     return *this;
 }
 
-FeatureTrackerConfig& FeatureTrackerConfig::setCornerDetector(FeatureTrackerConfig::CornerDetector config) {
+FeatureTrackerConfig& FeatureTrackerConfig::setCornerDetector(const FeatureTrackerConfig::CornerDetector& config) {
     cornerDetector = config;
     return *this;
 }
@@ -24,7 +24,7 @@ FeatureTrackerConfig& FeatureTrackerConfig::setMotionEstimator(bool enable) {
     return *this;
 }
 
-FeatureTrackerConfig& FeatureTrackerConfig::setMotionEstimator(FeatureTrackerConfig::MotionEstimator config) {
+FeatureTrackerConfig& FeatureTrackerConfig::setMotionEstimator(const FeatureTrackerConfig::MotionEstimator& config) {
     motionEstimator = config;
     return *this;
 }
@@ -35,7 +35,7 @@ FeatureTrackerConfig& FeatureTrackerConfig::setOpticalFlow() {
     return *this;
 }
 
-FeatureTrackerConfig& FeatureTrackerConfig::setOpticalFlow(FeatureTrackerConfig::MotionEstimator::OpticalFlow config) {
+FeatureTrackerConfig& FeatureTrackerConfig::setOpticalFlow(const FeatureTrackerConfig::MotionEstimator::OpticalFlow& config) {
     motionEstimator.type = FeatureTrackerConfig::MotionEstimator::Type::LUCAS_KANADE_OPTICAL_FLOW;
     motionEstimator.opticalFlow = config;
     setMotionEstimator(true);

--- a/src/pipeline/datatype/ImageFiltersConfig.cpp
+++ b/src/pipeline/datatype/ImageFiltersConfig.cpp
@@ -18,7 +18,7 @@ void ToFDepthConfidenceFilterConfig::serialize(std::vector<std::uint8_t>& metada
     datatype = DatatypeEnum::ToFDepthConfidenceFilterConfig;
 }
 
-ImageFiltersConfig& ImageFiltersConfig::updateFilterAtIndex(std::int32_t index, FilterParams params) {
+ImageFiltersConfig& ImageFiltersConfig::updateFilterAtIndex(std::int32_t index, const FilterParams& params) {
     DAI_CHECK_V(this->filterIndices.size() == this->filterParams.size(),
                 "ImageFiltersConfig can either be used to create a new filter pipeline or update an existing one, not both");
     this->filterIndices.push_back(index);
@@ -26,7 +26,7 @@ ImageFiltersConfig& ImageFiltersConfig::updateFilterAtIndex(std::int32_t index, 
     return *this;
 }
 
-ImageFiltersConfig& ImageFiltersConfig::insertFilter(FilterParams params) {
+ImageFiltersConfig& ImageFiltersConfig::insertFilter(const FilterParams& params) {
     DAI_CHECK_V(filterIndices.size() == 0, "ImageFiltersConfig can either be used to create a new filter pipeline or update an existing one, not both");
     this->filterParams.push_back(params);
     return *this;

--- a/src/pipeline/datatype/ImageManipConfig.cpp
+++ b/src/pipeline/datatype/ImageManipConfig.cpp
@@ -32,11 +32,11 @@ ImageManipConfig& ImageManipConfig::addCrop(uint32_t x, uint32_t y, uint32_t w, 
     base.crop(x, y, w, h);
     return *this;
 }
-ImageManipConfig& ImageManipConfig::addCrop(dai::Rect rect, bool normalizedCoords) {
+ImageManipConfig& ImageManipConfig::addCrop(const dai::Rect& rect, bool normalizedCoords) {
     base.crop(rect.x, rect.y, rect.width, rect.height, normalizedCoords);
     return *this;
 }
-ImageManipConfig& ImageManipConfig::addCropRotatedRect(dai::RotatedRect rotatedRect, bool normalizedCoords) {
+ImageManipConfig& ImageManipConfig::addCropRotatedRect(const dai::RotatedRect& rotatedRect, bool normalizedCoords) {
     base.rotateDegrees(-rotatedRect.angle);
     base.crop(rotatedRect.center.x - rotatedRect.size.width / 2,
               rotatedRect.center.y - rotatedRect.size.height / 2,
@@ -69,11 +69,12 @@ ImageManipConfig& ImageManipConfig::addTransformAffine(std::array<float, 4> matr
     base.transformAffine(matrix);
     return *this;
 }
-ImageManipConfig& ImageManipConfig::addTransformPerspective(std::array<float, 9> matrix) {
+ImageManipConfig& ImageManipConfig::addTransformPerspective(const std::array<float, 9>& matrix) {
     base.transformPerspective(matrix);
     return *this;
 }
-ImageManipConfig& ImageManipConfig::addTransformFourPoints(std::array<dai::Point2f, 4> src, std::array<dai::Point2f, 4> dst, bool normalizedCoords) {
+ImageManipConfig& ImageManipConfig::addTransformFourPoints(const std::array<dai::Point2f, 4>& src,
+                                                           const std::array<dai::Point2f, 4>& dst, bool normalizedCoords) {
     base.transformFourPoints(src, dst, normalizedCoords);
     return *this;
 }

--- a/src/pipeline/datatype/ImgTransformations.cpp
+++ b/src/pipeline/datatype/ImgTransformations.cpp
@@ -66,7 +66,7 @@ dai::Point2f interSourceFrameTransform(dai::Point2f sourcePt, const ImgTransform
     return rayToPixel(rectifiedRay, to);
 }
 
-dai::RotatedRect interSourceFrameTransform(dai::RotatedRect sourceRect, const ImgTransformation& from, const ImgTransformation& to) {
+dai::RotatedRect interSourceFrameTransform(const dai::RotatedRect& sourceRect, const ImgTransformation& from, const ImgTransformation& to) {
     if(from.isEqualTransformation(to)) {
         return sourceRect;
     }
@@ -129,7 +129,7 @@ dai::Point2f ImgTransformation::transformPoint(dai::Point2f point) const {
     auto transformed = matrix::dehomogenizePoint3(matrix::matVecMul(transformationMatrix, {point.x, point.y, 1}));
     return {transformed[0], transformed[1]};
 }
-dai::RotatedRect ImgTransformation::transformRect(dai::RotatedRect rect) const {
+dai::RotatedRect ImgTransformation::transformRect(const dai::RotatedRect& rect) const {
     const auto points = rect.getPoints();
     std::vector<std::array<float, 2>> vPoints(points.size());
     for(auto i = 0U; i < points.size(); ++i) {
@@ -142,7 +142,7 @@ dai::Point2f ImgTransformation::invTransformPoint(dai::Point2f point) const {
     auto transformed = matrix::dehomogenizePoint3(matrix::matVecMul(transformationMatrixInv, {point.x, point.y, 1}));
     return {transformed[0], transformed[1]};
 }
-dai::RotatedRect ImgTransformation::invTransformRect(dai::RotatedRect rect) const {
+dai::RotatedRect ImgTransformation::invTransformRect(const dai::RotatedRect& rect) const {
     const auto points = rect.getPoints();
     std::vector<std::array<float, 2>> vPoints(points.size());
     for(auto i = 0U; i < points.size(); ++i) {
@@ -251,7 +251,7 @@ bool ImgTransformation::getDstMaskPt(size_t x, size_t y) {
     return isPointInRotatedRectangle({(float)x, (float)y}, dstCrop);
 };
 
-ImgTransformation& ImgTransformation::addTransformation(std::array<std::array<float, 3>, 3> matrix) {
+ImgTransformation& ImgTransformation::addTransformation(const std::array<std::array<float, 3>, 3>& matrix) {
     transformationMatrix = matrix::matMul(matrix, transformationMatrix);
     transformationMatrixInv = matrix::getMatrixInverse(transformationMatrix);
     cropsValid = false;
@@ -342,7 +342,7 @@ ImgTransformation& ImgTransformation::setSourceSize(size_t width, size_t height)
     this->srcHeight = height;
     return *this;
 }
-ImgTransformation& ImgTransformation::setIntrinsicMatrix(std::array<std::array<float, 3>, 3> intrinsicMatrix) {
+ImgTransformation& ImgTransformation::setIntrinsicMatrix(const std::array<std::array<float, 3>, 3>& intrinsicMatrix) {
     sourceIntrinsicMatrix = intrinsicMatrix;
     sourceIntrinsicMatrixInv = matrix::getMatrixInverse(intrinsicMatrix);
     return *this;
@@ -355,7 +355,7 @@ ImgTransformation& ImgTransformation::setDistortionModel(CameraModel model) {
     distortionModel = model;
     return *this;
 }
-ImgTransformation& ImgTransformation::setDistortionCoefficients(std::vector<float> coefficients) {
+ImgTransformation& ImgTransformation::setDistortionCoefficients(const std::vector<float>& coefficients) {
     distortionCoefficients = coefficients;
     return *this;
 }
@@ -403,7 +403,7 @@ dai::RotatedRect ImgTransformation::remapRectTo(const ImgTransformation& to, dai
     }
     return transformed;
 }
-dai::RotatedRect ImgTransformation::remapRectFrom(const ImgTransformation& from, dai::RotatedRect rect) const {
+dai::RotatedRect ImgTransformation::remapRectFrom(const ImgTransformation& from, const dai::RotatedRect& rect) const {
     return from.remapRectTo(*this, rect);
 }
 

--- a/src/pipeline/datatype/SpatialLocationCalculatorConfig.cpp
+++ b/src/pipeline/datatype/SpatialLocationCalculatorConfig.cpp
@@ -9,7 +9,7 @@ void SpatialLocationCalculatorConfig::serialize(std::vector<std::uint8_t>& metad
     datatype = DatatypeEnum::SpatialLocationCalculatorConfig;
 }
 
-void SpatialLocationCalculatorConfig::setROIs(std::vector<SpatialLocationCalculatorConfigData> ROIs) {
+void SpatialLocationCalculatorConfig::setROIs(const std::vector<SpatialLocationCalculatorConfigData>& ROIs) {
     config = ROIs;
 }
 

--- a/src/pipeline/node/AutoCalibration.cpp
+++ b/src/pipeline/node/AutoCalibration.cpp
@@ -15,7 +15,7 @@ constexpr int GATE_FPS_DEFAULT = 5;
 constexpr int BYTES_PER_SECOND_LIMIT_DEFAULT = GATE_FPS_DEFAULT * 1280 * 800 * 2;
 constexpr int PACKET_SIZE_DEFAULT = 100000;
 
-bool areLensesWide(std::shared_ptr<Device> device) {
+bool areLensesWide(const std::shared_ptr<Device>& device) {
     auto handler = device->getCalibration();
     auto eepromData = handler.getEepromData();
     const auto& hardwareConf = eepromData.hardwareConf;
@@ -168,7 +168,7 @@ void AutoCalibration::loadData(unsigned int numImages) {
     dynamicCalibration->syncInput.tryGetAll<dai::MessageGroup>();
 }
 
-std::shared_ptr<dai::CalibrationMetrics> AutoCalibration::getMetrics(std::shared_ptr<dai::CalibrationHandler> calibration) {
+std::shared_ptr<dai::CalibrationMetrics> AutoCalibration::getMetrics(const std::shared_ptr<dai::CalibrationHandler>& calibration) {
     dynamicCalibrationCommandQueue.send(DCC::computeCalibrationMetrics(*calibration));
     return metricsQueue.get<dai::CalibrationMetrics>();
 }

--- a/src/pipeline/node/Camera.cpp
+++ b/src/pipeline/node/Camera.cpp
@@ -69,7 +69,7 @@ Camera::Camera(std::shared_ptr<Device>& defaultDevice)
     : DeviceNodeCRTP<DeviceNode, Camera, CameraProperties>(defaultDevice), pimpl(spimpl::make_impl<Impl>()) {}
 
 std::shared_ptr<Camera> Camera::build(CameraBoardSocket boardSocket,
-                                      std::optional<std::pair<uint32_t, uint32_t>> sensorResolution,
+                                      const std::optional<std::pair<uint32_t, uint32_t>>& sensorResolution,
                                       std::optional<float> sensorFps) {
     if(isBuilt) {
         throw std::runtime_error("Camera node is already built");
@@ -228,7 +228,7 @@ Node::Output* Camera::requestFullResolutionOutput(std::optional<ImgFrame::Type> 
     return pimpl->requestOutput(*this, cap, false);
 }
 
-Node::Output* Camera::requestOutput(std::pair<uint32_t, uint32_t> size,
+Node::Output* Camera::requestOutput(const std::pair<uint32_t, uint32_t>& size,
                                     std::optional<ImgFrame::Type> type,
                                     ImgResizeMode resizeMode,
                                     std::optional<float> fps,

--- a/src/pipeline/node/ColorCamera.cpp
+++ b/src/pipeline/node/ColorCamera.cpp
@@ -26,7 +26,7 @@ CameraBoardSocket ColorCamera::getBoardSocket() const {
     return properties.boardSocket;
 }
 
-void ColorCamera::setCamera(std::string name) {
+void ColorCamera::setCamera(const std::string& name) {
     properties.cameraName = name;
 }
 
@@ -208,7 +208,7 @@ void ColorCamera::setPreviewSize(int width, int height) {
     properties.previewHeight = height;
 }
 
-void ColorCamera::setPreviewSize(std::tuple<int, int> size) {
+void ColorCamera::setPreviewSize(const std::tuple<int, int>& size) {
     setPreviewSize(std::get<0>(size), std::get<1>(size));
 }
 
@@ -218,7 +218,7 @@ void ColorCamera::setVideoSize(int width, int height) {
     properties.videoHeight = height;
 }
 
-void ColorCamera::setVideoSize(std::tuple<int, int> size) {
+void ColorCamera::setVideoSize(const std::tuple<int, int>& size) {
     setVideoSize(std::get<0>(size), std::get<1>(size));
 }
 
@@ -228,7 +228,7 @@ void ColorCamera::setStillSize(int width, int height) {
     properties.stillHeight = height;
 }
 
-void ColorCamera::setStillSize(std::tuple<int, int> size) {
+void ColorCamera::setStillSize(const std::tuple<int, int>& size) {
     setStillSize(std::get<0>(size), std::get<1>(size));
 }
 
@@ -248,11 +248,11 @@ void ColorCamera::setIspScale(int numerator, int denominator) {
     setIspScale(numerator, denominator, numerator, denominator);
 }
 
-void ColorCamera::setIspScale(std::tuple<int, int> scale) {
+void ColorCamera::setIspScale(const std::tuple<int, int>& scale) {
     setIspScale(std::get<0>(scale), std::get<1>(scale));
 }
 
-void ColorCamera::setIspScale(std::tuple<int, int> horizScale, std::tuple<int, int> vertScale) {
+void ColorCamera::setIspScale(const std::tuple<int, int>& horizScale, const std::tuple<int, int>& vertScale) {
     setIspScale(std::get<0>(horizScale), std::get<1>(horizScale), std::get<0>(vertScale), std::get<1>(vertScale));
 }
 

--- a/src/pipeline/node/DetectionNetwork.cpp
+++ b/src/pipeline/node/DetectionNetwork.cpp
@@ -174,7 +174,7 @@ void DetectionNetwork::setBlobPath(const std::filesystem::path& path) {
     detectionParser->setBlobPath(path);
 }
 
-void DetectionNetwork::setBlob(OpenVINO::Blob blob) {
+void DetectionNetwork::setBlob(const OpenVINO::Blob& blob) {
     neuralNetwork->setBlob(blob);
     detectionParser->setBlob(blob);
 }
@@ -205,15 +205,15 @@ void DetectionNetwork::setNumShavesPerInferenceThread(int numShavesPerThread) {
     neuralNetwork->setNumShavesPerInferenceThread(numShavesPerThread);
 }
 
-void DetectionNetwork::setBackend(std::string backend) {
+void DetectionNetwork::setBackend(const std::string& backend) {
     neuralNetwork->setBackend(backend);
 }
 
-void DetectionNetwork::setBackendProperties(std::map<std::string, std::string> props) {
+void DetectionNetwork::setBackendProperties(const std::map<std::string, std::string>& props) {
     neuralNetwork->setBackendProperties(props);
 }
 
-int DetectionNetwork::getNumInferenceThreads() {
+int DetectionNetwork::getNumInferenceThreads() const {
     return neuralNetwork->getNumInferenceThreads();
 }
 

--- a/src/pipeline/node/DetectionParser.cpp
+++ b/src/pipeline/node/DetectionParser.cpp
@@ -274,7 +274,7 @@ void DetectionParser::setNNArchiveOther(const NNArchive& nnArchive) {
     setConfig(nnArchive.getVersionedConfig());
 }
 
-void DetectionParser::setBlob(OpenVINO::Blob blob) {
+void DetectionParser::setBlob(const OpenVINO::Blob& blob) {
     properties.networkInputs = blob.networkInputs;
 }
 
@@ -286,7 +286,7 @@ void DetectionParser::setBlob(const std::filesystem::path& path) {
     setBlobPath(path);
 }
 
-void DetectionParser::setInputImageSize(std::tuple<int, int> size) {
+void DetectionParser::setInputImageSize(const std::tuple<int, int>& size) {
     setInputImageSize(std::get<0>(size), std::get<1>(size));
 }
 
@@ -305,7 +305,7 @@ void DetectionParser::setNumFramesPool(int numFramesPool) {
     properties.numFramesPool = numFramesPool;
 }
 
-int DetectionParser::getNumFramesPool() {
+int DetectionParser::getNumFramesPool() const {
     return properties.numFramesPool;
 }
 
@@ -313,7 +313,7 @@ void DetectionParser::setNNFamily(DetectionNetworkType type) {
     properties.parser.nnFamily = type;
 }
 
-DetectionNetworkType DetectionParser::getNNFamily() {
+DetectionNetworkType DetectionParser::getNNFamily() const {
     return properties.parser.nnFamily;
 }
 
@@ -333,11 +333,11 @@ void DetectionParser::setCoordinateSize(const int coordinates) {
     properties.parser.coordinates = coordinates;
 }
 
-void DetectionParser::setAnchors(std::vector<float> anchors) {
+void DetectionParser::setAnchors(const std::vector<float>& anchors) {
     properties.parser.anchors = anchors;
 }
 
-void DetectionParser::setAnchorMasks(std::map<std::string, std::vector<int>> anchorMasks) {
+void DetectionParser::setAnchorMasks(const std::map<std::string, std::vector<int>>& anchorMasks) {
     properties.parser.anchorMasks = anchorMasks;
 }
 

--- a/src/pipeline/node/DynamicCalibrationNode.cpp
+++ b/src/pipeline/node/DynamicCalibrationNode.cpp
@@ -421,7 +421,7 @@ DynamicCalibration::ErrorCode DynamicCalibration::computeCoverage() {
     return DynamicCalibration::ErrorCode::OK;
 }
 
-DynamicCalibration::ErrorCode DynamicCalibration::initializePipeline(const std::shared_ptr<dai::Device> daiDevice) {
+DynamicCalibration::ErrorCode DynamicCalibration::initializePipeline(const std::shared_ptr<dai::Device>& daiDevice) {
     logger->trace("Initializing DynamicCalibration pipeline for device: {}", daiDevice->getDeviceId());
 
     auto inSyncGroup = syncInput.get<dai::MessageGroup>();

--- a/src/pipeline/node/ImageAlign.cpp
+++ b/src/pipeline/node/ImageAlign.cpp
@@ -120,10 +120,10 @@ std::string matToString(const cv::Mat& mat) {
     return oss.str();
 }
 
-int shiftDepthImg(std::shared_ptr<dai::ImgFrame> inVec,
-                  std::shared_ptr<dai::ImgFrame> outVec,
-                  std::array<std::array<float, 3>, 3> depthSourceIntrinsics,
-                  std::array<std::array<float, 4>, 4> depthToAlignExtrinsics) {
+int shiftDepthImg(const std::shared_ptr<dai::ImgFrame>& inVec,
+                  const std::shared_ptr<dai::ImgFrame>& outVec,
+                  const std::array<std::array<float, 3>, 3>& depthSourceIntrinsics,
+                  const std::array<std::array<float, 4>, 4>& depthToAlignExtrinsics) {
     int depthLut[65536];
 
     auto& depthIntrinsics = depthSourceIntrinsics;

--- a/src/pipeline/node/ImageManip.cpp
+++ b/src/pipeline/node/ImageManip.cpp
@@ -7,7 +7,7 @@ namespace dai {
 
 namespace node {
 
-inline std::array<float, 9> flatten(std::array<std::array<float, 3>, 3> mat) {
+inline std::array<float, 9> flatten(const std::array<std::array<float, 3>, 3>& mat) {
     return {mat[0][0], mat[0][1], mat[0][2], mat[1][0], mat[1][1], mat[1][2], mat[2][0], mat[2][1], mat[2][2]};
 }
 

--- a/src/pipeline/node/MonoCamera.cpp
+++ b/src/pipeline/node/MonoCamera.cpp
@@ -22,7 +22,7 @@ CameraBoardSocket MonoCamera::getBoardSocket() const {
     return properties.boardSocket;
 }
 
-void MonoCamera::setCamera(std::string name) {
+void MonoCamera::setCamera(const std::string& name) {
     properties.cameraName = name;
 }
 

--- a/src/pipeline/node/NeuralNetwork.cpp
+++ b/src/pipeline/node/NeuralNetwork.cpp
@@ -81,7 +81,7 @@ void NeuralNetwork::decodeModel(const Model& model) {
     setNNArchive(*nnArchive);
 }
 
-ImgFrameCapability NeuralNetwork::getFrameCapability(const NNArchive& nnArchive, std::optional<ImgFrameCapability> expectedCapability) {
+ImgFrameCapability NeuralNetwork::getFrameCapability(const NNArchive& nnArchive, const std::optional<ImgFrameCapability>& expectedCapability) {
     const auto& nnArchiveCfg = nnArchive.getVersionedConfig();
 
     DAI_CHECK_V(nnArchiveCfg.getVersion() == NNArchiveConfigVersion::V1, "Only V1 configs are supported for NeuralNetwork.build method");
@@ -279,15 +279,15 @@ void NeuralNetwork::setNumShavesPerInferenceThread(int numShavesPerThread) {
     properties.numShavesPerThread = numShavesPerThread;
 }
 
-void NeuralNetwork::setBackend(std::string backend) {
+void NeuralNetwork::setBackend(const std::string& backend) {
     properties.backend = backend;
 }
 
-void NeuralNetwork::setBackendProperties(std::map<std::string, std::string> props) {
+void NeuralNetwork::setBackendProperties(const std::map<std::string, std::string>& props) {
     properties.backendProperties = props;
 }
 
-int NeuralNetwork::getNumInferenceThreads() {
+int NeuralNetwork::getNumInferenceThreads() const {
     return properties.numThreads;
 }
 

--- a/src/pipeline/node/ObjectTracker.cpp
+++ b/src/pipeline/node/ObjectTracker.cpp
@@ -30,7 +30,7 @@ void ObjectTracker::setMaxObjectsToTrack(std::int32_t maxObjectsToTrack) {
     properties.maxObjectsToTrack = maxObjectsToTrack;
 }
 
-void ObjectTracker::setDetectionLabelsToTrack(std::vector<std::uint32_t> labels) {
+void ObjectTracker::setDetectionLabelsToTrack(const std::vector<std::uint32_t>& labels) {
     properties.detectionLabelsToTrack = labels;
 }
 
@@ -77,7 +77,7 @@ bool ObjectTracker::runOnHost() const {
 }
 
 #ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
-cv::Rect toCvRect(Rect r) {
+cv::Rect toCvRect(const Rect& r) {
     if(r.isNormalized()) throw std::runtime_error("dai::Rect must not be normalized in conversion to cv::Rect");
     return {(int)r.x, (int)r.y, (int)r.width, (int)r.height};
 }

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -33,7 +33,7 @@ namespace node {
 
 // ── Impl: apply / get methods ──
 
-void PointCloud::Impl::setLogger(std::shared_ptr<::spdlog::logger> log) {
+void PointCloud::Impl::setLogger(const std::shared_ptr<::spdlog::logger>& log) {
     logger = log;
 }
 
@@ -616,7 +616,7 @@ void PointCloud::initialize(const ImgFrame& depthFrame, const PointCloudConfig& 
 // Processing helpers (depth-only and colorized paths)
 //------------------------------------------------------------------
 
-void PointCloud::processDepthOnly(std::shared_ptr<ImgFrame> depthFrame, std::shared_ptr<PointCloudData> pc, bool organized) {
+void PointCloud::processDepthOnly(const std::shared_ptr<ImgFrame>& depthFrame, const std::shared_ptr<PointCloudData>& pc, bool organized) {
     const auto width = depthFrame->getWidth();
     const auto height = depthFrame->getHeight();
     const auto* depthData = depthFrame->getData().data();
@@ -640,9 +640,9 @@ void PointCloud::processDepthOnly(std::shared_ptr<ImgFrame> depthFrame, std::sha
     pc->setPoints(std::move(points));
 }
 
-void PointCloud::processColorized(std::shared_ptr<ImgFrame> depthFrame,
-                                  std::shared_ptr<ImgFrame> colorFrame,
-                                  std::shared_ptr<PointCloudData> pc,
+void PointCloud::processColorized(const std::shared_ptr<ImgFrame>& depthFrame,
+                                  const std::shared_ptr<ImgFrame>& colorFrame,
+                                  const std::shared_ptr<PointCloudData>& pc,
                                   bool organized) {
     const auto width = depthFrame->getWidth();
     const auto height = depthFrame->getHeight();

--- a/src/pipeline/node/SpatialDetectionNetwork.cpp
+++ b/src/pipeline/node/SpatialDetectionNetwork.cpp
@@ -282,7 +282,7 @@ void SpatialDetectionNetwork::setBlobPath(const std::filesystem::path& path) {
     detectionParser->setBlobPath(path);
 }
 
-void SpatialDetectionNetwork::setBlob(OpenVINO::Blob blob) {
+void SpatialDetectionNetwork::setBlob(const OpenVINO::Blob& blob) {
     neuralNetwork->setBlob(blob);
     detectionParser->setBlob(blob);
 }
@@ -313,11 +313,11 @@ void SpatialDetectionNetwork::setNumShavesPerInferenceThread(int numShavesPerThr
     neuralNetwork->setNumShavesPerInferenceThread(numShavesPerThread);
 }
 
-void SpatialDetectionNetwork::setBackend(std::string backend) {
+void SpatialDetectionNetwork::setBackend(const std::string& backend) {
     neuralNetwork->setBackend(backend);
 }
 
-void SpatialDetectionNetwork::setBackendProperties(std::map<std::string, std::string> props) {
+void SpatialDetectionNetwork::setBackendProperties(const std::map<std::string, std::string>& props) {
     neuralNetwork->setBackendProperties(props);
 }
 

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -14,7 +14,7 @@
 namespace dai {
 namespace node {
 
-std::shared_ptr<StereoDepth> StereoDepth::build(bool autoCreateCameras, PresetMode presetMode, std::pair<int, int> size, std::optional<float> fps) {
+std::shared_ptr<StereoDepth> StereoDepth::build(bool autoCreateCameras, PresetMode presetMode, const std::pair<int, int>& size, std::optional<float> fps) {
     if(!autoCreateCameras) {
         return std::static_pointer_cast<StereoDepth>(shared_from_this());
     }
@@ -91,7 +91,7 @@ void StereoDepth::setInputResolution(int width, int height) {
     properties.width = width;
     properties.height = height;
 }
-void StereoDepth::setInputResolution(std::tuple<int, int> resolution) {
+void StereoDepth::setInputResolution(const std::tuple<int, int>& resolution) {
     setInputResolution(std::get<0>(resolution), std::get<1>(resolution));
 }
 void StereoDepth::setOutputSize(int width, int height) {

--- a/src/pipeline/node/UVC.cpp
+++ b/src/pipeline/node/UVC.cpp
@@ -7,15 +7,15 @@ UVC::UVC(std::unique_ptr<Properties> props) : DeviceNodeCRTP<DeviceNode, UVC, UV
 
 UVC::~UVC() = default;
 
-void UVC::setGpiosOnInit(std::unordered_map<int, int> list) {
+void UVC::setGpiosOnInit(const std::unordered_map<int, int>& list) {
     properties.gpioInit = list;
 }
 
-void UVC::setGpiosOnStreamOn(std::unordered_map<int, int> list) {
+void UVC::setGpiosOnStreamOn(const std::unordered_map<int, int>& list) {
     properties.gpioStreamOn = list;
 }
 
-void UVC::setGpiosOnStreamOff(std::unordered_map<int, int> list) {
+void UVC::setGpiosOnStreamOff(const std::unordered_map<int, int>& list) {
     properties.gpioStreamOff = list;
 }
 

--- a/src/pipeline/node/Warp.cpp
+++ b/src/pipeline/node/Warp.cpp
@@ -2,7 +2,7 @@
 namespace dai {
 namespace node {
 
-void Warp::setOutputSize(std::tuple<int, int> size) {
+void Warp::setOutputSize(const std::tuple<int, int>& size) {
     properties.outputWidth = std::get<0>(size);
     properties.outputHeight = std::get<1>(size);
 }
@@ -72,7 +72,7 @@ void Warp::setWarpMesh(const std::vector<std::pair<float, float>>& meshData, int
     setWarpMesh(reinterpret_cast<const float*>(meshData.data()), static_cast<int>(meshData.size()), width, height);
 }
 
-void Warp::setHwIds(std::vector<int> ids) {
+void Warp::setHwIds(const std::vector<int>& ids) {
     properties.warpHwIds = ids;
 }
 

--- a/src/pipeline/node/host/RGBD.cpp
+++ b/src/pipeline/node/host/RGBD.cpp
@@ -245,7 +245,7 @@ std::shared_ptr<RGBD> RGBD::build() {
     return std::static_pointer_cast<RGBD>(shared_from_this());
 }
 
-std::shared_ptr<RGBD> RGBD::build(bool autocreate, StereoDepth::PresetMode mode, std::pair<int, int> size, std::optional<float> fps) {
+std::shared_ptr<RGBD> RGBD::build(bool autocreate, StereoDepth::PresetMode mode, const std::pair<int, int>& size, std::optional<float> fps) {
     if(!autocreate) {
         return std::static_pointer_cast<RGBD>(shared_from_this());
     }
@@ -314,13 +314,13 @@ std::shared_ptr<RGBD> RGBD::build(bool autocreate, StereoDepth::PresetMode mode,
 
 std::shared_ptr<RGBD> RGBD::build(const std::shared_ptr<Camera>& camera,
                                   const DepthSource& depthSource,
-                                  std::pair<int, int> frameSize,
+                                  const std::pair<int, int>& frameSize,
                                   std::optional<float> fps) {
     alignDepth(depthSource, camera, frameSize, fps);
     return build();
 }
 
-void RGBD::initialize(std::shared_ptr<MessageGroup> frames) {
+void RGBD::initialize(const std::shared_ptr<MessageGroup>& frames) {
     // Initialize the camera intrinsics
     // Check if width, width and cameraID match
     auto colorFrame = std::dynamic_pointer_cast<ImgFrame>(frames->group.at(inColor.getName()));
@@ -467,7 +467,7 @@ void RGBD::alignDepth(const DepthSource& depthSource, const std::shared_ptr<Came
 
 void RGBD::alignDepthImpl(const std::shared_ptr<StereoDepth>& stereo,
                           const std::shared_ptr<Camera>& camera,
-                          std::pair<int, int> frameSize,
+                          const std::pair<int, int>& frameSize,
                           std::optional<float> fps) {
     auto pipeline = getParentPipeline();
     auto device = pipeline.getDefaultDevice();
@@ -506,7 +506,7 @@ void RGBD::alignDepthImpl(const std::shared_ptr<StereoDepth>& stereo,
 
 void RGBD::alignDepthImpl(const std::shared_ptr<NeuralDepth>& neuralDepth,
                           const std::shared_ptr<Camera>& camera,
-                          std::pair<int, int> frameSize,
+                          const std::pair<int, int>& frameSize,
                           std::optional<float> fps) {
     auto pipeline = getParentPipeline();
     auto device = pipeline.getDefaultDevice();
@@ -528,7 +528,8 @@ void RGBD::alignDepthImpl(const std::shared_ptr<NeuralDepth>& neuralDepth,
     align->outputAligned.link(inDepth);
 }
 
-void RGBD::alignDepthImpl(const std::shared_ptr<ToF>& tof, const std::shared_ptr<Camera>& camera, std::pair<int, int> frameSize, std::optional<float> fps) {
+void RGBD::alignDepthImpl(const std::shared_ptr<ToF>& tof, const std::shared_ptr<Camera>& camera,
+                          const std::pair<int, int>& frameSize, std::optional<float> fps) {
     auto pipeline = getParentPipeline();
     auto device = pipeline.getDefaultDevice();
 

--- a/src/pipeline/node/internal/PipelineEventAggregation.cpp
+++ b/src/pipeline/node/internal/PipelineEventAggregation.cpp
@@ -28,7 +28,7 @@ class NodeEventAggregation {
     uint32_t eventWaitWindow;
 
    public:
-    NodeEventAggregation(uint32_t windowSize, uint32_t statsUpdateIntervalMs, uint32_t eventWaitWindow, std::shared_ptr<spdlog::async_logger> logger)
+    NodeEventAggregation(uint32_t windowSize, uint32_t statsUpdateIntervalMs, uint32_t eventWaitWindow, const std::shared_ptr<spdlog::async_logger>& logger)
         : logger(logger),
           windowSize(windowSize),
           statsUpdateIntervalMs(statsUpdateIntervalMs),
@@ -454,7 +454,7 @@ class PipelineEventHandler {
                          uint32_t aggregationWindowSize,
                          uint32_t statsUpdateIntervalMs,
                          uint32_t eventWaitWindow,
-                         std::shared_ptr<spdlog::async_logger> logger)
+                         const std::shared_ptr<spdlog::async_logger>& logger)
         : inputs(inputs),
           aggregationWindowSize(aggregationWindowSize),
           statsUpdateIntervalMs(statsUpdateIntervalMs),
@@ -499,7 +499,7 @@ class PipelineEventHandler {
         running = false;
         if(thread.joinable()) thread.join();
     }
-    bool getState(std::shared_ptr<PipelineState> outState, bool sendEvents) {
+    bool getState(const std::shared_ptr<PipelineState>& outState, bool sendEvents) {
         // Copy over node states and return if any were recently updated
         std::shared_lock lock(mutex);
         bool updated = false;
@@ -530,7 +530,7 @@ class TraceOutputHandler {
     std::shared_ptr<spdlog::async_logger> logger;
 
    public:
-    TraceOutputHandler(Node::Output& outTrace, PipelineEventHandler& handler, std::shared_ptr<spdlog::async_logger> logger)
+    TraceOutputHandler(Node::Output& outTrace, PipelineEventHandler& handler, const std::shared_ptr<spdlog::async_logger>& logger)
         : outTrace(outTrace), handler(handler), logger(logger) {}
 
     void run(const std::optional<PipelineEventAggregationConfig>& traceOutputConfig) {

--- a/src/pipeline/utilities/NNDataViewer.hpp
+++ b/src/pipeline/utilities/NNDataViewer.hpp
@@ -20,7 +20,7 @@ class NNDataViewer {
 
     FactorsBefore factorsBefore;
 
-    NNDataViewer(dai::TensorInfo tensor, std::shared_ptr<dai::Memory> data, std::shared_ptr<spdlog::async_logger> logger)
+    NNDataViewer(const dai::TensorInfo& tensor, const std::shared_ptr<dai::Memory>& data, const std::shared_ptr<spdlog::async_logger>& logger)
         : data{data}, tensor{tensor}, logger{logger} {};
     bool build() {
         if(tensor.strides.size() < 2) {

--- a/src/remote_connection/RemoteConnectionImpl.cpp
+++ b/src/remote_connection/RemoteConnectionImpl.cpp
@@ -146,16 +146,16 @@ bool RemoteConnectionImpl::initWebsocketServer(const std::string& address, uint1
         return false;
     }
     foxglove::ServerHandlers<websocketpp::connection_hdl> hdlrs;
-    hdlrs.subscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle clientHandle) {
+    hdlrs.subscribeHandler = [&](foxglove::ChannelId chanId, const foxglove::ConnHandle& clientHandle) {
         const auto clientStr = server->remoteEndpointString(clientHandle);
         logger::info("Client {} subscribed to {}", clientStr, chanId);
     };
-    hdlrs.unsubscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle clientHandle) {
+    hdlrs.unsubscribeHandler = [&](foxglove::ChannelId chanId, const foxglove::ConnHandle& clientHandle) {
         const auto clientStr = server->remoteEndpointString(clientHandle);
         logger::info("Client {} unsubscribed from {}", clientStr, chanId);
     };
 
-    hdlrs.serviceRequestHandler = [&](const foxglove::ServiceRequest& request, foxglove::ConnHandle clientHandle) {
+    hdlrs.serviceRequestHandler = [&](const foxglove::ServiceRequest& request, const foxglove::ConnHandle& clientHandle) {
         logger::info("Received service request from client {}", server->remoteEndpointString(clientHandle));
         auto it = serviceMap.find(request.serviceId);
         if(it == serviceMap.end()) {
@@ -369,7 +369,7 @@ void RemoteConnectionImpl::exposeTopicGroupsService() {
     assert(ids.size() == 1);
     auto id = ids[0];
 
-    serviceMap[id] = [this](foxglove::ServiceResponse request) {
+    serviceMap[id] = [this](const foxglove::ServiceResponse& request) {
         (void)request;
         auto response = foxglove::ServiceResponse();
         auto topicGroups = std::unordered_map<std::string, std::string>();
@@ -476,7 +476,7 @@ void RemoteConnectionImpl::exposePipelineService(const Pipeline& pipeline) {
             node[1]["properties"] = nlohmann::json::parse(node[1]["properties"].get<std::vector<uint8_t>>());
         }
         auto serializedPipelineStr = serializedPipeline.dump();
-        serviceMap[id] = [serializedPipelineStr](foxglove::ServiceResponse request) {
+        serviceMap[id] = [serializedPipelineStr](const foxglove::ServiceResponse& request) {
             (void)request;
             auto response = foxglove::ServiceResponse();
             response.data = std::vector<uint8_t>(serializedPipelineStr.begin(), serializedPipelineStr.end());
@@ -491,7 +491,7 @@ void RemoteConnectionImpl::exposePipelineService(const Pipeline& pipeline) {
         nlohmann::json j;
         j["pipeline"] = pipeline.getPipelineSchema(SerializationType::JSON, false);
         auto serializedPipelineStr = j.dump();
-        serviceMap[id] = [serializedPipelineStr](foxglove::ServiceResponse request) {
+        serviceMap[id] = [serializedPipelineStr](const foxglove::ServiceResponse& request) {
             (void)request;
             auto response = foxglove::ServiceResponse();
             response.data = std::vector<uint8_t>(serializedPipelineStr.begin(), serializedPipelineStr.end());
@@ -506,7 +506,7 @@ void RemoteConnectionImpl::exposePipelineService(const Pipeline& pipeline) {
         if(pipeline.isPipelineDebuggingEnabled()) {
             PipelineStateApi pipelineStateApi(pipeline.getPipelineStateOut(), pipeline.getPipelineStateRequest(), pipeline.getAllNodes());
 
-            serviceMap[id] = [pipelineStateApi](foxglove::ServiceResponse request) mutable {
+            serviceMap[id] = [pipelineStateApi](const foxglove::ServiceResponse& request) mutable {
                 (void)request;
                 std::string stateStr;
                 try {
@@ -520,7 +520,7 @@ void RemoteConnectionImpl::exposePipelineService(const Pipeline& pipeline) {
                 return response;
             };
         } else {
-            serviceMap[id] = [](foxglove::ServiceResponse request) {
+            serviceMap[id] = [](const foxglove::ServiceResponse& request) {
                 (void)request;
                 std::string stateStr = R"({"error": "Pipeline debugging disabled. Cannot get pipeline state."})";
                 auto response = foxglove::ServiceResponse();
@@ -608,7 +608,7 @@ void RemoteConnectionImpl::registerBinaryService(const std::string& serviceName,
     auto ids = server->addServices({service});
     assert(ids.size() == 1);
     auto id = ids[0];
-    serviceMap[id] = [callback](foxglove::ServiceResponse request) {
+    serviceMap[id] = [callback](const foxglove::ServiceResponse& request) {
         auto response = callback(request.data);
         foxglove::ServiceResponse ret;
         ret.data = std::vector<uint8_t>(response.begin(), response.end());

--- a/src/utility/ArchiveUtil.cpp
+++ b/src/utility/ArchiveUtil.cpp
@@ -41,7 +41,7 @@ void ArchiveUtil::init(NNArchiveEntry::Compression format) {
     }
 }
 
-void ArchiveUtil::unpackArchiveInDirectory(const std::filesystem::path directory) {
+void ArchiveUtil::unpackArchiveInDirectory(const std::filesystem::path& directory) {
     struct archive* a = getA();
     struct archive_entry* entry = nullptr;
     std::filesystem::create_directories(directory);

--- a/src/utility/ArchiveUtil.hpp
+++ b/src/utility/ArchiveUtil.hpp
@@ -30,7 +30,7 @@ class ArchiveUtil {
     struct archive* getA();
     // Throws on error
     void readEntry(struct archive_entry* entry, std::vector<uint8_t>& out);
-    void unpackArchiveInDirectory(const std::filesystem::path directory);
+    void unpackArchiveInDirectory(const std::filesystem::path& directory);
     // Reads entryName from archive to curEntry member.
     // Returns true if entry found, false otherwise.
     // Throws on other errors

--- a/src/utility/EepromDataParser.cpp
+++ b/src/utility/EepromDataParser.cpp
@@ -19,7 +19,7 @@ std::vector<std::string> split(const std::string& s, char delimiter) {
     return tokens;
 }
 
-std::string parseProductName(EepromData eeprom, EepromData eepromFactory) {
+std::string parseProductName(const EepromData& eeprom, const EepromData& eepromFactory) {
     std::string productName;
     if((productName = eepromFactory.productName).empty()) {
         if((productName = eeprom.productName).empty()) {
@@ -43,7 +43,7 @@ std::string parseProductName(EepromData eeprom, EepromData eepromFactory) {
     return productName;
 }
 
-std::string parseDeviceName(EepromData eeprom, EepromData eepromFactory) {
+std::string parseDeviceName(const EepromData& eeprom, const EepromData& eepromFactory) {
     std::string deviceName;
     if((deviceName = eepromFactory.deviceName).empty()) {
         if((deviceName = eeprom.deviceName).empty()) {

--- a/src/utility/EepromDataParser.hpp
+++ b/src/utility/EepromDataParser.hpp
@@ -15,13 +15,13 @@ std::vector<std::string> split(const std::string& s, char delimiter);
 /// @param eeprom EepromData containing fields to parse product name from
 /// @param eepromFactory Additional factory eeprom which takes precedence when parsing
 /// @return string contaning product name or empty
-std::string parseProductName(EepromData eeprom, EepromData eepromFactory = {});
+std::string parseProductName(const EepromData& eeprom, const EepromData& eepromFactory = {});
 
 /// @brief Parses device name from given EepromData combination
 /// @param eeprom EepromData containing fields to parse device name from
 /// @param eepromFactory Additional factory eeprom which takes precedence when parsing
 /// @return string contaning device name or empty
-std::string parseDeviceName(EepromData eeprom, EepromData eepromFactory = {});
+std::string parseDeviceName(const EepromData& eeprom, const EepromData& eepromFactory = {});
 
 }  // namespace utility
 }  // namespace dai

--- a/src/utility/H26xParsers.cpp
+++ b/src/utility/H26xParsers.cpp
@@ -79,7 +79,7 @@ SliceType getSliceType(uint num, Profile p) {
     }
 }
 
-bool scodeEq(buf& bs, uint pos, buf code) {
+bool scodeEq(buf& bs, uint pos, buf& code) {
     if(bs.size() - pos > code.size()) {
         for(uint i = 0; i < code.size(); ++i) {
             if(bs[pos + i] != code[i]) return false;

--- a/src/utility/ImageManipImpl.cpp
+++ b/src/utility/ImageManipImpl.cpp
@@ -52,7 +52,7 @@ void transformOpenCV(const uint8_t* src,
                      const size_t dstStride,
                      const uint16_t numChannels,
                      const uint16_t bpp,
-                     const std::array<std::array<float, 3>, 3> matrix,
+                     const std::array<std::array<float, 3>, 3>& matrix,
                      const std::vector<uint32_t>& background,
                      const dai::impl::FrameSpecs& srcImgSpecs,
                      const size_t sourceMinX,
@@ -161,7 +161,7 @@ bool transformFastCV(const uint8_t* src,
                      const size_t dstStride,
                      const uint16_t numChannels,
                      const uint16_t bpp,
-                     const std::array<std::array<float, 3>, 3> matrix,
+                     const std::array<std::array<float, 3>, 3>& matrix,
                      const std::vector<uint32_t>& background,
                      const dai::impl::FrameSpecs& srcImgSpecs,
                      const size_t sourceMinX,
@@ -392,7 +392,7 @@ dai::impl::FrameSpecs dai::impl::getDstFrameSpecs(size_t width, size_t height, d
     return specs;
 }
 
-dai::impl::FrameSpecs dai::impl::getCcDstFrameSpecs(FrameSpecs srcSpecs, dai::ImgFrame::Type from, dai::ImgFrame::Type to) {
+dai::impl::FrameSpecs dai::impl::getCcDstFrameSpecs(const FrameSpecs& srcSpecs, dai::ImgFrame::Type from, dai::ImgFrame::Type to) {
     if(from == to)
         return srcSpecs;
     else
@@ -480,7 +480,7 @@ bool dai::impl::getFrameTypeInfo(dai::ImgFrame::Type outFrameType, int& outNumPl
     return true;
 }
 
-std::tuple<float, float, float, float> dai::impl::getOuterRect(const std::vector<std::array<float, 2>> points) {
+std::tuple<float, float, float, float> dai::impl::getOuterRect(const std::vector<std::array<float, 2>>& points) {
     float minx = points[0][0];
     float maxx = points[0][0];
     float miny = points[0][1];
@@ -539,7 +539,7 @@ std::array<std::array<float, 3>, 3> dai::impl::getResizeMat(Resize o, float widt
 
 void dai::impl::getOutputSizeFromCorners(const std::array<std::array<float, 2>, 4>& corners,
                                          const bool center,
-                                         const std::array<std::array<float, 3>, 3> transformInv,
+                                         const std::array<std::array<float, 3>, 3>& transformInv,
                                          const uint32_t srcWidth,
                                          const uint32_t srcHeight,
                                          uint32_t& outputWidth,
@@ -631,8 +631,8 @@ void dai::impl::getTransformImpl(const ManipOp& op,
                            mat = matmul({{{1, 0, moveX}, {0, 1, moveY}, {0, 0, 1}}}, mat);
                        }
                    },
-                   [&](Resize o) { mat = getResizeMat(o, width, height, outputWidth, outputHeight); },
-                   [&](Flip o) {
+                   [&](const Resize& o) { mat = getResizeMat(o, width, height, outputWidth, outputHeight); },
+                   [&](const Flip& o) {
                        float moveX = centerX;
                        float moveY = centerY;
                        switch(o.direction) {
@@ -690,8 +690,8 @@ void dai::impl::getTransformImpl(const ManipOp& op,
                        mat = matrix::getHomographyMatrix(o.src, o.dst);
 #endif
                    },
-                   [&](Affine o) { mat = {{{o.matrix[0], o.matrix[1], 0}, {o.matrix[2], o.matrix[3], 0}, {0, 0, 1}}}; },
-                   [&](Perspective o) {
+                   [&](const Affine& o) { mat = {{{o.matrix[0], o.matrix[1], 0}, {o.matrix[2], o.matrix[3], 0}, {0, 0, 1}}}; },
+                   [&](const Perspective& o) {
                        mat = {{{o.matrix[0], o.matrix[1], o.matrix[2]}, {o.matrix[3], o.matrix[4], o.matrix[5]}, {o.matrix[6], o.matrix[7], o.matrix[8]}}};
                    },
                    [&](Crop o) {
@@ -845,7 +845,7 @@ size_t dai::impl::getAlignedOutputFrameSize(ImgFrame::Type type, size_t width, s
 }
 
 #ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
-bool dai::impl::UndistortOpenCvImpl::validMatrix(std::array<float, 9> matrix) const {
+bool dai::impl::UndistortOpenCvImpl::validMatrix(const std::array<float, 9>& matrix) const {
     return !floatEq(matrix[0], 0) && floatEq(matrix[1], 0) && floatEq(matrix[3], 0) && !floatEq(matrix[4], 0) && floatEq(matrix[6], 0) && floatEq(matrix[7], 0)
            && floatEq(matrix[8], 1);
 }
@@ -3050,7 +3050,7 @@ void WarpH::buildUndistort(bool enable,
 }
 
 void WarpH::transform(const std::shared_ptr<OffsetMemory>& src,
-                      std::shared_ptr<OffsetMemory> dst,
+                      const std::shared_ptr<OffsetMemory>& dst,
                       const size_t srcWidth,
                       const size_t srcHeight,
                       const size_t srcStride,
@@ -3059,7 +3059,7 @@ void WarpH::transform(const std::shared_ptr<OffsetMemory>& src,
                       const size_t dstStride,
                       const uint16_t numChannels,
                       const uint16_t bpp,
-                      const std::array<std::array<float, 3>, 3> matrix,
+                      const std::array<std::array<float, 3>, 3>& matrix,
                       const std::vector<uint32_t>& background) {
 #ifdef DEPTHAI_IMAGEMANIPV2_OPENCV
     transformOpenCV(src->getOffsetData().data(),

--- a/src/utility/Initialization.cpp
+++ b/src/utility/Initialization.cpp
@@ -61,7 +61,7 @@ bool initialize(void* javavm) {
     return initialize(nullptr, false, javavm);
 }
 
-bool initialize(std::string additionalInfo, bool installSignalHandler, void* javavm) {
+bool initialize(const std::string& additionalInfo, bool installSignalHandler, void* javavm) {
     return initialize(additionalInfo.c_str(), installSignalHandler, javavm);
 }
 

--- a/src/utility/ObjectTrackerImpl.cpp
+++ b/src/utility/ObjectTrackerImpl.cpp
@@ -114,7 +114,7 @@ class OCSTracker::State {
         KalmanFilterNew() = default;
         KalmanFilterNew(int dim_x_, int dim_z_, FilterType filterType_);
         void predict();
-        void update(Eigen::VectorXf z_);
+        void update(const Eigen::VectorXf& z_);
         void freeze();
         void unfreeze();
         KalmanFilterNew& operator=(const KalmanFilterNew&) = delete;
@@ -293,7 +293,7 @@ class OCSTracker::State {
                    int min_hits_ = 3,
                    float iou_threshold_ = 0.3,
                    int delta_t_ = 3,
-                   std::string asso_func_ = "iou",
+                   const std::string& asso_func_ = "iou",
                    float inertia_ = 0.2,
                    bool use_byte_ = false);
 
@@ -359,7 +359,7 @@ class OCSTracker::State {
           bool track_by_class_ = false,
           uint32_t max_trackers_ = 100,
           int delta_t_ = 3,
-          std::string asso_func_ = "iou",
+          const std::string& asso_func_ = "iou",
           float inertia_ = 0.2,
           bool use_byte_ = false,
           bool use_spatial_association_ = false,
@@ -557,7 +557,7 @@ OCSTracker::State::ClassState::ClassState(State* parent_,
                                           int min_hits_,
                                           float iou_threshold_,
                                           int delta_t_,
-                                          std::string asso_func_,
+                                          const std::string& asso_func_,
                                           float inertia_,
                                           bool use_byte_) {
     /*Sets key parameters for SORT*/
@@ -986,7 +986,7 @@ OCSTracker::State::State(float det_thresh_,
                          bool track_by_class_,
                          uint32_t max_trackers_,
                          int delta_t_,
-                         std::string asso_func_,
+                         const std::string& asso_func_,
                          float inertia_,
                          bool use_byte_,
                          bool use_spatial_association_,
@@ -1324,7 +1324,7 @@ Q : np.array(dim_x, dim_x), scalar, or None
     x_prior = x;
     P_prior = P;
 }
-void OCSTracker::State::KalmanFilterNew::update(Eigen::VectorXf z_) {
+void OCSTracker::State::KalmanFilterNew::update(const Eigen::VectorXf& z_) {
     /*
     Add a new measurement (z) to the Kalman filter.
     If z is None, nothing is computed. However, x_post and P_post are

--- a/src/utility/PipelineImplHelper.cpp
+++ b/src/utility/PipelineImplHelper.cpp
@@ -15,7 +15,7 @@
 namespace dai {
 namespace utility {
 
-void PipelineImplHelper::setupHolisticRecordAndReplay(std::weak_ptr<PipelineImpl> pipelineWeak) {
+void PipelineImplHelper::setupHolisticRecordAndReplay(const std::weak_ptr<PipelineImpl>& pipelineWeak) {
     auto pipeline = pipelineWeak.lock();
     if(!pipeline) throw std::runtime_error("PipelineImplHelper: Pipeline is no longer available.");
 
@@ -166,7 +166,7 @@ void PipelineImplHelper::finishHolisticRecordAndReplay(PipelineImpl* pipeline) {
         pipeline->recordConfig.state = RecordConfig::RecordReplayState::NONE;
     }
 }
-void PipelineImplHelper::setupPipelineDebuggingPre(std::weak_ptr<PipelineImpl> pipelineWeak) {
+void PipelineImplHelper::setupPipelineDebuggingPre(const std::weak_ptr<PipelineImpl>& pipelineWeak) {
     auto pipeline = pipelineWeak.lock();
     if(!pipeline) throw std::runtime_error("PipelineImplHelper: Pipeline is no longer available.");
 
@@ -234,7 +234,7 @@ void PipelineImplHelper::setupPipelineDebuggingPre(std::weak_ptr<PipelineImpl> p
         }
     }
 }
-void PipelineImplHelper::setupPipelineDebuggingPost(std::weak_ptr<PipelineImpl> pipelineWeak,
+void PipelineImplHelper::setupPipelineDebuggingPost(const std::weak_ptr<PipelineImpl>& pipelineWeak,
                                                     std::unordered_map<dai::Node::Output*, node::internal::XLinkOutBridge>& bridgesOut,
                                                     std::unordered_map<dai::Node::Input*, node::internal::XLinkInBridge>& bridgesIn) {
     auto pipeline = pipelineWeak.lock();

--- a/src/utility/PipelineImplHelper.hpp
+++ b/src/utility/PipelineImplHelper.hpp
@@ -7,10 +7,10 @@ namespace utility {
 
 class PipelineImplHelper {
    public:
-    static void setupHolisticRecordAndReplay(std::weak_ptr<PipelineImpl> pipelineWeak);
+    static void setupHolisticRecordAndReplay(const std::weak_ptr<PipelineImpl>& pipelineWeak);
     static void finishHolisticRecordAndReplay(PipelineImpl* pipeline);
-    static void setupPipelineDebuggingPre(std::weak_ptr<PipelineImpl> pipelineWeak);
-    static void setupPipelineDebuggingPost(std::weak_ptr<PipelineImpl> pipelineWeak,
+    static void setupPipelineDebuggingPre(const std::weak_ptr<PipelineImpl>& pipelineWeak);
+    static void setupPipelineDebuggingPost(const std::weak_ptr<PipelineImpl>& pipelineWeak,
                                            std::unordered_map<dai::Node::Output*, node::internal::XLinkOutBridge>&,
                                            std::unordered_map<dai::Node::Input*, node::internal::XLinkInBridge>&);
 };

--- a/src/utility/Platform.cpp
+++ b/src/utility/Platform.cpp
@@ -45,7 +45,7 @@
 namespace dai {
 namespace platform {
 
-uint32_t getIPv4AddressAsBinary(std::string address) {
+uint32_t getIPv4AddressAsBinary(const std::string& address) {
     uint32_t binary = 0;
     if(address == "") {
         // inet_addr returns 0xFFFFFFFF if addr is ""

--- a/src/utility/Platform.cpp
+++ b/src/utility/Platform.cpp
@@ -46,7 +46,6 @@
 namespace dai {
 namespace platform {
 
-uint32_t getIPv4AddressAsBinary(const std::string& address) {
 namespace {
 
 std::filesystem::path getEnvPath(const char* name) {
@@ -75,7 +74,7 @@ std::filesystem::path getHomePath() {
 
 }  // namespace
 
-uint32_t getIPv4AddressAsBinary(std::string address) {
+uint32_t getIPv4AddressAsBinary(const std::string& address) {
     uint32_t binary = 0;
     if(address == "") {
         // inet_addr returns 0xFFFFFFFF if addr is ""

--- a/src/utility/Platform.hpp
+++ b/src/utility/Platform.hpp
@@ -21,7 +21,7 @@
 namespace dai {
 namespace platform {
 
-uint32_t getIPv4AddressAsBinary(std::string address);
+uint32_t getIPv4AddressAsBinary(const std::string& address);
 std::string getIPv4AddressAsString(std::uint32_t binary);
 std::string getLocalIpAddress();
 

--- a/src/utility/RecordReplayImpl.hpp
+++ b/src/utility/RecordReplayImpl.hpp
@@ -70,7 +70,7 @@ class ByteRecorder {
         throw std::runtime_error("ByteRecorder not supported without protobuf support");
 #endif
     }
-    void write(std::vector<uint8_t> data) {
+    void write(const std::vector<uint8_t>& data) {
         mcap::Timestamp writeTime = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         mcap::Message msg;
         msg.channelId = channelId;

--- a/src/xlink/XLinkConnection.cpp
+++ b/src/xlink/XLinkConnection.cpp
@@ -140,7 +140,7 @@ constexpr std::chrono::milliseconds XLinkConnection::WAIT_FOR_BOOTUP_TIMEOUT;
 constexpr std::chrono::milliseconds XLinkConnection::WAIT_FOR_CONNECT_TIMEOUT;
 constexpr std::chrono::milliseconds XLinkConnection::POLLING_DELAY_TIME;
 
-bool isInCommaSeparatedVar(std::string list, std::string value) {
+bool isInCommaSeparatedVar(const std::string& list, const std::string& value) {
     const std::string delimiter = ",";
     for(auto& val : utility::splitList(list, delimiter)) {
         if(val == value) {
@@ -294,7 +294,7 @@ std::tuple<bool, DeviceInfo> XLinkConnection::getFirstDevice(XLinkDeviceState_t 
     return {false, {}};
 }
 
-std::tuple<bool, DeviceInfo> XLinkConnection::getDeviceById(std::string deviceId, XLinkDeviceState_t state, bool skipInvalidDevices) {
+std::tuple<bool, DeviceInfo> XLinkConnection::getDeviceById(const std::string& deviceId, XLinkDeviceState_t state, bool skipInvalidDevices) {
     initialize();
 
     DeviceInfo dev;

--- a/src/xlink/XLinkStream.cpp
+++ b/src/xlink/XLinkStream.cpp
@@ -14,7 +14,7 @@ namespace dai {
 constexpr std::chrono::milliseconds XLinkStream::WAIT_FOR_STREAM_RETRY;
 constexpr int XLinkStream::STREAM_OPEN_RETRIES;
 
-XLinkStream::XLinkStream(const std::shared_ptr<XLinkConnection> conn, const std::string& name, std::size_t maxWriteSize) : connection(conn), streamName(name) {
+XLinkStream::XLinkStream(const std::shared_ptr<XLinkConnection>& conn, const std::string& name, std::size_t maxWriteSize) : connection(conn), streamName(name) {
     if(name.empty()) throw std::invalid_argument("Cannot create XLinkStream using empty stream name");
     if(!connection || connection->getLinkId() == -1) throw std::invalid_argument("Cannot create XLinkStream using unconnected XLinkConnection");
 


### PR DESCRIPTION
This commit converts all arguments which are passed by value and then cloned(causing the value pass to be redundant) to be passed by reference instead, and additionally refactors a few non-mutating methods to be const
@moratom this PR per our email discussion, changes in this PR should not break any user space code(I compiled tests and examples with no modifications).

## Purpose
General purpose cleanup of clang lints, specifically "performance-unnecessary-value-param" 

## Specification
None / not applicable

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
cmake with --target all compiles successfully 

## AI Usage
All initial changes to the main lib made directly via clang suggested fixes using IDE. All code modification done in the main library were then carried over to bindings using codellama 34b with every change manually reviewed.

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved const-correctness across calibration, device, pipeline, and node APIs by switching many inputs (strings, tuples, vectors, matrices, and shared pointers) to const-reference/const-qualified forms to reduce copying and tighten read-only contracts.
  * Updated Python bindings to align with the revised overloads (e.g., calibration/intrinsics, image/crop helpers, and pipeline configuration), selecting `const&`-style signatures for better parameter matching.
  * Added const-correctness for selected accessors (e.g., camera misc controls, inference thread count, and frame capability queries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->