### PR TITLE
Fix that cam_test.py actually assigns color or mono

### DIFF
--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -415,7 +415,9 @@ with dai.Pipeline(dai.Device(*dai_device_args)) as pipeline:
             xout[thermal_color_name] = cam[c].color
             streams.append(thermal_color_name)
         else:
-            cam[c] = pipeline.create(dai.node.Camera).build(cam_socket_opts[c])
+            cam[c] = pipeline.create(dai.node.Camera)
+            cam[c].setSensorType(dai.CameraSensorType.COLOR if cam_type_color[c] else dai.CameraSensorType.MONO)
+            cam[c].build(cam_socket_opts[c], get_socket_resolution(c), args.fps)
             cap = dai.ImgFrameCapability()
             cap.size.fixed(get_socket_resolution(c))
             cap.fps.fixed(args.fps)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standard camera connections now initialize with the correct sensor type.
  * Camera setup now uses the socket’s configured resolution and the selected frame rate, improving consistency for non-ToF and non-thermal cameras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->