### PR TITLE
Add load && save method to ImgFrame

### DIFF
--- a/bindings/python/src/pipeline/datatype/EncodedFrameBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/EncodedFrameBindings.cpp
@@ -120,6 +120,10 @@ void bind_encodedframe(pybind11::module& m, void* pCallstack) {
         .def("setLossless", &EncodedFrame::setLossless, DOC(dai, EncodedFrame, getLossless))
         .def("setProfile", &EncodedFrame::setProfile, DOC(dai, EncodedFrame, getProfile))
         .def("setTransformation", [](EncodedFrame& msg, const ImgTransformation& transformation) { msg.transformation = transformation; });
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+    encodedFrame.def("save", &EncodedFrame::save, py::arg("path"), py::arg("metadataOnly") = false)
+        .def("load", &EncodedFrame::load, py::arg("path"), py::arg("metadataOnly") = false);
+#endif
     //   // add aliases dai.ImgFrame.Type and dai.ImgFrame.Specs
     //   m.attr("EncodedFrame").attr("FrameType") =
     //       m.attr("RawEncodedFrame").attr("FrameType");

--- a/bindings/python/src/pipeline/datatype/IMUDataBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/IMUDataBindings.cpp
@@ -156,4 +156,8 @@ void bind_imudata(pybind11::module& m, void* pCallstack) {
             [](IMUData& imuDta) -> std::vector<IMUPacket>& { return imuDta.packets; },
             [](IMUData& imuDta, std::vector<IMUPacket>& val) { imuDta.packets = val; },
             DOC(dai, IMUData, packets));
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+    imuData.def("save", &IMUData::save, py::arg("path"), py::arg("metadataOnly") = false)
+        .def("load", &IMUData::load, py::arg("path"), py::arg("metadataOnly") = false);
+#endif
 }

