### PR TITLE
Remove unnecessary write permissions check when using holistic replay

### DIFF
--- a/src/utility/PipelineImplHelper.cpp
+++ b/src/utility/PipelineImplHelper.cpp
@@ -75,24 +75,20 @@ void PipelineImplHelper::setupHolisticRecordAndReplay(const std::weak_ptr<Pipeli
                         }
                     } else if(!replayPath.empty()) {
                         if(platform::checkPathExists(replayPath)) {
-                            if(platform::checkWritePermissions(replayPath)) {
-                                if(utility::setupHolisticReplay(dai::Pipeline(pipeline),
-                                                                replayPath,
-                                                                pipeline->defaultDeviceId,
-                                                                pipeline->recordConfig,
-                                                                pipeline->recordReplayFilenames,
-                                                                pipeline->defaultDevice->getDeviceInfo().platform == XLinkPlatform_t::X_LINK_MYRIAD_2
-                                                                    || pipeline->defaultDevice->getDeviceInfo().platform == XLinkPlatform_t::X_LINK_MYRIAD_X)) {
-                                    pipeline->recordConfig.state = RecordConfig::RecordReplayState::REPLAY;
-                                    if(platform::checkPathExists(replayPath, true)) {
-                                        pipeline->removeRecordReplayFiles = false;
-                                    }
-                                    Logging::getInstance().logger.info("Replay enabled.");
-                                } else {
-                                    Logging::getInstance().logger.warn("Could not set up holistic replay. Record and replay disabled.");
+                            if(utility::setupHolisticReplay(dai::Pipeline(pipeline),
+                                                            replayPath,
+                                                            pipeline->defaultDeviceId,
+                                                            pipeline->recordConfig,
+                                                            pipeline->recordReplayFilenames,
+                                                            pipeline->defaultDevice->getDeviceInfo().platform == XLinkPlatform_t::X_LINK_MYRIAD_2
+                                                                || pipeline->defaultDevice->getDeviceInfo().platform == XLinkPlatform_t::X_LINK_MYRIAD_X)) {
+                                pipeline->recordConfig.state = RecordConfig::RecordReplayState::REPLAY;
+                                if(platform::checkPathExists(replayPath, true)) {
+                                    pipeline->removeRecordReplayFiles = false;
                                 }
+                                Logging::getInstance().logger.info("Replay enabled.");
                             } else {
-                                Logging::getInstance().logger.warn("DEPTHAI_REPLAY path does not have write permissions. Replay disabled.");
+                                Logging::getInstance().logger.warn("Could not set up holistic replay. Record and replay disabled.");
                             }
                         } else {
                             Logging::getInstance().logger.warn("DEPTHAI_REPLAY path does not exist or is invalid. Replay disabled.");


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Replay was disabled when a user didn't have write permissions for the path of the replay tar file. This check was unnecessary as the files get extracted to a tmp dir.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay setup error handling by consolidating permission validation logic, providing more direct feedback when replay initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->