### PR TITLE
Fix RVC4 PointCloud config deserialization and color input handling

### DIFF
--- a/include/depthai/pipeline/node/PointCloud.hpp
+++ b/include/depthai/pipeline/node/PointCloud.hpp
@@ -118,6 +118,7 @@ class PointCloud : public DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudPrope
 
    public:
     PointCloud();
+    PointCloud(std::unique_ptr<Properties> props);
     ~PointCloud();
 
     /**

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -420,7 +420,12 @@ void PointCloud::Impl::setExtrinsics(const std::vector<std::vector<float>>& tran
 }
 
 // PointCloud main class implementations
-PointCloud::PointCloud() : pimplPointCloud() {}
+PointCloud::PointCloud() : PointCloud(std::make_unique<Properties>()) {}
+
+PointCloud::PointCloud(std::unique_ptr<Properties> props)
+    : DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudProperties>(std::move(props)),
+      initialConfig(std::make_shared<decltype(properties.initialConfig)>(properties.initialConfig)),
+      pimplPointCloud() {}
 
 PointCloud::~PointCloud() = default;
 
@@ -736,7 +741,8 @@ void PointCloud::run() {
             continue;
         }
 
-        auto colorFrame = colorMode ? group->get<ImgFrame>(colorInputName) : nullptr;
+        auto colorFrame = group->get<ImgFrame>(colorInputName);
+        colorMode = (colorFrame != nullptr);
 
         // Check for runtime config update
         auto newConfig = inputConfig.tryGet<PointCloudConfig>();

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -424,7 +424,7 @@ PointCloud::PointCloud() : PointCloud(std::make_unique<Properties>()) {}
 
 PointCloud::PointCloud(std::unique_ptr<Properties> props)
     : DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudProperties>(std::move(props)),
-      initialConfig(std::make_shared<decltype(properties.initialConfig)>(properties.initialConfig)),
+      initialConfig(std::make_shared<PointCloudConfig>(properties.initialConfig)),
       pimplPointCloud() {}
 
 PointCloud::~PointCloud() = default;
@@ -742,7 +742,6 @@ void PointCloud::run() {
         }
 
         auto colorFrame = group->get<ImgFrame>(colorInputName);
-        colorMode = (colorFrame != nullptr);
 
         // Check for runtime config update
         auto newConfig = inputConfig.tryGet<PointCloudConfig>();

--- a/tests/src/onhost_tests/pipeline/datatype/pointclouddata_test.cpp
+++ b/tests/src/onhost_tests/pipeline/datatype/pointclouddata_test.cpp
@@ -1,6 +1,7 @@
 #include "depthai/pipeline/datatype/PointCloudData.hpp"
 
 #include <catch2/catch_all.hpp>
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -246,6 +247,7 @@ TEST_CASE("PointCloudConfig serialization roundtrip", "[PointCloudConfig][Serial
     dai::PointCloudConfig cfg;
     cfg.setOrganized(true);
     cfg.setLengthUnit(dai::LengthUnit::METER);
+    cfg.setTargetCoordinateSystem(dai::CameraBoardSocket::CAM_A, false);
     std::array<std::array<float, 4>, 4> mat = {{{0.5f, 0, 0, 1}, {0, 0.5f, 0, 2}, {0, 0, 0.5f, 3}, {0, 0, 0, 1}}};
     cfg.setTransformationMatrix(mat);
 
@@ -259,6 +261,9 @@ TEST_CASE("PointCloudConfig serialization roundtrip", "[PointCloudConfig][Serial
     dai::utility::deserialize(meta, cfg2);
     REQUIRE(cfg2.getOrganized());
     REQUIRE(cfg2.getLengthUnit() == dai::LengthUnit::METER);
+    REQUIRE(cfg2.getCoordinateSystemType() == dai::PointCloudConfig::CoordinateSystemType::CAMERA_SOCKET);
+    REQUIRE(cfg2.getTargetCameraSocket() == dai::CameraBoardSocket::CAM_A);
+    REQUIRE_FALSE(cfg2.getUseSpecTranslation());
     auto out = cfg2.getTransformationMatrix();
     for(int i = 0; i < 4; ++i)
         for(int j = 0; j < 4; ++j) REQUIRE(out[i][j] == Catch::Approx(mat[i][j]));
@@ -274,12 +279,27 @@ TEST_CASE("PointCloudProperties defaults and serialization", "[PointCloudPropert
 
     props.numFramesPool = 16;
     props.initialConfig.setOrganized(true);
+    props.initialConfig.setLengthUnit(dai::LengthUnit::METER);
+    props.initialConfig.setTargetCoordinateSystem(dai::CameraBoardSocket::CAM_A, false);
+    std::array<std::array<float, 4>, 4> mat = {{{0.f, -1.f, 0.f, 10.f}, {1.f, 0.f, 0.f, 20.f}, {0.f, 0.f, 1.f, 30.f}, {0.f, 0.f, 0.f, 1.f}}};
+    props.initialConfig.setTransformationMatrix(mat);
 
     auto ser = dai::utility::serialize(props);
     dai::PointCloudProperties props2;
     dai::utility::deserialize(ser, props2);
     REQUIRE(props2.numFramesPool == 16);
     REQUIRE(props2.initialConfig.getOrganized());
+    REQUIRE(props2.initialConfig.getLengthUnit() == dai::LengthUnit::METER);
+    REQUIRE(props2.initialConfig.getCoordinateSystemType() == dai::PointCloudConfig::CoordinateSystemType::CAMERA_SOCKET);
+    REQUIRE(props2.initialConfig.getTargetCameraSocket() == dai::CameraBoardSocket::CAM_A);
+    REQUIRE_FALSE(props2.initialConfig.getUseSpecTranslation());
+
+    auto out = props2.initialConfig.getTransformationMatrix();
+    for(int i = 0; i < 4; ++i) {
+        for(int j = 0; j < 4; ++j) {
+            REQUIRE(out[i][j] == Catch::Approx(mat[i][j]));
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Purpose
Fix `PointCloud` behavior on RVC4/device execution, where deserialized config was not applied correctly and colorized point clouds did not enable the color path on device.

## Specification
Restore `PointCloud` constructor parity so `initialConfig` is rebuilt from serialized properties during device-side node reconstruction.
Allow the device run path to detect and use an attached color frame on RVC4.
Extend serialization tests to cover the `PointCloudConfig` and `PointCloudProperties` fields involved in the regression.

## Dependencies & Potential Impact
No intended API changes.

## Testing & Validation
Validated with the PointCloud showcase on RVC4 device execution:
- point_cloud_showcase examples work

## AI Usage
Assisted-by: Codex:GPT-5

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an additional initialization option for PointCloud via configuration object construction.
  * Improved coordinate-system-related configuration handling for point cloud generation.

* **Bug Fixes**
  * Updated PointCloud processing to choose between colorized and depth-only output based on actual available color data.

* **Tests**
  * Expanded on-device serialization round-trip coverage for PointCloudConfig and PointCloudProperties, including coordinate system fields and transformation matrix values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->