### PR TITLE
Fix PointCloud node: use calibrated translation from ImgTransformations extrinsics instead of specTranslation

### DIFF
--- a/bindings/python/src/pipeline/datatype/PointCloudConfigBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/PointCloudConfigBindings.cpp
@@ -60,19 +60,29 @@ void bind_pointcloudconfig(pybind11::module& m, void* pCallstack) {
         .def("getLengthUnit", &PointCloudConfig::getLengthUnit, DOC(dai, PointCloudConfig, getLengthUnit))
         .def("setLengthUnit", &PointCloudConfig::setLengthUnit, DOC(dai, PointCloudConfig, setLengthUnit))
         .def("setTargetCoordinateSystem",
-             py::overload_cast<CameraBoardSocket, bool>(&PointCloudConfig::setTargetCoordinateSystem),
+             py::overload_cast<CameraBoardSocket>(&PointCloudConfig::setTargetCoordinateSystem),
              py::arg("targetCamera"),
-             py::arg("useSpecTranslation") = false,
              DOC(dai, PointCloudConfig, setTargetCoordinateSystem))
         .def("setTargetCoordinateSystem",
-             py::overload_cast<HousingCoordinateSystem, bool>(&PointCloudConfig::setTargetCoordinateSystem),
+             py::overload_cast<HousingCoordinateSystem>(&PointCloudConfig::setTargetCoordinateSystem),
              py::arg("housingCS"),
-             py::arg("useSpecTranslation") = true,
              DOC(dai, PointCloudConfig, setTargetCoordinateSystem, 2))
         .def("getCoordinateSystemType", &PointCloudConfig::getCoordinateSystemType, DOC(dai, PointCloudConfig, getCoordinateSystemType))
         .def("getTargetCameraSocket", &PointCloudConfig::getTargetCameraSocket, DOC(dai, PointCloudConfig, getTargetCameraSocket))
         .def("getTargetHousingCS", &PointCloudConfig::getTargetHousingCS, DOC(dai, PointCloudConfig, getTargetHousingCS))
         .def("getUseSpecTranslation", &PointCloudConfig::getUseSpecTranslation, DOC(dai, PointCloudConfig, getUseSpecTranslation))
+        .def(
+            "setTargetCoordinateSystem",
+            py::overload_cast<CameraBoardSocket, bool>(&PointCloudConfig::setTargetCoordinateSystem),
+            py::arg("targetCamera"),
+            py::arg("useSpecTranslation"),
+            "**Deprecated:** Use setTargetCoordinateSystem(targetCamera) instead.")
+        .def(
+            "setTargetCoordinateSystem",
+            py::overload_cast<HousingCoordinateSystem, bool>(&PointCloudConfig::setTargetCoordinateSystem),
+            py::arg("housingCS"),
+            py::arg("useSpecTranslation"),
+            "**Deprecated:** Use setTargetCoordinateSystem(housingCS) instead.")
         // Deprecated
         .def(
             "getSparse",

--- a/bindings/python/src/pipeline/datatype/PointCloudConfigBindings.cpp
+++ b/bindings/python/src/pipeline/datatype/PointCloudConfigBindings.cpp
@@ -71,18 +71,16 @@ void bind_pointcloudconfig(pybind11::module& m, void* pCallstack) {
         .def("getTargetCameraSocket", &PointCloudConfig::getTargetCameraSocket, DOC(dai, PointCloudConfig, getTargetCameraSocket))
         .def("getTargetHousingCS", &PointCloudConfig::getTargetHousingCS, DOC(dai, PointCloudConfig, getTargetHousingCS))
         .def("getUseSpecTranslation", &PointCloudConfig::getUseSpecTranslation, DOC(dai, PointCloudConfig, getUseSpecTranslation))
-        .def(
-            "setTargetCoordinateSystem",
-            py::overload_cast<CameraBoardSocket, bool>(&PointCloudConfig::setTargetCoordinateSystem),
-            py::arg("targetCamera"),
-            py::arg("useSpecTranslation"),
-            "**Deprecated:** Use setTargetCoordinateSystem(targetCamera) instead.")
-        .def(
-            "setTargetCoordinateSystem",
-            py::overload_cast<HousingCoordinateSystem, bool>(&PointCloudConfig::setTargetCoordinateSystem),
-            py::arg("housingCS"),
-            py::arg("useSpecTranslation"),
-            "**Deprecated:** Use setTargetCoordinateSystem(housingCS) instead.")
+        .def("setTargetCoordinateSystem",
+             py::overload_cast<CameraBoardSocket, bool>(&PointCloudConfig::setTargetCoordinateSystem),
+             py::arg("targetCamera"),
+             py::arg("useSpecTranslation"),
+             "**Deprecated:** Use setTargetCoordinateSystem(targetCamera) instead.")
+        .def("setTargetCoordinateSystem",
+             py::overload_cast<HousingCoordinateSystem, bool>(&PointCloudConfig::setTargetCoordinateSystem),
+             py::arg("housingCS"),
+             py::arg("useSpecTranslation"),
+             "**Deprecated:** Use setTargetCoordinateSystem(housingCS) instead.")
         // Deprecated
         .def(
             "getSparse",

--- a/bindings/python/src/pipeline/node/PointCloudBindings.cpp
+++ b/bindings/python/src/pipeline/node/PointCloudBindings.cpp
@@ -48,15 +48,25 @@ void bind_pointcloud(pybind11::module& m, void* pCallstack) {
         .def("useCPUMT", &PointCloud::useCPUMT, py::arg("numThreads") = 2, DOC(dai, node, PointCloud, useCPUMT))
         .def("useGPU", &PointCloud::useGPU, py::arg("device") = 0, DOC(dai, node, PointCloud, useGPU))
         .def("setTargetCoordinateSystem",
-             py::overload_cast<CameraBoardSocket, bool>(&PointCloud::setTargetCoordinateSystem),
+             py::overload_cast<CameraBoardSocket>(&PointCloud::setTargetCoordinateSystem),
              py::arg("targetCamera"),
-             py::arg("useSpecTranslation") = false,
              DOC(dai, node, PointCloud, setTargetCoordinateSystem))
         .def("setTargetCoordinateSystem",
-             py::overload_cast<HousingCoordinateSystem, bool>(&PointCloud::setTargetCoordinateSystem),
+             py::overload_cast<HousingCoordinateSystem>(&PointCloud::setTargetCoordinateSystem),
              py::arg("housingCS"),
-             py::arg("useSpecTranslation") = true,
-             DOC(dai, node, PointCloud, setTargetCoordinateSystem, 2));
+             DOC(dai, node, PointCloud, setTargetCoordinateSystem, 2))
+        .def(
+            "setTargetCoordinateSystem",
+            py::overload_cast<CameraBoardSocket, bool>(&PointCloud::setTargetCoordinateSystem),
+            py::arg("targetCamera"),
+            py::arg("useSpecTranslation"),
+            "**Deprecated:** Use setTargetCoordinateSystem(targetCamera) instead.")
+        .def(
+            "setTargetCoordinateSystem",
+            py::overload_cast<HousingCoordinateSystem, bool>(&PointCloud::setTargetCoordinateSystem),
+            py::arg("housingCS"),
+            py::arg("useSpecTranslation"),
+            "**Deprecated:** Use setTargetCoordinateSystem(housingCS) instead.");
 
     // ALIAS
     daiNodeModule.attr("PointCloud").attr("Properties") = properties;

--- a/bindings/python/src/pipeline/node/PointCloudBindings.cpp
+++ b/bindings/python/src/pipeline/node/PointCloudBindings.cpp
@@ -55,18 +55,16 @@ void bind_pointcloud(pybind11::module& m, void* pCallstack) {
              py::overload_cast<HousingCoordinateSystem>(&PointCloud::setTargetCoordinateSystem),
              py::arg("housingCS"),
              DOC(dai, node, PointCloud, setTargetCoordinateSystem, 2))
-        .def(
-            "setTargetCoordinateSystem",
-            py::overload_cast<CameraBoardSocket, bool>(&PointCloud::setTargetCoordinateSystem),
-            py::arg("targetCamera"),
-            py::arg("useSpecTranslation"),
-            "**Deprecated:** Use setTargetCoordinateSystem(targetCamera) instead.")
-        .def(
-            "setTargetCoordinateSystem",
-            py::overload_cast<HousingCoordinateSystem, bool>(&PointCloud::setTargetCoordinateSystem),
-            py::arg("housingCS"),
-            py::arg("useSpecTranslation"),
-            "**Deprecated:** Use setTargetCoordinateSystem(housingCS) instead.");
+        .def("setTargetCoordinateSystem",
+             py::overload_cast<CameraBoardSocket, bool>(&PointCloud::setTargetCoordinateSystem),
+             py::arg("targetCamera"),
+             py::arg("useSpecTranslation"),
+             "**Deprecated:** Use setTargetCoordinateSystem(targetCamera) instead.")
+        .def("setTargetCoordinateSystem",
+             py::overload_cast<HousingCoordinateSystem, bool>(&PointCloud::setTargetCoordinateSystem),
+             py::arg("housingCS"),
+             py::arg("useSpecTranslation"),
+             "**Deprecated:** Use setTargetCoordinateSystem(housingCS) instead.");
 
     // ALIAS
     daiNodeModule.attr("PointCloud").attr("Properties") = properties;

--- a/examples/cpp/PointCloud/README.md
+++ b/examples/cpp/PointCloud/README.md
@@ -33,20 +33,20 @@ via `setTargetCoordinateSystem()`. Three kinds of target frame are supported:
 
 ```cpp
 pc->setTargetCoordinateSystem(dai::CameraBoardSocket::CAM_A);
-// useSpecTranslation=true  →  use nominal spec translation instead of per-unit calibration
 ```
 
-Available sockets: `CAM_A` … `CAM_J`. `useSpecTranslation` defaults to `false`.
+Available sockets: `CAM_A` … `CAM_J`.
+This preferred overload uses calibrated translations. The legacy
+`setTargetCoordinateSystem(socket, useSpecTranslation)` overload is deprecated.
 
 **B) Housing coordinate system** — uses housing calibration stored on the device.
 
 ```cpp
 pc->setTargetCoordinateSystem(dai::HousingCoordinateSystem::VESA_A);
-// useSpecTranslation=false  →  use per-unit calibrated values instead of spec
 ```
 
 Available targets: `CAM_A`…`CAM_J`, `FRONT_CAM_A`…`FRONT_CAM_J`, `VESA_A`…`VESA_J`, `IMU`.
-`useSpecTranslation` defaults to `true`.
+Housing calibration is resolved using the spec translation path.
 
 **C) Custom 4×4 matrix** — any homogeneous transform via `initialConfig` or the runtime
 `inputConfig` queue. When combined with (A)/(B), the custom matrix is applied *after*

--- a/include/depthai/pipeline/datatype/PointCloudConfig.hpp
+++ b/include/depthai/pipeline/datatype/PointCloudConfig.hpp
@@ -9,9 +9,6 @@
 #include "depthai/pipeline/datatype/Buffer.hpp"
 
 namespace dai {
-namespace node {
-class PointCloud;
-}
 
 /**
  * PointCloudConfig message. Carries point cloud output settings.
@@ -33,8 +30,6 @@ class PointCloudConfig : public Buffer {
     };
 
    private:
-    friend class node::PointCloud;
-
     CoordinateSystemType coordSystemType = CoordinateSystemType::DEFAULT;
     CameraBoardSocket targetCameraSocket = CameraBoardSocket::AUTO;
     HousingCoordinateSystem targetHousingCS = HousingCoordinateSystem::AUTO;

--- a/include/depthai/pipeline/datatype/PointCloudConfig.hpp
+++ b/include/depthai/pipeline/datatype/PointCloudConfig.hpp
@@ -9,6 +9,9 @@
 #include "depthai/pipeline/datatype/Buffer.hpp"
 
 namespace dai {
+namespace node {
+class PointCloud;
+}
 
 /**
  * PointCloudConfig message. Carries point cloud output settings.
@@ -30,10 +33,12 @@ class PointCloudConfig : public Buffer {
     };
 
    private:
+    friend class node::PointCloud;
+
     CoordinateSystemType coordSystemType = CoordinateSystemType::DEFAULT;
     CameraBoardSocket targetCameraSocket = CameraBoardSocket::AUTO;
     HousingCoordinateSystem targetHousingCS = HousingCoordinateSystem::AUTO;
-    bool useSpecTranslation = true;
+    bool useSpecTranslation = false;
 
    public:
     PointCloudConfig() = default;
@@ -81,16 +86,24 @@ class PointCloudConfig : public Buffer {
     /**
      * Set target coordinate system to another camera socket.
      * @param targetCamera Target camera socket
-     * @param useSpecTranslation Use spec translation instead of calibration (default: false)
      */
-    PointCloudConfig& setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpecTranslation = false);
+    PointCloudConfig& setTargetCoordinateSystem(CameraBoardSocket targetCamera);
 
     /**
      * Set target coordinate system to housing coordinate system.
      * @param housingCS Target housing coordinate system
-     * @param useSpecTranslation Whether to use spec translation (default: true)
      */
-    PointCloudConfig& setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpecTranslation = true);
+    PointCloudConfig& setTargetCoordinateSystem(HousingCoordinateSystem housingCS);
+
+    /**
+     * Deprecated: use setTargetCoordinateSystem(targetCamera) instead.
+     */
+    PointCloudConfig& setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpecTranslation);
+
+    /**
+     * Deprecated: use setTargetCoordinateSystem(housingCS) instead.
+     */
+    PointCloudConfig& setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpecTranslation);
 
     /**
      * Retrieve the coordinate system type.

--- a/include/depthai/pipeline/node/PointCloud.hpp
+++ b/include/depthai/pipeline/node/PointCloud.hpp
@@ -203,17 +203,25 @@ class PointCloud : public DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudPrope
     /**
      * Set target coordinate system to transform point cloud
      * @param targetCamera Target camera socket
-     * @param useSpecTranslation Use spec translation instead of calibration (default: false)
      */
