### PR TITLE
Bugfix/DCL use getIntrinsics

### DIFF
--- a/src/pipeline/node/DynamicCalibrationNode.cpp
+++ b/src/pipeline/node/DynamicCalibrationNode.cpp
@@ -57,7 +57,7 @@ std::pair<std::shared_ptr<dcl::CameraCalibrationHandle>, std::shared_ptr<dcl::Ca
     const ImgTransformation& imgTransformationA,
     const ImgTransformation& imgTransformationB) {
     // clang-format off
-    std::array<std::array<float, 3>, 3> cameraMatrixA = imgTransformationA.getSourceIntrinsicMatrix();
+    std::array<std::array<float, 3>, 3> cameraMatrixA = imgTransformationA.getIntrinsicMatrix();
     std::shared_ptr<dcl::CameraCalibrationHandle> calibA = DclUtils::createDclCalibration(cameraMatrixA, imgTransformationA.getDistortionCoefficients(),
 	{
 	    {1.0f, 0.0f, 0.0f},
@@ -67,7 +67,7 @@ std::pair<std::shared_ptr<dcl::CameraCalibrationHandle>, std::shared_ptr<dcl::Ca
 	{0.0f, 0.0f, 0.0f},
 	currentCalibration.getDistortionModel(boardSocketA)
     );
-    std::array<std::array<float, 3>, 3> cameraMatrixB = imgTransformationB.getSourceIntrinsicMatrix();
+    std::array<std::array<float, 3>, 3> cameraMatrixB = imgTransformationB.getIntrinsicMatrix();
     std::shared_ptr<dcl::CameraCalibrationHandle> calibB = DclUtils::createDclCalibration(cameraMatrixB,
         imgTransformationB.getDistortionCoefficients(),
 	    currentCalibration.getCameraRotationMatrix(boardSocketA, boardSocketB),


### PR DESCRIPTION
There was an issue that DCL take into the account the SourceIntrinsicMatrix, which is resolution of the frame, before being altered by the rescaling.
SInce RVC2 devices support the 640x400 downscale on sensor level, getIntrinsics = getSourceIntrinsics(), while for the RVC4 devices, that is not true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated camera calibration handling so the correct intrinsic matrices are used for downstream calibration processing.
  * This should improve consistency in camera calibration results for affected devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->