--- a/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
@@ -326,6 +326,19 @@ void bind_imgframe(pybind11::module& m, void* pCallstack) {
         .def("setTransformation", &ImgFrame::setTransformation, py::arg("transformation"), DOC(dai, ImgFrame, setTransformation))
         // .def("set", &ImgFrame::set, py::arg("type"), DOC(dai, ImgFrame, set))
         ;
+
+    imgFrame
+        .def(
+            "save",
+            &ImgFrame::save,
+            py::arg("path"),
+            py::arg("metadataOnly") = false)
+        .def(
+            "load",
+            &ImgFrame::load,
+            py::arg("path"),
+            py::arg("metadataOnly") = false);
+
     // add aliases dai.ImgFrame.Type and dai.ImgFrame.Specs
     // m.attr("ImgFrame").attr("Type") = m.attr("RawImgFrame").attr("Type");
     // m.attr("ImgFrame").attr("Specs") = m.attr("RawImgFrame").attr("Specs");

--- a/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/ImgFrameBindings.cpp
@@ -327,6 +327,7 @@ void bind_imgframe(pybind11::module& m, void* pCallstack) {
         // .def("set", &ImgFrame::set, py::arg("type"), DOC(dai, ImgFrame, set))
         ;
 
+#ifdef DEPTHAI_ENABLE_PROTOBUF
     imgFrame
         .def(
             "save",
@@ -338,6 +339,7 @@ void bind_imgframe(pybind11::module& m, void* pCallstack) {
             &ImgFrame::load,
             py::arg("path"),
             py::arg("metadataOnly") = false);
+#endif
 
     // add aliases dai.ImgFrame.Type and dai.ImgFrame.Specs
     // m.attr("ImgFrame").attr("Type") = m.attr("RawImgFrame").attr("Type");

--- a/bindings/python/src/pipeline/datatype/PointCloudDataBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/PointCloudDataBindings.cpp
@@ -183,4 +183,8 @@ void bind_pointclouddata(pybind11::module& m, void* pCallstack) {
         .def("updateBoundingBox", &PointCloudData::updateBoundingBox, DOC(dai, PointCloudData, updateBoundingBox))
         .def("getTransformation", &PointCloudData::getTransformation, py::return_value_policy::reference_internal)
         .def("setTransformation", &PointCloudData::setTransformation, py::arg("transformation"));
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+    pointCloudData.def("save", &PointCloudData::save, py::arg("path"), py::arg("metadataOnly") = false)
+        .def("load", &PointCloudData::load, py::arg("path"), py::arg("metadataOnly") = false);
+#endif
 }

--- a/bindings/python/src/pipeline/datatype/RGBDDataBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/RGBDDataBindings.cpp
@@ -36,4 +36,8 @@ void bind_rgbddata(pybind11::module& m, void* pCallstack) {
         .def("getDepthFrame", &RGBDData::getDepthFrame, DOC(dai, RGBDData, getDepthFrame))
         .def("setRGBFrame", &RGBDData::setRGBFrame, py::arg("frame"), DOC(dai, RGBDData, setRGBFrame))
         .def("setDepthFrame", &RGBDData::setDepthFrame, py::arg("frame"), DOC(dai, RGBDData, setDepthFrame));
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+    rgbdData.def("save", &RGBDData::save, py::arg("path"), py::arg("metadataOnly") = false)
+        .def("load", &RGBDData::load, py::arg("path"), py::arg("metadataOnly") = false);
+#endif
 }

--- a/bindings/python/tests/imgframe_test.py
+++ b/bindings/python/tests/imgframe_test.py
@@ -3,6 +3,7 @@ import depthai as dai
 import numpy as np
 import pytest
 import numpy.typing as npt
+from pathlib import Path
 
 DEBUG = False
 
@@ -42,6 +43,38 @@ def max_abs_diff(expected, recovered):
 def assert_images_close(expected, recovered, tolerance, msg):
     max_diff = max_abs_diff(expected, recovered)
     assert max_diff <= tolerance, f"{msg} max abs diff too high: {max_diff} > {tolerance}"
+
+
+def make_test_frame():
+    image = generate_color_image()
+    frame = dai.ImgFrame()
+    frame.setCvFrame(image, dai.ImgFrame.Type.BGR888i)
+    frame.setTimestamp(frame.getTimestamp())
+    frame.setTimestampDevice(frame.getTimestampDevice())
+    frame.setSequenceNum(123)
+    frame.setInstanceNum(7)
+    frame.setCategory(11)
+
+    transformation = dai.ImgTransformation(160, 120, image.shape[1], image.shape[0])
+    transformation.addCrop(8, 6, image.shape[1] - 12, image.shape[0] - 10)
+    frame.setTransformation(transformation)
+
+    return frame, image
+
+
+def assert_frame_metadata_equal(expected, actual):
+    assert actual.getSequenceNum() == expected.getSequenceNum()
+    assert actual.getInstanceNum() == expected.getInstanceNum()
+    assert actual.getCategory() == expected.getCategory()
+    assert actual.getWidth() == expected.getWidth()
+    assert actual.getHeight() == expected.getHeight()
+    assert actual.getType() == expected.getType()
+    assert actual.getTimestamp() == expected.getTimestamp()
+    assert actual.getTimestampDevice() == expected.getTimestampDevice()
+
+    expected_transform = np.array(expected.getTransformation().getTransformationMatrix())
+    actual_transform = np.array(actual.getTransformation().getTransformationMatrix())
+    np.testing.assert_allclose(actual_transform, expected_transform)
 
 
 
@@ -127,3 +160,28 @@ def test_setcvframe_raw32():
     assert recovered.shape == image.shape
     assert recovered.dtype == np.int32
     assert_images_close(image, recovered, tolerance=0.0, msg="RAW32")
+
+
+def test_imgframe_file_roundtrip(tmp_path: Path):
+    frame, image = make_test_frame()
+    path = tmp_path / "frame.pb"
+
+    frame.save(path)
+    recovered = dai.ImgFrame()
+    recovered.load(path)
+
+    assert_frame_metadata_equal(frame, recovered)
+    assert np.array_equal(np.asarray(recovered.getData()), np.asarray(frame.getData()))
+    assert_images_close(image, recovered.getCvFrame(), tolerance=0.5, msg="imgframe file roundtrip")
+
+
+def test_imgframe_metadata_only_roundtrip(tmp_path: Path):
+    frame, _ = make_test_frame()
+    path = tmp_path / "frame-metadata.pb"
+
+    frame.save(path, metadataOnly=True)
+    recovered = dai.ImgFrame()
+    recovered.load(path, metadataOnly=True)
+
+    assert_frame_metadata_equal(frame, recovered)
+    assert recovered.getData().size == 0

--- a/bindings/python/tests/imgframe_test.py
+++ b/bindings/python/tests/imgframe_test.py
@@ -185,3 +185,30 @@ def test_imgframe_metadata_only_roundtrip(tmp_path: Path):
 
     assert_frame_metadata_equal(frame, recovered)
     assert recovered.getData().size == 0
+
+
+def test_encodedframe_file_roundtrip(tmp_path: Path):
+    frame = dai.EncodedFrame()
+    frame.setWidth(320)
+    frame.setHeight(180)
+    frame.setQuality(90)
+    frame.setBitrate(1_000_000)
+    frame.setProfile(dai.EncodedFrame.Profile.JPEG)
+    frame.setFrameType(dai.EncodedFrame.FrameType.I)
+    frame.setLossless(False)
+    frame.setData(np.arange(64, dtype=np.uint8))
+
+    path = tmp_path / "encoded-frame.pb"
+    frame.save(path)
+
+    recovered = dai.EncodedFrame()
+    recovered.load(path)
+
+    assert recovered.getWidth() == frame.getWidth()
+    assert recovered.getHeight() == frame.getHeight()
+    assert recovered.getQuality() == frame.getQuality()
+    assert recovered.getBitrate() == frame.getBitrate()
+    assert recovered.getProfile() == frame.getProfile()
+    assert recovered.getFrameType() == frame.getFrameType()
+    assert recovered.getLossless() == frame.getLossless()
+    assert np.array_equal(np.asarray(recovered.getData()), np.asarray(frame.getData()))

--- a/include/depthai/pipeline/datatype/EncodedFrame.hpp
+++ b/include/depthai/pipeline/datatype/EncodedFrame.hpp
@@ -215,9 +215,7 @@ class EncodedFrame : public Buffer, public ProtoSerializable {
      * @returns serialized schema
      */
     ProtoSerializable::SchemaPair serializeSchema() const override;
-#endif
 
-#ifdef DEPTHAI_ENABLE_PROTOBUF
    protected:
     void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
 

--- a/include/depthai/pipeline/datatype/EncodedFrame.hpp
+++ b/include/depthai/pipeline/datatype/EncodedFrame.hpp
@@ -217,6 +217,13 @@ class EncodedFrame : public Buffer, public ProtoSerializable {
     ProtoSerializable::SchemaPair serializeSchema() const override;
 #endif
 
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+   protected:
+    void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
+
+   public:
+#endif
+
     DEPTHAI_SERIALIZE(EncodedFrame,
                       cam,
                       instanceNum,

--- a/include/depthai/pipeline/datatype/IMUData.hpp
+++ b/include/depthai/pipeline/datatype/IMUData.hpp
@@ -259,6 +259,13 @@ class IMUData : public Buffer, public ProtoSerializable {
     ProtoSerializable::SchemaPair serializeSchema() const override;
 #endif
 
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+   protected:
+    void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
+
+   public:
+#endif
+
     DEPTHAI_SERIALIZE(IMUData, Buffer::ts, Buffer::tsDevice, Buffer::tsSystem, Buffer::sequenceNum, packets);
 };
 

--- a/include/depthai/pipeline/datatype/IMUData.hpp
+++ b/include/depthai/pipeline/datatype/IMUData.hpp
@@ -257,9 +257,7 @@ class IMUData : public Buffer, public ProtoSerializable {
      * @returns serialized schema
      */
     ProtoSerializable::SchemaPair serializeSchema() const override;
-#endif
 
-#ifdef DEPTHAI_ENABLE_PROTOBUF
    protected:
     void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
 

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -772,11 +772,8 @@ class ImgFrame : public Buffer, public ProtoSerializable {
 #ifdef DEPTHAI_ENABLE_PROTOBUF
    protected:
     void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
-
-   public:
-#else
-   public:
 #endif
+   public:
     DEPTHAI_SERIALIZE(ImgFrame, Buffer::ts, Buffer::tsDevice, Buffer::tsSystem, Buffer::sequenceNum, fb, sourceFb, cam, category, instanceNum, transformation);
 };
 

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <chrono>
-#include <filesystem>
 #include <unordered_map>
 #include <vector>
 
@@ -102,6 +101,7 @@ class ImgFrame : public Buffer, public ProtoSerializable {
      * @returns serialized schema
      */
     ProtoSerializable::SchemaPair serializeSchema() const override;
+
 #endif
 
     // getters
@@ -368,22 +368,6 @@ class ImgFrame : public Buffer, public ProtoSerializable {
      * @returns cloned ImgFrame
      */
     std::shared_ptr<ImgFrame> clone() const;
-
-    /**
-     * Save the frame in the XLink packet format used by host/device transport.
-     *
-     * @param path Output file path
-     * @param metadataOnly If true, only metadata is written and image payload is omitted
-     */
-    void save(const std::filesystem::path& path, bool metadataOnly = false) const;
-
-    /**
-     * Load the frame from the XLink packet format used by host/device transport.
-     *
-     * @param path Input file path
-     * @param metadataOnly If true, loaded payload bytes are discarded after parsing
-     */
-    void load(const std::filesystem::path& path, bool metadataOnly = false);
 
     /**
      * @note Fov API works correctly only on rectilinear frames
@@ -785,7 +769,14 @@ class ImgFrame : public Buffer, public ProtoSerializable {
     dai::FrameEvent event = dai::FrameEvent::NONE;
     ImgTransformation transformation;
 
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+   protected:
+    void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
+
    public:
+#else
+   public:
+#endif
     DEPTHAI_SERIALIZE(ImgFrame, Buffer::ts, Buffer::tsDevice, Buffer::tsSystem, Buffer::sequenceNum, fb, sourceFb, cam, category, instanceNum, transformation);
 };
 

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <filesystem>
 #include <unordered_map>
 #include <vector>
 
@@ -367,6 +368,22 @@ class ImgFrame : public Buffer, public ProtoSerializable {
      * @returns cloned ImgFrame
      */
     std::shared_ptr<ImgFrame> clone() const;
+
+    /**
+     * Save the frame in the XLink packet format used by host/device transport.
+     *
+     * @param path Output file path
+     * @param metadataOnly If true, only metadata is written and image payload is omitted
+     */
+    void save(const std::filesystem::path& path, bool metadataOnly = false) const;
+
+    /**
+     * Load the frame from the XLink packet format used by host/device transport.
+     *
+     * @param path Input file path
+     * @param metadataOnly If true, loaded payload bytes are discarded after parsing
+     */
+    void load(const std::filesystem::path& path, bool metadataOnly = false);
 
     /**
      * @note Fov API works correctly only on rectilinear frames

--- a/include/depthai/pipeline/datatype/ImgFrame.hpp
+++ b/include/depthai/pipeline/datatype/ImgFrame.hpp
@@ -102,8 +102,11 @@ class ImgFrame : public Buffer, public ProtoSerializable {
      */
     ProtoSerializable::SchemaPair serializeSchema() const override;
 
-#endif
+   protected:
+    void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
 
+   public:
+#endif
     // getters
     /**
      * Retrieves image timestamp (at the specified offset of exposure) related to dai::Clock::now()
@@ -769,11 +772,6 @@ class ImgFrame : public Buffer, public ProtoSerializable {
     dai::FrameEvent event = dai::FrameEvent::NONE;
     ImgTransformation transformation;
 
-#ifdef DEPTHAI_ENABLE_PROTOBUF
-   protected:
-    void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
-#endif
-   public:
     DEPTHAI_SERIALIZE(ImgFrame, Buffer::ts, Buffer::tsDevice, Buffer::tsSystem, Buffer::sequenceNum, fb, sourceFb, cam, category, instanceNum, transformation);
 };
 

--- a/include/depthai/pipeline/datatype/PointCloudData.hpp
+++ b/include/depthai/pipeline/datatype/PointCloudData.hpp
@@ -268,6 +268,13 @@ class PointCloudData : public Buffer, public ProtoSerializable, public Transform
     ProtoSerializable::SchemaPair serializeSchema() const override;
 #endif
 
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+   protected:
+    void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
+
+   public:
+#endif
+
 #ifdef DEPTHAI_HAVE_PCL_SUPPORT
     /**
      * Converts PointCloudData to pcl::PointCloud<pcl::PointXYZ>

--- a/include/depthai/pipeline/datatype/PointCloudData.hpp
+++ b/include/depthai/pipeline/datatype/PointCloudData.hpp
@@ -266,9 +266,7 @@ class PointCloudData : public Buffer, public ProtoSerializable, public Transform
      * @returns serialized schema
      */
     ProtoSerializable::SchemaPair serializeSchema() const override;
-#endif
 
-#ifdef DEPTHAI_ENABLE_PROTOBUF
    protected:
     void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
 

--- a/include/depthai/pipeline/datatype/RGBDData.hpp
+++ b/include/depthai/pipeline/datatype/RGBDData.hpp
@@ -61,9 +61,7 @@ class RGBDData : public Buffer, public ProtoSerializable {
      * @returns serialized schema
      */
     ProtoSerializable::SchemaPair serializeSchema() const override;
-#endif
 
-#ifdef DEPTHAI_ENABLE_PROTOBUF
    protected:
     void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
 

--- a/include/depthai/pipeline/datatype/RGBDData.hpp
+++ b/include/depthai/pipeline/datatype/RGBDData.hpp
@@ -63,6 +63,13 @@ class RGBDData : public Buffer, public ProtoSerializable {
     ProtoSerializable::SchemaPair serializeSchema() const override;
 #endif
 
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+   protected:
+    void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) override;
+
+   public:
+#endif
+
     DEPTHAI_SERIALIZE(RGBDData, colorFrame, depthFrame, Buffer::ts, Buffer::tsDevice, Buffer::tsSystem, Buffer::sequenceNum);
 };
 

--- a/include/depthai/utility/ProtoSerializable.hpp
+++ b/include/depthai/utility/ProtoSerializable.hpp
@@ -17,7 +17,18 @@ class ProtoSerializable {
     virtual ~ProtoSerializable();
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
+    /**
+     * @brief Serialize this object and write it to disk
+     * @param path Output path. If it has no extension, the final on-disk filename is resolved to `<path>.dai`.
+     * @param metadataOnly If true, serialize only metadata and omit payload data where supported by the concrete type.
+     */
     void save(const std::filesystem::path& path, bool metadataOnly = false) const;
+
+    /**
+     * @brief Load this object from a serialized protobuf file on disk
+     * @param path Input path. If it has no extension, the file is resolved as `<path>.dai`.
+     * @param metadataOnly If true, load only metadata and omit payload data where supported by the concrete type.
+     */
     void load(const std::filesystem::path& path, bool metadataOnly = false);
 
     /**

--- a/include/depthai/utility/ProtoSerializable.hpp
+++ b/include/depthai/utility/ProtoSerializable.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,9 @@ class ProtoSerializable {
     virtual ~ProtoSerializable();
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
+    void save(const std::filesystem::path& path, bool metadataOnly = false) const;
+    void load(const std::filesystem::path& path, bool metadataOnly = false);
+
     /**
      * @brief Serialize the protobuf message of this object
      * @return serialized protobuf message
@@ -27,6 +31,9 @@ class ProtoSerializable {
      * @return schemaPair
      */
     virtual SchemaPair serializeSchema() const = 0;
+
+   protected:
+    virtual void deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly);
 
 #else
     // Helper struct for compile-time check

--- a/src/opencv/ImgFrame.cpp
+++ b/src/opencv/ImgFrame.cpp
@@ -7,10 +7,6 @@
 #include <opencv2/core/types.hpp>
 #include <opencv2/imgproc.hpp>
 
-#ifdef DEPTHAI_ENABLE_PROTOBUF
-    #include "utility/ProtoFileIO.hpp"
-#endif
-
 // #include "spdlog/spdlog.h"
 
 namespace dai {

--- a/src/opencv/ImgFrame.cpp
+++ b/src/opencv/ImgFrame.cpp
@@ -2,86 +2,18 @@
 
 #include <cassert>
 #include <cmath>
-#include <fstream>
 #include <opencv2/core/base.hpp>
 #include <opencv2/core/mat.hpp>
 #include <opencv2/core/types.hpp>
 #include <opencv2/imgproc.hpp>
 
-#include "depthai/pipeline/datatype/StreamMessageParser.hpp"
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+    #include "utility/ProtoFileIO.hpp"
+#endif
 
 // #include "spdlog/spdlog.h"
 
 namespace dai {
-
-namespace {
-
-std::vector<uint8_t> readBinaryFile(const std::filesystem::path& path) {
-    std::ifstream file(path, std::ios::binary);
-    if(!file) {
-        throw std::runtime_error("Failed to open file for reading: " + path.string());
-    }
-
-    file.seekg(0, std::ios::end);
-    const auto size = file.tellg();
-    if(size < 0) {
-        throw std::runtime_error("Failed to determine file size: " + path.string());
-    }
-    file.seekg(0, std::ios::beg);
-
-    std::vector<uint8_t> buffer(static_cast<size_t>(size));
-    if(!buffer.empty()) {
-        file.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
-        if(!file) {
-            throw std::runtime_error("Failed to read file: " + path.string());
-        }
-    }
-    return buffer;
-}
-
-void writeBinaryFile(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
-    std::ofstream file(path, std::ios::binary);
-    if(!file) {
-        throw std::runtime_error("Failed to open file for writing: " + path.string());
-    }
-    if(!bytes.empty()) {
-        file.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
-        if(!file) {
-            throw std::runtime_error("Failed to write file: " + path.string());
-        }
-    }
-}
-
-std::vector<uint8_t> serializeImgFrameXLinkPacket(const ImgFrame& frame, bool metadataOnly) {
-    std::vector<uint8_t> serialized;
-    if(!metadataOnly) {
-        auto data = frame.getData();
-        serialized.insert(serialized.end(), data.begin(), data.end());
-    }
-    auto metadata = StreamMessageParser::serializeMetadata(frame);
-    serialized.insert(serialized.end(), metadata.begin(), metadata.end());
-    return serialized;
-}
-
-std::shared_ptr<ImgFrame> parseImgFrameBytes(const std::vector<uint8_t>& serialized, bool metadataOnly) {
-    auto packetBytes = serialized;
-    streamPacketDesc_t packet{};
-    packet.data = packetBytes.data();
-    packet.length = packetBytes.size();
-    packet.fd = -1;
-
-    auto parsed = StreamMessageParser::parseMessage(&packet);
-    auto frame = std::dynamic_pointer_cast<ImgFrame>(parsed);
-    if(frame == nullptr) {
-        throw std::runtime_error("Failed to parse ImgFrame payload");
-    }
-    if(metadataOnly) {
-        frame->setData(std::vector<std::uint8_t>{});
-    }
-    return frame;
-}
-
-}  // namespace
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wswitch-enum"
@@ -97,14 +29,6 @@ ImgFrame& ImgFrame::setFrame(cv::Mat frame) {
     }
     setData(dataVec);
     return *this;
-}
-
-void ImgFrame::save(const std::filesystem::path& path, bool metadataOnly) const {
-    writeBinaryFile(path, serializeImgFrameXLinkPacket(*this, metadataOnly));
-}
-
-void ImgFrame::load(const std::filesystem::path& path, bool metadataOnly) {
-    *this = *parseImgFrameBytes(readBinaryFile(path), metadataOnly);
 }
 
 cv::Mat ImgFrame::getFrame(bool deepCopy) {

--- a/src/opencv/ImgFrame.cpp
+++ b/src/opencv/ImgFrame.cpp
@@ -2,14 +2,87 @@
 
 #include <cassert>
 #include <cmath>
+#include <fstream>
 #include <opencv2/core/base.hpp>
 #include <opencv2/core/mat.hpp>
 #include <opencv2/core/types.hpp>
 #include <opencv2/imgproc.hpp>
 
+#include "depthai/pipeline/datatype/StreamMessageParser.hpp"
+
 // #include "spdlog/spdlog.h"
 
 namespace dai {
+
+namespace {
+
+std::vector<uint8_t> readBinaryFile(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary);
+    if(!file) {
+        throw std::runtime_error("Failed to open file for reading: " + path.string());
+    }
+
+    file.seekg(0, std::ios::end);
+    const auto size = file.tellg();
+    if(size < 0) {
+        throw std::runtime_error("Failed to determine file size: " + path.string());
+    }
+    file.seekg(0, std::ios::beg);
+
+    std::vector<uint8_t> buffer(static_cast<size_t>(size));
+    if(!buffer.empty()) {
+        file.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
+        if(!file) {
+            throw std::runtime_error("Failed to read file: " + path.string());
+        }
+    }
+    return buffer;
+}
+
+void writeBinaryFile(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
+    std::ofstream file(path, std::ios::binary);
+    if(!file) {
+        throw std::runtime_error("Failed to open file for writing: " + path.string());
+    }
+    if(!bytes.empty()) {
+        file.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+        if(!file) {
+            throw std::runtime_error("Failed to write file: " + path.string());
+        }
+    }
+}
+
+std::vector<uint8_t> serializeImgFrameXLinkPacket(const ImgFrame& frame, bool metadataOnly) {
+    std::vector<uint8_t> serialized;
+    if(!metadataOnly) {
+        auto data = frame.getData();
+        serialized.insert(serialized.end(), data.begin(), data.end());
+    }
+    auto metadata = StreamMessageParser::serializeMetadata(frame);
+    serialized.insert(serialized.end(), metadata.begin(), metadata.end());
+    return serialized;
+}
+
+std::shared_ptr<ImgFrame> parseImgFrameBytes(const std::vector<uint8_t>& serialized, bool metadataOnly) {
+    auto packetBytes = serialized;
+    streamPacketDesc_t packet{};
+    packet.data = packetBytes.data();
+    packet.length = packetBytes.size();
+    packet.fd = -1;
+
+    auto parsed = StreamMessageParser::parseMessage(&packet);
+    auto frame = std::dynamic_pointer_cast<ImgFrame>(parsed);
+    if(frame == nullptr) {
+        throw std::runtime_error("Failed to parse ImgFrame payload");
+    }
+    if(metadataOnly) {
+        frame->setData(std::vector<std::uint8_t>{});
+    }
+    return frame;
+}
+
+}  // namespace
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wswitch-enum"
 ImgFrame& ImgFrame::setFrame(cv::Mat frame) {
@@ -24,6 +97,14 @@ ImgFrame& ImgFrame::setFrame(cv::Mat frame) {
     }
     setData(dataVec);
     return *this;
+}
+
+void ImgFrame::save(const std::filesystem::path& path, bool metadataOnly) const {
+    writeBinaryFile(path, serializeImgFrameXLinkPacket(*this, metadataOnly));
+}
+
+void ImgFrame::load(const std::filesystem::path& path, bool metadataOnly) {
+    *this = *parseImgFrameBytes(readBinaryFile(path), metadataOnly);
 }
 
 cv::Mat ImgFrame::getFrame(bool deepCopy) {

--- a/src/pipeline/datatype/EncodedFrame.cpp
+++ b/src/pipeline/datatype/EncodedFrame.cpp
@@ -1,6 +1,7 @@
 #include "depthai/pipeline/datatype/EncodedFrame.hpp"
 #ifdef DEPTHAI_ENABLE_PROTOBUF
     #include "depthai/schemas/EncodedFrame.pb.h"
+    #include "utility/ProtoFileIO.hpp"
     #include "utility/ProtoSerialize.hpp"
 #endif
 
@@ -161,6 +162,10 @@ ImgFrame EncodedFrame::getImgFrameMeta() const {
 }
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
+void EncodedFrame::deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) {
+    utility::loadProtoMessageFromBytes(*this, bytes, metadataOnly);
+}
+
 ProtoSerializable::SchemaPair EncodedFrame::serializeSchema() const {
     return utility::serializeSchema(utility::getProtoMessage(this));
 }

--- a/src/pipeline/datatype/IMUData.cpp
+++ b/src/pipeline/datatype/IMUData.cpp
@@ -3,6 +3,7 @@
 #if DEPTHAI_ENABLE_PROTOBUF
     #include "depthai/schemas/IMUData.pb.h"
     #include "depthai/schemas/common.pb.h"
+    #include "utility/ProtoFileIO.hpp"
     #include "utility/ProtoSerialize.hpp"
 #endif
 
@@ -16,6 +17,9 @@ void IMUData::serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datat
 }
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
+void IMUData::deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) {
+    utility::loadProtoMessageFromBytes(*this, bytes, metadataOnly);
+}
 
 ProtoSerializable::SchemaPair IMUData::serializeSchema() const {
     return utility::serializeSchema(utility::getProtoMessage(this));

--- a/src/pipeline/datatype/ImgFrame.cpp
+++ b/src/pipeline/datatype/ImgFrame.cpp
@@ -6,6 +6,7 @@
 #include "depthai/utility/SharedMemory.hpp"
 #ifdef DEPTHAI_ENABLE_PROTOBUF
     #include "depthai/schemas/ImgFrame.pb.h"
+    #include "utility/ProtoFileIO.hpp"
     #include "utility/ProtoSerialize.hpp"
 #endif
 namespace dai {
@@ -361,6 +362,10 @@ Rect ImgFrame::remapRectBetweenFrames(const Rect& originRect, const ImgFrame& or
 }
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
+void ImgFrame::deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) {
+    utility::loadProtoMessageFromBytes(*this, bytes, metadataOnly);
+}
+
 ProtoSerializable::SchemaPair ImgFrame::serializeSchema() const {
     return utility::serializeSchema(utility::getProtoMessage(this));
 }

--- a/src/pipeline/datatype/PointCloudData.cpp
+++ b/src/pipeline/datatype/PointCloudData.cpp
@@ -7,6 +7,7 @@
 #include "depthai/common/Point3f.hpp"
 #ifdef DEPTHAI_ENABLE_PROTOBUF
     #include "depthai/schemas/PointCloudData.pb.h"
+    #include "utility/ProtoFileIO.hpp"
     #include "utility/ProtoSerialize.hpp"
 #endif
 namespace dai {
@@ -244,6 +245,10 @@ PointCloudData& PointCloudData::setColor(bool val) {
 }
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
+void PointCloudData::deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) {
+    utility::loadProtoMessageFromBytes(*this, bytes, metadataOnly);
+}
+
 std::vector<std::uint8_t> PointCloudData::serializeProto(bool metadataOnly) const {
     return utility::serializeProto(utility::getProtoMessage(this, metadataOnly));
 }

--- a/src/pipeline/datatype/RGBDData.cpp
+++ b/src/pipeline/datatype/RGBDData.cpp
@@ -2,6 +2,7 @@
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
     #include "depthai/schemas/RGBDData.pb.h"
+    #include "utility/ProtoFileIO.hpp"
     #include "utility/ProtoSerialize.hpp"
 #endif
 
@@ -62,6 +63,10 @@ std::optional<RGBDData::FrameVariant> RGBDData::getDepthFrame() const {
 }
 
 #ifdef DEPTHAI_ENABLE_PROTOBUF
+void RGBDData::deserializeProtoMessage(const std::vector<std::uint8_t>& bytes, bool metadataOnly) {
+    utility::loadProtoMessageFromBytes(*this, bytes, metadataOnly);
+}
+
 std::vector<std::uint8_t> RGBDData::serializeProto(bool metadataOnly) const {
     return utility::serializeProto(utility::getProtoMessage(this, metadataOnly));
 }

--- a/src/utility/ProtoFileIO.hpp
+++ b/src/utility/ProtoFileIO.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <vector>
+
+#include "ProtoSerialize.hpp"
+
+namespace dai {
+namespace utility {
+
+namespace detail {
+
+template <typename T>
+struct ProtoMessageType;
+
+template <>
+struct ProtoMessageType<ImgFrame> {
+    using type = proto::img_frame::ImgFrame;
+};
+
+template <>
+struct ProtoMessageType<EncodedFrame> {
+    using type = proto::encoded_frame::EncodedFrame;
+};
+
+template <>
+struct ProtoMessageType<IMUData> {
+    using type = proto::imu_data::IMUData;
+};
+
+template <>
+struct ProtoMessageType<PointCloudData> {
+    using type = proto::point_cloud_data::PointCloudData;
+};
+
+template <>
+struct ProtoMessageType<RGBDData> {
+    using type = proto::rgbd_data::RGBDData;
+};
+
+}  // namespace detail
+
+template <typename T>
+void loadProtoMessageFromBytes(T& message, const std::vector<uint8_t>& bytes, bool metadataOnly = false) {
+    using ProtoType = typename detail::ProtoMessageType<T>::type;
+
+    ProtoType protoMessage;
+    if(!protoMessage.ParseFromArray(bytes.data(), static_cast<int>(bytes.size()))) {
+        throw std::runtime_error("Failed to parse protobuf message");
+    }
+
+    utility::setProtoMessage(message, &protoMessage, metadataOnly);
+}
+
+}  // namespace utility
+}  // namespace dai

--- a/src/utility/ProtoSerializable.cpp
+++ b/src/utility/ProtoSerializable.cpp
@@ -1,7 +1,66 @@
 #include "depthai/utility/ProtoSerializable.hpp"
 
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+    #include <fstream>
+    #include <stdexcept>
+#endif
+
 namespace dai {
 
 ProtoSerializable::~ProtoSerializable() = default;
+
+#ifdef DEPTHAI_ENABLE_PROTOBUF
+namespace {
+
+std::vector<std::uint8_t> readBinaryFile(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary);
+    if(!file) {
+        throw std::runtime_error("Failed to open file for reading: " + path.string());
+    }
+
+    file.seekg(0, std::ios::end);
+    const auto size = file.tellg();
+    if(size < 0) {
+        throw std::runtime_error("Failed to determine file size: " + path.string());
+    }
+    file.seekg(0, std::ios::beg);
+
+    std::vector<std::uint8_t> buffer(static_cast<size_t>(size));
+    if(!buffer.empty()) {
+        file.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
+        if(!file) {
+            throw std::runtime_error("Failed to read file: " + path.string());
+        }
+    }
+    return buffer;
+}
+
+void writeBinaryFile(const std::filesystem::path& path, const std::vector<std::uint8_t>& bytes) {
+    std::ofstream file(path, std::ios::binary);
+    if(!file) {
+        throw std::runtime_error("Failed to open file for writing: " + path.string());
+    }
+    if(!bytes.empty()) {
+        file.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+        if(!file) {
+            throw std::runtime_error("Failed to write file: " + path.string());
+        }
+    }
+}
+
+}  // namespace
+
+void ProtoSerializable::save(const std::filesystem::path& path, bool metadataOnly) const {
+    writeBinaryFile(path, serializeProto(metadataOnly));
+}
+
+void ProtoSerializable::load(const std::filesystem::path& path, bool metadataOnly) {
+    deserializeProtoMessage(readBinaryFile(path), metadataOnly);
+}
+
+void ProtoSerializable::deserializeProtoMessage(const std::vector<std::uint8_t>&, bool) {
+    throw std::runtime_error("Protobuf deserialization is not implemented for this message type");
+}
+#endif
 
 }  // namespace dai

--- a/src/utility/ProtoSerializable.cpp
+++ b/src/utility/ProtoSerializable.cpp
@@ -12,6 +12,15 @@ ProtoSerializable::~ProtoSerializable() = default;
 #ifdef DEPTHAI_ENABLE_PROTOBUF
 namespace {
 
+std::filesystem::path resolveDataPath(const std::filesystem::path& path) {
+    if(path.has_extension()) {
+        return path;
+    }
+    auto resolved = path;
+    resolved += ".dai";
+    return resolved;
+}
+
 std::vector<std::uint8_t> readBinaryFile(const std::filesystem::path& path) {
     std::ifstream file(path, std::ios::binary);
     if(!file) {
@@ -51,11 +60,11 @@ void writeBinaryFile(const std::filesystem::path& path, const std::vector<std::u
 }  // namespace
 
 void ProtoSerializable::save(const std::filesystem::path& path, bool metadataOnly) const {
-    writeBinaryFile(path, serializeProto(metadataOnly));
+    writeBinaryFile(resolveDataPath(path), serializeProto(metadataOnly));
 }
 
 void ProtoSerializable::load(const std::filesystem::path& path, bool metadataOnly) {
-    deserializeProtoMessage(readBinaryFile(path), metadataOnly);
+    deserializeProtoMessage(readBinaryFile(resolveDataPath(path)), metadataOnly);
 }
 
 void ProtoSerializable::deserializeProtoMessage(const std::vector<std::uint8_t>&, bool) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -516,6 +516,10 @@ dai_set_test_labels(imgdetections_test onhost ci)
 dai_add_test(imgframe_test src/onhost_tests/pipeline/datatype/imgframe_test.cpp)
 dai_set_test_labels(imgframe_test onhost ci)
 
+# ProtoSerializable file I/O tests
+dai_add_test(proto_file_io_test src/onhost_tests/pipeline/datatype/proto_file_io_test.cpp)
+dai_set_test_labels(proto_file_io_test onhost ci)
+
 # PointCloudData / PointCloudConfig / PointCloudProperties datatype tests
 dai_add_test(pointclouddata_test src/onhost_tests/pipeline/datatype/pointclouddata_test.cpp)
 dai_set_test_labels(pointclouddata_test onhost ci)

--- a/tests/src/onhost_tests/pipeline/datatype/proto_file_io_test.cpp
+++ b/tests/src/onhost_tests/pipeline/datatype/proto_file_io_test.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <variant>
@@ -21,15 +22,28 @@ namespace {
 class TempFile {
    public:
     explicit TempFile(const std::string& stem)
-        : path(fs::temp_directory_path() / (stem + "_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".pb")) {}
+        : path(fs::temp_directory_path() / (stem + "_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()))) {}
 
     ~TempFile() {
         std::error_code ec;
         fs::remove(path, ec);
+        fs::remove(path.string() + ".dai", ec);
     }
 
     fs::path path;
 };
+
+fs::path withDaiExtension(const fs::path& path) {
+    auto resolved = path;
+    resolved += ".dai";
+    return resolved;
+}
+
+fs::path withCustomExtension(const fs::path& path, const std::string& extension) {
+    auto resolved = path;
+    resolved += extension;
+    return resolved;
+}
 
 std::vector<uint8_t> toVector(dai::span<const uint8_t> data) {
     return std::vector<uint8_t>(data.begin(), data.end());
@@ -52,20 +66,42 @@ TEST_CASE("ImgFrame save/load roundtrip", "[ProtoFileIO][ImgFrame]") {
     frame.cam.exposureTimeUs = 2500;
     frame.setData(std::vector<uint8_t>{1, 2, 3, 4, 5, 6, 7, 8});
 
-    TempFile file("imgframe_roundtrip");
-    frame.save(file.path);
+    SECTION("Extensionless path resolves to .dai for save and load") {
+        TempFile file("imgframe_roundtrip_no_ext");
+        frame.save(file.path);
+        REQUIRE(fs::exists(withDaiExtension(file.path)));
 
-    dai::ImgFrame restored;
-    restored.load(file.path);
+        dai::ImgFrame restored;
+        restored.load(file.path);
 
-    REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
-    REQUIRE(restored.getCategory() == frame.getCategory());
-    REQUIRE(restored.getWidth() == frame.getWidth());
-    REQUIRE(restored.getHeight() == frame.getHeight());
-    REQUIRE(restored.getType() == frame.getType());
-    REQUIRE(restored.getSequenceNum() == frame.getSequenceNum());
-    REQUIRE(restored.getExposureTime() == frame.getExposureTime());
-    REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+        REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
+        REQUIRE(restored.getCategory() == frame.getCategory());
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getHeight() == frame.getHeight());
+        REQUIRE(restored.getType() == frame.getType());
+        REQUIRE(restored.getSequenceNum() == frame.getSequenceNum());
+        REQUIRE(restored.getExposureTime() == frame.getExposureTime());
+        REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+    }
+
+    SECTION("Explicit .dai path works the same for save and load") {
+        TempFile file("imgframe_roundtrip_ext");
+        auto explicitPath = withDaiExtension(file.path);
+        frame.save(explicitPath);
+        REQUIRE(fs::exists(explicitPath));
+
+        dai::ImgFrame restored;
+        restored.load(explicitPath);
+
+        REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
+        REQUIRE(restored.getCategory() == frame.getCategory());
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getHeight() == frame.getHeight());
+        REQUIRE(restored.getType() == frame.getType());
+        REQUIRE(restored.getSequenceNum() == frame.getSequenceNum());
+        REQUIRE(restored.getExposureTime() == frame.getExposureTime());
+        REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+    }
 }
 
 TEST_CASE("ImgFrame metadata-only save/load clears payload", "[ProtoFileIO][ImgFrame]") {
@@ -73,16 +109,34 @@ TEST_CASE("ImgFrame metadata-only save/load clears payload", "[ProtoFileIO][ImgF
     frame.setSize(4, 4).setSourceSize(4, 4).setType(dai::ImgFrame::Type::RAW8);
     frame.setData(std::vector<uint8_t>{9, 8, 7, 6});
 
-    TempFile file("imgframe_metadata_only");
-    frame.save(file.path, true);
+    SECTION("Extensionless metadata-only path resolves to .dai") {
+        TempFile file("imgframe_metadata_only_no_ext");
+        frame.save(file.path, true);
+        REQUIRE(fs::exists(withDaiExtension(file.path)));
 
-    dai::ImgFrame restored;
-    restored.load(file.path, true);
+        dai::ImgFrame restored;
+        restored.load(file.path, true);
 
-    REQUIRE(restored.getWidth() == frame.getWidth());
-    REQUIRE(restored.getHeight() == frame.getHeight());
-    REQUIRE(restored.getType() == frame.getType());
-    REQUIRE(restored.getData().empty());
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getHeight() == frame.getHeight());
+        REQUIRE(restored.getType() == frame.getType());
+        REQUIRE(restored.getData().empty());
+    }
+
+    SECTION("Explicit .dai metadata-only path works the same") {
+        TempFile file("imgframe_metadata_only_ext");
+        auto explicitPath = withDaiExtension(file.path);
+        frame.save(explicitPath, true);
+        REQUIRE(fs::exists(explicitPath));
+
+        dai::ImgFrame restored;
+        restored.load(explicitPath, true);
+
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getHeight() == frame.getHeight());
+        REQUIRE(restored.getType() == frame.getType());
+        REQUIRE(restored.getData().empty());
+    }
 }
 
 TEST_CASE("EncodedFrame save/load roundtrip", "[ProtoFileIO][EncodedFrame]") {
@@ -93,22 +147,101 @@ TEST_CASE("EncodedFrame save/load roundtrip", "[ProtoFileIO][EncodedFrame]") {
     frame.setSequenceNum(777);
     frame.setData(std::vector<uint8_t>{10, 20, 30, 40, 50});
 
-    TempFile file("encodedframe_roundtrip");
-    frame.save(file.path);
+    SECTION("Extensionless path resolves to .dai for save and load") {
+        TempFile file("encodedframe_roundtrip_no_ext");
+        frame.save(file.path);
+        REQUIRE(fs::exists(withDaiExtension(file.path)));
 
-    dai::EncodedFrame restored;
-    restored.load(file.path);
+        dai::EncodedFrame restored;
+        restored.load(file.path);
 
-    REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
-    REQUIRE(restored.getWidth() == frame.getWidth());
-    REQUIRE(restored.getHeight() == frame.getHeight());
-    REQUIRE(restored.getQuality() == frame.getQuality());
-    REQUIRE(restored.getBitrate() == frame.getBitrate());
-    REQUIRE(restored.getProfile() == frame.getProfile());
-    REQUIRE(restored.getFrameType() == frame.getFrameType());
-    REQUIRE(restored.getLossless() == frame.getLossless());
-    REQUIRE(restored.getSequenceNum() == frame.getSequenceNum());
-    REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+        REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getHeight() == frame.getHeight());
+        REQUIRE(restored.getQuality() == frame.getQuality());
+        REQUIRE(restored.getBitrate() == frame.getBitrate());
+        REQUIRE(restored.getProfile() == frame.getProfile());
+        REQUIRE(restored.getFrameType() == frame.getFrameType());
+        REQUIRE(restored.getLossless() == frame.getLossless());
+        REQUIRE(restored.getSequenceNum() == frame.getSequenceNum());
+        REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+    }
+
+    SECTION("Explicit .dai path works the same for save and load") {
+        TempFile file("encodedframe_roundtrip_ext");
+        auto explicitPath = withDaiExtension(file.path);
+        frame.save(explicitPath);
+        REQUIRE(fs::exists(explicitPath));
+
+        dai::EncodedFrame restored;
+        restored.load(explicitPath);
+
+        REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getHeight() == frame.getHeight());
+        REQUIRE(restored.getQuality() == frame.getQuality());
+        REQUIRE(restored.getBitrate() == frame.getBitrate());
+        REQUIRE(restored.getProfile() == frame.getProfile());
+        REQUIRE(restored.getFrameType() == frame.getFrameType());
+        REQUIRE(restored.getLossless() == frame.getLossless());
+        REQUIRE(restored.getSequenceNum() == frame.getSequenceNum());
+        REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+    }
+
+    SECTION("Explicit non-.dai extension is preserved") {
+        TempFile file("encodedframe_roundtrip_bin");
+        auto explicitPath = withCustomExtension(file.path, ".bin");
+        frame.save(explicitPath);
+        REQUIRE(fs::exists(explicitPath));
+        REQUIRE_FALSE(fs::exists(withDaiExtension(explicitPath)));
+
+        dai::EncodedFrame restored;
+        restored.load(explicitPath);
+
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getProfile() == frame.getProfile());
+        REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+    }
+}
+
+TEST_CASE("EncodedFrame metadata-only save/load clears payload", "[ProtoFileIO][EncodedFrame]") {
+    dai::EncodedFrame frame;
+    frame.setInstanceNum(5).setSize(128, 72).setProfile(dai::EncodedFrame::Profile::JPEG).setFrameType(dai::EncodedFrame::FrameType::I);
+    frame.setQuality(80);
+    frame.setData(std::vector<uint8_t>{5, 4, 3, 2, 1});
+
+    SECTION("Extensionless metadata-only path resolves to .dai") {
+        TempFile file("encodedframe_metadata_only_no_ext");
+        frame.save(file.path, true);
+        REQUIRE(fs::exists(withDaiExtension(file.path)));
+
+        dai::EncodedFrame restored;
+        restored.load(file.path, true);
+
+        REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getHeight() == frame.getHeight());
+        REQUIRE(restored.getProfile() == frame.getProfile());
+        REQUIRE(restored.getFrameType() == frame.getFrameType());
+        REQUIRE(restored.getData().empty());
+    }
+
+    SECTION("Explicit .dai metadata-only path works the same") {
+        TempFile file("encodedframe_metadata_only_ext");
+        auto explicitPath = withDaiExtension(file.path);
+        frame.save(explicitPath, true);
+        REQUIRE(fs::exists(explicitPath));
+
+        dai::EncodedFrame restored;
+        restored.load(explicitPath, true);
+
+        REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
+        REQUIRE(restored.getWidth() == frame.getWidth());
+        REQUIRE(restored.getHeight() == frame.getHeight());
+        REQUIRE(restored.getProfile() == frame.getProfile());
+        REQUIRE(restored.getFrameType() == frame.getFrameType());
+        REQUIRE(restored.getData().empty());
+    }
 }
 
 TEST_CASE("IMUData save/load roundtrip", "[ProtoFileIO][IMUData]") {
@@ -125,19 +258,40 @@ TEST_CASE("IMUData save/load roundtrip", "[ProtoFileIO][IMUData]") {
     packet.gyroscope.z = 0.3F;
     imu.packets.push_back(packet);
 
-    TempFile file("imudata_roundtrip");
-    imu.save(file.path);
+    SECTION("Extensionless path resolves to .dai for save and load") {
+        TempFile file("imudata_roundtrip_no_ext");
+        imu.save(file.path);
+        REQUIRE(fs::exists(withDaiExtension(file.path)));
 
-    dai::IMUData restored;
-    restored.load(file.path);
+        dai::IMUData restored;
+        restored.load(file.path);
 
-    REQUIRE(restored.getSequenceNum() == imu.getSequenceNum());
-    REQUIRE(restored.packets.size() == 1);
-    REQUIRE(restored.packets[0].acceleroMeter.sequence == 100);
-    REQUIRE(restored.packets[0].acceleroMeter.x == Catch::Approx(1.5F));
-    REQUIRE(restored.packets[0].acceleroMeter.z == Catch::Approx(9.81F));
-    REQUIRE(restored.packets[0].gyroscope.sequence == 101);
-    REQUIRE(restored.packets[0].gyroscope.y == Catch::Approx(0.2F));
+        REQUIRE(restored.getSequenceNum() == imu.getSequenceNum());
+        REQUIRE(restored.packets.size() == 1);
+        REQUIRE(restored.packets[0].acceleroMeter.sequence == 100);
+        REQUIRE(restored.packets[0].acceleroMeter.x == Catch::Approx(1.5F));
+        REQUIRE(restored.packets[0].acceleroMeter.z == Catch::Approx(9.81F));
+        REQUIRE(restored.packets[0].gyroscope.sequence == 101);
+        REQUIRE(restored.packets[0].gyroscope.y == Catch::Approx(0.2F));
+    }
+
+    SECTION("Explicit .dai path works the same for save and load") {
+        TempFile file("imudata_roundtrip_ext");
+        auto explicitPath = withDaiExtension(file.path);
+        imu.save(explicitPath);
+        REQUIRE(fs::exists(explicitPath));
+
+        dai::IMUData restored;
+        restored.load(explicitPath);
+
+        REQUIRE(restored.getSequenceNum() == imu.getSequenceNum());
+        REQUIRE(restored.packets.size() == 1);
+        REQUIRE(restored.packets[0].acceleroMeter.sequence == 100);
+        REQUIRE(restored.packets[0].acceleroMeter.x == Catch::Approx(1.5F));
+        REQUIRE(restored.packets[0].acceleroMeter.z == Catch::Approx(9.81F));
+        REQUIRE(restored.packets[0].gyroscope.sequence == 101);
+        REQUIRE(restored.packets[0].gyroscope.y == Catch::Approx(0.2F));
+    }
 }
 
 TEST_CASE("PointCloudData save/load roundtrip", "[ProtoFileIO][PointCloudData]") {
@@ -146,20 +300,42 @@ TEST_CASE("PointCloudData save/load roundtrip", "[ProtoFileIO][PointCloudData]")
     pcd.updateBoundingBox();
     pcd.setSequenceNum(55);
 
-    TempFile file("pointcloud_roundtrip");
-    pcd.save(file.path);
+    SECTION("Extensionless path resolves to .dai for save and load") {
+        TempFile file("pointcloud_roundtrip_no_ext");
+        pcd.save(file.path);
+        REQUIRE(fs::exists(withDaiExtension(file.path)));
 
-    dai::PointCloudData restored;
-    restored.load(file.path);
+        dai::PointCloudData restored;
+        restored.load(file.path);
 
-    REQUIRE(restored.getWidth() == pcd.getWidth());
-    REQUIRE(restored.getHeight() == pcd.getHeight());
-    REQUIRE(restored.getInstanceNum() == pcd.getInstanceNum());
-    REQUIRE(restored.getSequenceNum() == pcd.getSequenceNum());
-    REQUIRE(restored.getMinX() == Catch::Approx(pcd.getMinX()));
-    REQUIRE(restored.getMaxZ() == Catch::Approx(pcd.getMaxZ()));
-    REQUIRE(restored.getPoints().size() == pcd.getPoints().size());
-    REQUIRE(restored.getPoints()[2].z == Catch::Approx(9.F));
+        REQUIRE(restored.getWidth() == pcd.getWidth());
+        REQUIRE(restored.getHeight() == pcd.getHeight());
+        REQUIRE(restored.getInstanceNum() == pcd.getInstanceNum());
+        REQUIRE(restored.getSequenceNum() == pcd.getSequenceNum());
+        REQUIRE(restored.getMinX() == Catch::Approx(pcd.getMinX()));
+        REQUIRE(restored.getMaxZ() == Catch::Approx(pcd.getMaxZ()));
+        REQUIRE(restored.getPoints().size() == pcd.getPoints().size());
+        REQUIRE(restored.getPoints()[2].z == Catch::Approx(9.F));
+    }
+
+    SECTION("Explicit .dai path works the same for save and load") {
+        TempFile file("pointcloud_roundtrip_ext");
+        auto explicitPath = withDaiExtension(file.path);
+        pcd.save(explicitPath);
+        REQUIRE(fs::exists(explicitPath));
+
+        dai::PointCloudData restored;
+        restored.load(explicitPath);
+
+        REQUIRE(restored.getWidth() == pcd.getWidth());
+        REQUIRE(restored.getHeight() == pcd.getHeight());
+        REQUIRE(restored.getInstanceNum() == pcd.getInstanceNum());
+        REQUIRE(restored.getSequenceNum() == pcd.getSequenceNum());
+        REQUIRE(restored.getMinX() == Catch::Approx(pcd.getMinX()));
+        REQUIRE(restored.getMaxZ() == Catch::Approx(pcd.getMaxZ()));
+        REQUIRE(restored.getPoints().size() == pcd.getPoints().size());
+        REQUIRE(restored.getPoints()[2].z == Catch::Approx(9.F));
+    }
 }
 
 TEST_CASE("RGBDData save/load roundtrip", "[ProtoFileIO][RGBDData]") {
@@ -176,31 +352,92 @@ TEST_CASE("RGBDData save/load roundtrip", "[ProtoFileIO][RGBDData]") {
     rgbd.setRGBFrame(color);
     rgbd.setDepthFrame(depth);
 
-    TempFile file("rgbd_roundtrip");
-    rgbd.save(file.path);
+    SECTION("Extensionless path resolves to .dai for save and load") {
+        TempFile file("rgbd_roundtrip_no_ext");
+        rgbd.save(file.path);
+        REQUIRE(fs::exists(withDaiExtension(file.path)));
 
-    dai::RGBDData restored;
-    restored.load(file.path);
+        dai::RGBDData restored;
+        restored.load(file.path);
 
-    REQUIRE(restored.getSequenceNum() == rgbd.getSequenceNum());
+        REQUIRE(restored.getSequenceNum() == rgbd.getSequenceNum());
 
-    auto rgb = restored.getRGBFrame();
-    REQUIRE(rgb.has_value());
-    REQUIRE(std::holds_alternative<std::shared_ptr<dai::ImgFrame>>(*rgb));
-    auto restoredColor = std::get<std::shared_ptr<dai::ImgFrame>>(*rgb);
-    REQUIRE(restoredColor != nullptr);
-    REQUIRE(restoredColor->getWidth() == color->getWidth());
-    REQUIRE(restoredColor->getType() == color->getType());
-    REQUIRE(toVector(restoredColor->getData()) == toVector(color->getData()));
+        auto rgb = restored.getRGBFrame();
+        REQUIRE(rgb.has_value());
+        REQUIRE(std::holds_alternative<std::shared_ptr<dai::ImgFrame>>(*rgb));
+        auto restoredColor = std::get<std::shared_ptr<dai::ImgFrame>>(*rgb);
+        REQUIRE(restoredColor != nullptr);
+        REQUIRE(restoredColor->getWidth() == color->getWidth());
+        REQUIRE(restoredColor->getType() == color->getType());
+        REQUIRE(toVector(restoredColor->getData()) == toVector(color->getData()));
 
-    auto depthFrame = restored.getDepthFrame();
-    REQUIRE(depthFrame.has_value());
-    REQUIRE(std::holds_alternative<std::shared_ptr<dai::EncodedFrame>>(*depthFrame));
-    auto restoredDepth = std::get<std::shared_ptr<dai::EncodedFrame>>(*depthFrame);
-    REQUIRE(restoredDepth != nullptr);
-    REQUIRE(restoredDepth->getWidth() == depth->getWidth());
-    REQUIRE(restoredDepth->getProfile() == depth->getProfile());
-    REQUIRE(toVector(restoredDepth->getData()) == toVector(depth->getData()));
+        auto depthFrame = restored.getDepthFrame();
+        REQUIRE(depthFrame.has_value());
+        REQUIRE(std::holds_alternative<std::shared_ptr<dai::EncodedFrame>>(*depthFrame));
+        auto restoredDepth = std::get<std::shared_ptr<dai::EncodedFrame>>(*depthFrame);
+        REQUIRE(restoredDepth != nullptr);
+        REQUIRE(restoredDepth->getWidth() == depth->getWidth());
+        REQUIRE(restoredDepth->getProfile() == depth->getProfile());
+        REQUIRE(toVector(restoredDepth->getData()) == toVector(depth->getData()));
+    }
+
+    SECTION("Explicit .dai path works the same for save and load") {
+        TempFile file("rgbd_roundtrip_ext");
+        auto explicitPath = withDaiExtension(file.path);
+        rgbd.save(explicitPath);
+        REQUIRE(fs::exists(explicitPath));
+
+        dai::RGBDData restored;
+        restored.load(explicitPath);
+
+        REQUIRE(restored.getSequenceNum() == rgbd.getSequenceNum());
+
+        auto rgb = restored.getRGBFrame();
+        REQUIRE(rgb.has_value());
+        REQUIRE(std::holds_alternative<std::shared_ptr<dai::ImgFrame>>(*rgb));
+        auto restoredColor = std::get<std::shared_ptr<dai::ImgFrame>>(*rgb);
+        REQUIRE(restoredColor != nullptr);
+        REQUIRE(restoredColor->getWidth() == color->getWidth());
+        REQUIRE(restoredColor->getType() == color->getType());
+        REQUIRE(toVector(restoredColor->getData()) == toVector(color->getData()));
+
+        auto depthFrame = restored.getDepthFrame();
+        REQUIRE(depthFrame.has_value());
+        REQUIRE(std::holds_alternative<std::shared_ptr<dai::EncodedFrame>>(*depthFrame));
+        auto restoredDepth = std::get<std::shared_ptr<dai::EncodedFrame>>(*depthFrame);
+        REQUIRE(restoredDepth != nullptr);
+        REQUIRE(restoredDepth->getWidth() == depth->getWidth());
+        REQUIRE(restoredDepth->getProfile() == depth->getProfile());
+        REQUIRE(toVector(restoredDepth->getData()) == toVector(depth->getData()));
+    }
+}
+
+TEST_CASE("Proto file I/O reports missing and invalid files", "[ProtoFileIO][Failures]") {
+    SECTION("Missing file throws for extensionless path") {
+        TempFile file("missing_proto_file");
+        dai::ImgFrame frame;
+        REQUIRE_THROWS_AS(frame.load(file.path), std::runtime_error);
+    }
+
+    SECTION("Missing file throws for explicit .dai path") {
+        TempFile file("missing_proto_file_dai");
+        auto explicitPath = withDaiExtension(file.path);
+        dai::EncodedFrame frame;
+        REQUIRE_THROWS_AS(frame.load(explicitPath), std::runtime_error);
+    }
+
+    SECTION("Invalid protobuf payload throws") {
+        TempFile file("invalid_proto_file");
+        auto invalidPath = withDaiExtension(file.path);
+        {
+            std::ofstream out(invalidPath, std::ios::binary);
+            REQUIRE(out.good());
+            out << "not a protobuf payload";
+        }
+
+        dai::IMUData imu;
+        REQUIRE_THROWS_AS(imu.load(invalidPath), std::runtime_error);
+    }
 }
 
 #endif

--- a/tests/src/onhost_tests/pipeline/datatype/proto_file_io_test.cpp
+++ b/tests/src/onhost_tests/pipeline/datatype/proto_file_io_test.cpp
@@ -1,0 +1,206 @@
+#include <catch2/catch_all.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "depthai/pipeline/datatype/EncodedFrame.hpp"
+#include "depthai/pipeline/datatype/IMUData.hpp"
+#include "depthai/pipeline/datatype/ImgFrame.hpp"
+#include "depthai/pipeline/datatype/PointCloudData.hpp"
+#include "depthai/pipeline/datatype/RGBDData.hpp"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+class TempFile {
+   public:
+    explicit TempFile(const std::string& stem)
+        : path(fs::temp_directory_path() / (stem + "_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".pb")) {}
+
+    ~TempFile() {
+        std::error_code ec;
+        fs::remove(path, ec);
+    }
+
+    fs::path path;
+};
+
+std::vector<uint8_t> toVector(dai::span<const uint8_t> data) {
+    return std::vector<uint8_t>(data.begin(), data.end());
+}
+
+}  // namespace
+
+#ifndef DEPTHAI_ENABLE_PROTOBUF
+
+TEST_CASE("Proto file I/O requires protobuf support", "[ProtoFileIO]") {
+    SUCCEED("Protobuf support disabled");
+}
+
+#else
+
+TEST_CASE("ImgFrame save/load roundtrip", "[ProtoFileIO][ImgFrame]") {
+    dai::ImgFrame frame;
+    frame.setInstanceNum(4).setCategory(9).setSize(8, 6).setSourceSize(8, 6).setType(dai::ImgFrame::Type::RAW8);
+    frame.setSequenceNum(123);
+    frame.cam.exposureTimeUs = 2500;
+    frame.setData(std::vector<uint8_t>{1, 2, 3, 4, 5, 6, 7, 8});
+
+    TempFile file("imgframe_roundtrip");
+    frame.save(file.path);
+
+    dai::ImgFrame restored;
+    restored.load(file.path);
+
+    REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
+    REQUIRE(restored.getCategory() == frame.getCategory());
+    REQUIRE(restored.getWidth() == frame.getWidth());
+    REQUIRE(restored.getHeight() == frame.getHeight());
+    REQUIRE(restored.getType() == frame.getType());
+    REQUIRE(restored.getSequenceNum() == frame.getSequenceNum());
+    REQUIRE(restored.getExposureTime() == frame.getExposureTime());
+    REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+}
+
+TEST_CASE("ImgFrame metadata-only save/load clears payload", "[ProtoFileIO][ImgFrame]") {
+    dai::ImgFrame frame;
+    frame.setSize(4, 4).setSourceSize(4, 4).setType(dai::ImgFrame::Type::RAW8);
+    frame.setData(std::vector<uint8_t>{9, 8, 7, 6});
+
+    TempFile file("imgframe_metadata_only");
+    frame.save(file.path, true);
+
+    dai::ImgFrame restored;
+    restored.load(file.path, true);
+
+    REQUIRE(restored.getWidth() == frame.getWidth());
+    REQUIRE(restored.getHeight() == frame.getHeight());
+    REQUIRE(restored.getType() == frame.getType());
+    REQUIRE(restored.getData().empty());
+}
+
+TEST_CASE("EncodedFrame save/load roundtrip", "[ProtoFileIO][EncodedFrame]") {
+    dai::EncodedFrame frame;
+    frame.setInstanceNum(3).setSize(320, 180).setQuality(91).setBitrate(1234567).setProfile(dai::EncodedFrame::Profile::JPEG).setFrameType(
+        dai::EncodedFrame::FrameType::I);
+    frame.setLossless(false);
+    frame.setSequenceNum(777);
+    frame.setData(std::vector<uint8_t>{10, 20, 30, 40, 50});
+
+    TempFile file("encodedframe_roundtrip");
+    frame.save(file.path);
+
+    dai::EncodedFrame restored;
+    restored.load(file.path);
+
+    REQUIRE(restored.getInstanceNum() == frame.getInstanceNum());
+    REQUIRE(restored.getWidth() == frame.getWidth());
+    REQUIRE(restored.getHeight() == frame.getHeight());
+    REQUIRE(restored.getQuality() == frame.getQuality());
+    REQUIRE(restored.getBitrate() == frame.getBitrate());
+    REQUIRE(restored.getProfile() == frame.getProfile());
+    REQUIRE(restored.getFrameType() == frame.getFrameType());
+    REQUIRE(restored.getLossless() == frame.getLossless());
+    REQUIRE(restored.getSequenceNum() == frame.getSequenceNum());
+    REQUIRE(toVector(restored.getData()) == toVector(frame.getData()));
+}
+
+TEST_CASE("IMUData save/load roundtrip", "[ProtoFileIO][IMUData]") {
+    dai::IMUData imu;
+    imu.setSequenceNum(42);
+    dai::IMUPacket packet;
+    packet.acceleroMeter.sequence = 100;
+    packet.acceleroMeter.x = 1.5F;
+    packet.acceleroMeter.y = -2.0F;
+    packet.acceleroMeter.z = 9.81F;
+    packet.gyroscope.sequence = 101;
+    packet.gyroscope.x = 0.1F;
+    packet.gyroscope.y = 0.2F;
+    packet.gyroscope.z = 0.3F;
+    imu.packets.push_back(packet);
+
+    TempFile file("imudata_roundtrip");
+    imu.save(file.path);
+
+    dai::IMUData restored;
+    restored.load(file.path);
+
+    REQUIRE(restored.getSequenceNum() == imu.getSequenceNum());
+    REQUIRE(restored.packets.size() == 1);
+    REQUIRE(restored.packets[0].acceleroMeter.sequence == 100);
+    REQUIRE(restored.packets[0].acceleroMeter.x == Catch::Approx(1.5F));
+    REQUIRE(restored.packets[0].acceleroMeter.z == Catch::Approx(9.81F));
+    REQUIRE(restored.packets[0].gyroscope.sequence == 101);
+    REQUIRE(restored.packets[0].gyroscope.y == Catch::Approx(0.2F));
+}
+
+TEST_CASE("PointCloudData save/load roundtrip", "[ProtoFileIO][PointCloudData]") {
+    dai::PointCloudData pcd;
+    pcd.setWidth(2).setHeight(2).setInstanceNum(6).setPoints({{1.F, 2.F, 3.F}, {4.F, 5.F, 6.F}, {7.F, 8.F, 9.F}, {10.F, 11.F, 12.F}});
+    pcd.updateBoundingBox();
+    pcd.setSequenceNum(55);
+
+    TempFile file("pointcloud_roundtrip");
+    pcd.save(file.path);
+
+    dai::PointCloudData restored;
+    restored.load(file.path);
+
+    REQUIRE(restored.getWidth() == pcd.getWidth());
+    REQUIRE(restored.getHeight() == pcd.getHeight());
+    REQUIRE(restored.getInstanceNum() == pcd.getInstanceNum());
+    REQUIRE(restored.getSequenceNum() == pcd.getSequenceNum());
+    REQUIRE(restored.getMinX() == Catch::Approx(pcd.getMinX()));
+    REQUIRE(restored.getMaxZ() == Catch::Approx(pcd.getMaxZ()));
+    REQUIRE(restored.getPoints().size() == pcd.getPoints().size());
+    REQUIRE(restored.getPoints()[2].z == Catch::Approx(9.F));
+}
+
+TEST_CASE("RGBDData save/load roundtrip", "[ProtoFileIO][RGBDData]") {
+    auto color = std::make_shared<dai::ImgFrame>();
+    color->setSize(4, 3).setSourceSize(4, 3).setType(dai::ImgFrame::Type::RAW8).setInstanceNum(1);
+    color->setData(std::vector<uint8_t>{1, 2, 3, 4});
+
+    auto depth = std::make_shared<dai::EncodedFrame>();
+    depth->setSize(4, 3).setProfile(dai::EncodedFrame::Profile::JPEG).setFrameType(dai::EncodedFrame::FrameType::I).setInstanceNum(2);
+    depth->setData(std::vector<uint8_t>{9, 8, 7});
+
+    dai::RGBDData rgbd;
+    rgbd.setSequenceNum(999);
+    rgbd.setRGBFrame(color);
+    rgbd.setDepthFrame(depth);
+
+    TempFile file("rgbd_roundtrip");
+    rgbd.save(file.path);
+
+    dai::RGBDData restored;
+    restored.load(file.path);
+
+    REQUIRE(restored.getSequenceNum() == rgbd.getSequenceNum());
+
+    auto rgb = restored.getRGBFrame();
+    REQUIRE(rgb.has_value());
+    REQUIRE(std::holds_alternative<std::shared_ptr<dai::ImgFrame>>(*rgb));
+    auto restoredColor = std::get<std::shared_ptr<dai::ImgFrame>>(*rgb);
+    REQUIRE(restoredColor != nullptr);
+    REQUIRE(restoredColor->getWidth() == color->getWidth());
+    REQUIRE(restoredColor->getType() == color->getType());
+    REQUIRE(toVector(restoredColor->getData()) == toVector(color->getData()));
+
+    auto depthFrame = restored.getDepthFrame();
+    REQUIRE(depthFrame.has_value());
+    REQUIRE(std::holds_alternative<std::shared_ptr<dai::EncodedFrame>>(*depthFrame));
+    auto restoredDepth = std::get<std::shared_ptr<dai::EncodedFrame>>(*depthFrame);
+    REQUIRE(restoredDepth != nullptr);
+    REQUIRE(restoredDepth->getWidth() == depth->getWidth());
+    REQUIRE(restoredDepth->getProfile() == depth->getProfile());
+    REQUIRE(toVector(restoredDepth->getData()) == toVector(depth->getData()));
+}
+
+#endif


### PR DESCRIPTION
## Purpose
- add load && save functions to `ImgFrame`
- This allows to store and load image without any compression with all metadata present.
- This is useful for the benchmarks / datasets especially when the imgTransformations are present

## Notes
- this can be done for all `Buffer`s except `MessageGroup` ... for now I did it only for `ImgFrame`

example of usage:
[load_save.py](https://github.com/user-attachments/files/29045587/load_save.py)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added disk persistence APIs `save(path, metadataOnly=False)` and `load(path, metadataOnly=False)` for image frames, including metadata-only mode that omits payload data.
  * Extended the same file-based persistence (with metadata-only option) to additional datatypes: encoded frames, IMU data, point clouds, and RGBD.
  * Extensionless paths are automatically saved/loaded using a `.dai` suffix in protobuf-enabled builds.

* **Tests**
  * Added on-host roundtrip and failure-mode tests validating full vs metadata-only behavior, pixel/data preservation, `.dai` path handling, and error handling for missing/invalid files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->