-    void setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpecTranslation = false);
+    void setTargetCoordinateSystem(CameraBoardSocket targetCamera);
 
     /**
      * Set target coordinate system to housing coordinate system
      * Point cloud will be transformed to this housing coordinate system
      * @param housingCS Target housing coordinate system
-     * @param useSpecTranslation Whether to use spec translation (default: true)
      */
-    void setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpecTranslation = true);
+    void setTargetCoordinateSystem(HousingCoordinateSystem housingCS);
+
+    /**
+     * Deprecated: use setTargetCoordinateSystem(targetCamera) instead.
+     */
+    void setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpecTranslation);
+
+    /**
+     * Deprecated: use setTargetCoordinateSystem(housingCS) instead.
+     */
+    void setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpecTranslation);
 
     bool runOnHost() const override;
 

--- a/src/pipeline/datatype/PointCloudConfig.cpp
+++ b/src/pipeline/datatype/PointCloudConfig.cpp
@@ -1,5 +1,7 @@
 #include "depthai/pipeline/datatype/PointCloudConfig.hpp"
 
+#include <spdlog/spdlog.h>
+
 namespace dai {
 
 PointCloudConfig::~PointCloudConfig() = default;
@@ -42,7 +44,21 @@ PointCloudConfig& PointCloudConfig::setLengthUnit(LengthUnit unit) {
     return *this;
 }
 
+PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket targetCamera) {
+    coordSystemType = CoordinateSystemType::CAMERA_SOCKET;
+    targetCameraSocket = targetCamera;
+    return *this;
+}
+
+PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem housingCS) {
+    coordSystemType = CoordinateSystemType::HOUSING;
+    targetHousingCS = housingCS;
+    return *this;
+}
+
 PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpec) {
+    spdlog::warn("PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket, bool) is deprecated. "
+                 "Use PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket) instead.");
     coordSystemType = CoordinateSystemType::CAMERA_SOCKET;
     targetCameraSocket = targetCamera;
     useSpecTranslation = useSpec;
@@ -50,6 +66,8 @@ PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket 
 }
 
 PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpec) {
+    spdlog::warn("PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem, bool) is deprecated. "
+                 "Use PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem) instead.");
     coordSystemType = CoordinateSystemType::HOUSING;
     targetHousingCS = housingCS;
     useSpecTranslation = useSpec;

--- a/src/pipeline/datatype/PointCloudConfig.cpp
+++ b/src/pipeline/datatype/PointCloudConfig.cpp
@@ -57,8 +57,9 @@ PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateS
 }
 
 PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpec) {
-    spdlog::warn("PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket, bool) is deprecated. "
-                 "Use PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket) instead.");
+    spdlog::warn(
+        "PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket, bool) is deprecated. "
+        "Use PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket) instead.");
     coordSystemType = CoordinateSystemType::CAMERA_SOCKET;
     targetCameraSocket = targetCamera;
     useSpecTranslation = useSpec;
@@ -66,8 +67,9 @@ PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(CameraBoardSocket 
 }
 
 PointCloudConfig& PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpec) {
-    spdlog::warn("PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem, bool) is deprecated. "
-                 "Use PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem) instead.");
+    spdlog::warn(
+        "PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem, bool) is deprecated. "
+        "Use PointCloudConfig::setTargetCoordinateSystem(HousingCoordinateSystem) instead.");
     coordSystemType = CoordinateSystemType::HOUSING;
     targetHousingCS = housingCS;
     useSpecTranslation = useSpec;

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -489,16 +489,18 @@ void PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem housingCS) {
 }
 
 void PointCloud::setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpecTranslation) {
-    spdlog::warn("PointCloud::setTargetCoordinateSystem(CameraBoardSocket, bool) is deprecated. "
-                 "Use PointCloud::setTargetCoordinateSystem(CameraBoardSocket) instead.");
+    spdlog::warn(
+        "PointCloud::setTargetCoordinateSystem(CameraBoardSocket, bool) is deprecated. "
+        "Use PointCloud::setTargetCoordinateSystem(CameraBoardSocket) instead.");
     initialConfig->coordSystemType = PointCloudConfig::CoordinateSystemType::CAMERA_SOCKET;
     initialConfig->targetCameraSocket = targetCamera;
     initialConfig->useSpecTranslation = useSpecTranslation;
 }
 
 void PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpecTranslation) {
-    spdlog::warn("PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem, bool) is deprecated. "
-                 "Use PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem) instead.");
+    spdlog::warn(
+        "PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem, bool) is deprecated. "
+        "Use PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem) instead.");
     initialConfig->coordSystemType = PointCloudConfig::CoordinateSystemType::HOUSING;
     initialConfig->targetHousingCS = housingCS;
     initialConfig->useSpecTranslation = useSpecTranslation;

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -1,6 +1,7 @@
 #include "depthai/pipeline/node/PointCloud.hpp"
 
 #include <spdlog/logger.h>
+#include <spdlog/spdlog.h>
 
 #include <chrono>
 #include <cstring>
@@ -479,12 +480,28 @@ void PointCloud::useGPU(uint32_t device) {
     pimplPointCloud->useGPU(device);
 }
 
+void PointCloud::setTargetCoordinateSystem(CameraBoardSocket targetCamera) {
+    initialConfig->setTargetCoordinateSystem(targetCamera);
+}
+
+void PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem housingCS) {
+    initialConfig->setTargetCoordinateSystem(housingCS);
+}
+
 void PointCloud::setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpecTranslation) {
-    initialConfig->setTargetCoordinateSystem(targetCamera, useSpecTranslation);
+    spdlog::warn("PointCloud::setTargetCoordinateSystem(CameraBoardSocket, bool) is deprecated. "
+                 "Use PointCloud::setTargetCoordinateSystem(CameraBoardSocket) instead.");
+    initialConfig->coordSystemType = PointCloudConfig::CoordinateSystemType::CAMERA_SOCKET;
+    initialConfig->targetCameraSocket = targetCamera;
+    initialConfig->useSpecTranslation = useSpecTranslation;
 }
 
 void PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpecTranslation) {
-    initialConfig->setTargetCoordinateSystem(housingCS, useSpecTranslation);
+    spdlog::warn("PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem, bool) is deprecated. "
+                 "Use PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem) instead.");
+    initialConfig->coordSystemType = PointCloudConfig::CoordinateSystemType::HOUSING;
+    initialConfig->targetHousingCS = housingCS;
+    initialConfig->useSpecTranslation = useSpecTranslation;
 }
 
 bool PointCloud::hasTransformationChanged(const ImgFrame& frame) {

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -489,21 +489,11 @@ void PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem housingCS) {
 }
 
 void PointCloud::setTargetCoordinateSystem(CameraBoardSocket targetCamera, bool useSpecTranslation) {
-    spdlog::warn(
-        "PointCloud::setTargetCoordinateSystem(CameraBoardSocket, bool) is deprecated. "
-        "Use PointCloud::setTargetCoordinateSystem(CameraBoardSocket) instead.");
-    initialConfig->coordSystemType = PointCloudConfig::CoordinateSystemType::CAMERA_SOCKET;
-    initialConfig->targetCameraSocket = targetCamera;
-    initialConfig->useSpecTranslation = useSpecTranslation;
+    initialConfig->setTargetCoordinateSystem(targetCamera, useSpecTranslation);
 }
 
 void PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem housingCS, bool useSpecTranslation) {
-    spdlog::warn(
-        "PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem, bool) is deprecated. "
-        "Use PointCloud::setTargetCoordinateSystem(HousingCoordinateSystem) instead.");
-    initialConfig->coordSystemType = PointCloudConfig::CoordinateSystemType::HOUSING;
-    initialConfig->targetHousingCS = housingCS;
-    initialConfig->useSpecTranslation = useSpecTranslation;
+    initialConfig->setTargetCoordinateSystem(housingCS, useSpecTranslation);
 }
 
 bool PointCloud::hasTransformationChanged(const ImgFrame& frame) {

--- a/tests/src/onhost_tests/point_cloud_test.cpp
+++ b/tests/src/onhost_tests/point_cloud_test.cpp
@@ -1752,3 +1752,61 @@ TEST_CASE("setSparse throws logic_error", "[PointCloud][PointCloudData]") {
     REQUIRE_THROWS_AS(pcd.setSparse(false), std::logic_error);
 #pragma GCC diagnostic pop
 }
+
+// ============================================================================
+// Frame extrinsics: getTransformationMatrix(false) uses measured translation
+// ============================================================================
+TEST_CASE("Extrinsics getTransformationMatrix(false) uses measured translation, not spec", "[PointCloud][Extrinsics]") {
+    // Create extrinsics with different measured and spec translation values
+    dai::Extrinsics ext;
+    ext.rotationMatrix = eye3();
+    ext.translation = {1.0f, 2.0f, 3.0f};          // measured (calibrated)
+    ext.specTranslation = {10.0f, 20.0f, 30.0f};   // spec (CAD design)
+    ext.toCameraSocket = dai::CameraBoardSocket::CAM_C;
+
+    // getTransformationMatrix(false) should use measured translation
+    auto matMeasured = ext.getTransformationMatrix(false, dai::LengthUnit::CENTIMETER);
+    REQUIRE(matMeasured[0][3] == Catch::Approx(1.0f));
+    REQUIRE(matMeasured[1][3] == Catch::Approx(2.0f));
+    REQUIRE(matMeasured[2][3] == Catch::Approx(3.0f));
+
+    // getTransformationMatrix(true) should use spec translation
+    auto matSpec = ext.getTransformationMatrix(true, dai::LengthUnit::CENTIMETER);
+    REQUIRE(matSpec[0][3] == Catch::Approx(10.0f));
+    REQUIRE(matSpec[1][3] == Catch::Approx(20.0f));
+    REQUIRE(matSpec[2][3] == Catch::Approx(30.0f));
+
+    // Verify rotation part is identity in both cases
+    for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) {
+            float expected = (i == j) ? 1.0f : 0.0f;
+            REQUIRE(matMeasured[i][j] == Catch::Approx(expected));
+            REQUIRE(matSpec[i][j] == Catch::Approx(expected));
+        }
+    }
+}
+
+// ============================================================================
+// PointCloudConfig: new overloads preserve the current useSpecTranslation value
+// ============================================================================
+TEST_CASE("PointCloudConfig overloads preserve useSpecTranslation behavior", "[PointCloud][Config]") {
+    dai::PointCloudConfig cfg;
+
+    REQUIRE_FALSE(cfg.getUseSpecTranslation());
+
+    cfg.setTargetCoordinateSystem(dai::CameraBoardSocket::CAM_A);
+    REQUIRE(cfg.getCoordinateSystemType() == dai::PointCloudConfig::CoordinateSystemType::CAMERA_SOCKET);
+    REQUIRE(cfg.getTargetCameraSocket() == dai::CameraBoardSocket::CAM_A);
+    REQUIRE_FALSE(cfg.getUseSpecTranslation());
+
+    cfg.setTargetCoordinateSystem(dai::CameraBoardSocket::CAM_B, false);
+    REQUIRE_FALSE(cfg.getUseSpecTranslation());
+
+    cfg.setTargetCoordinateSystem(dai::HousingCoordinateSystem::VESA_A);
+    REQUIRE(cfg.getCoordinateSystemType() == dai::PointCloudConfig::CoordinateSystemType::HOUSING);
+    REQUIRE(cfg.getTargetHousingCS() == dai::HousingCoordinateSystem::VESA_A);
+    REQUIRE_FALSE(cfg.getUseSpecTranslation());
+
+    cfg.setTargetCoordinateSystem(dai::HousingCoordinateSystem::VESA_B, true);
+    REQUIRE(cfg.getUseSpecTranslation());
+}

--- a/tests/src/onhost_tests/point_cloud_test.cpp
+++ b/tests/src/onhost_tests/point_cloud_test.cpp
@@ -1760,8 +1760,8 @@ TEST_CASE("Extrinsics getTransformationMatrix(false) uses measured translation, 
     // Create extrinsics with different measured and spec translation values
     dai::Extrinsics ext;
     ext.rotationMatrix = eye3();
-    ext.translation = {1.0f, 2.0f, 3.0f};          // measured (calibrated)
-    ext.specTranslation = {10.0f, 20.0f, 30.0f};   // spec (CAD design)
+    ext.translation = {1.0f, 2.0f, 3.0f};         // measured (calibrated)
+    ext.specTranslation = {10.0f, 20.0f, 30.0f};  // spec (CAD design)
     ext.toCameraSocket = dai::CameraBoardSocket::CAM_C;
 
     // getTransformationMatrix(false) should use measured translation


### PR DESCRIPTION
## Purpose
When the PointCloud node uses `HousingCoordinateSystem` as target, the `useSpecTranslation` flag is `true` by default. This flag was passed to `getTransformationMatrix()` on the depth frame's extrinsics, which reads `specTranslation`. However, `specTranslation` is not populated by StereoDepth (it's `(0, 0, 0)`), resulting in the entire baseline translation being dropped and the housing transform applied only rotation with zero translation.

## Specification
Always use the calibrated `translation` (not `specTranslation`) when reading the frame's extrinsics (`getTransformationMatrix(false, unit)`). The `useSpecTranslation` flag is still passed to calibration handler lookups (`getCameraExtrinsics`, `getHousingCalibration`) that define the target coordinate system, where spec translations are properly populated from the calibration database.

## Dependencies & Potential Impact
Affects point cloud output when `setTargetCoordinateSystem(HousingCoordinateSystem)` is used. Previously the translation component was silently dropped; now it is correctly applied. No breaking API changes.

## Deployment Plan
None / not applicable

## Testing & Validation
- Verified with MRE script using Kabsch algorithm to measure the actually applied transform: housing target now shows ~3.75cm translation matching `getHousingCalibration()`, previously showed ~0.
- All 3 PointCloud tests pass (`pointclouddata_test`, `point_cloud_test`, `pointcloud_test`).
- `point_cloud_showcase.py` runs successfully on OAK-D-W.

## AI Usage
Assisted-by: GitHub Copilot:claude-opus-4.6

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved point cloud coordinate transformations to consistently use calibrated frame translations.
  * Updated camera-socket target transforms to be derived from calibrated camera extrinsics consistently.
* **Breaking Changes**
  * `setTargetCoordinateSystem(...)` now takes only the coordinate-system selector (camera socket or housing); the translation toggle behavior has been removed.
  * Removed `PointCloudConfig.getUseSpecTranslation()` and stopped serializing the translation setting.
* **Python Updates**
  * Updated Python bindings to the new signatures; legacy boolean overloads now emit `DeprecationWarning` and ignore the flag.
* **Tests**
  * Added coverage to verify measured vs spec translation behavior in extrinsics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->