### PR TITLE
Remove move constructor and delegate to copy.

### DIFF
--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -306,7 +306,7 @@ class Pipeline {
     Pipeline& operator=(const Pipeline&) = default;
     Pipeline(Pipeline&& other) noexcept : Pipeline(static_cast<const Pipeline&>(other)) {}
     Pipeline& operator=(Pipeline&& other) noexcept {
-        return operator=(other);
+        return operator=(static_cast<const Pipeline&>(other));
     }
     ~Pipeline() = default;
 

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -304,10 +304,9 @@ class Pipeline {
 
     Pipeline(const Pipeline&) = default;
     Pipeline& operator=(const Pipeline&) = default;
-    Pipeline(Pipeline&& other) noexcept : pimpl(other.pimpl) {}
+    Pipeline(Pipeline&& other) noexcept : Pipeline(static_cast<const Pipeline&>(other)) {}
     Pipeline& operator=(Pipeline&& other) noexcept {
-        pimpl = other.pimpl;
-        return *this;
+        return operator=(other);
     }
     ~Pipeline() = default;
 

--- a/include/depthai/pipeline/Pipeline.hpp
+++ b/include/depthai/pipeline/Pipeline.hpp
@@ -302,6 +302,15 @@ class Pipeline {
         return pimpl.get();
     }
 
+    Pipeline(const Pipeline&) = default;
+    Pipeline& operator=(const Pipeline&) = default;
+    Pipeline(Pipeline&& other) noexcept : pimpl(other.pimpl) {}
+    Pipeline& operator=(Pipeline&& other) noexcept {
+        pimpl = other.pimpl;
+        return *this;
+    }
+    ~Pipeline() = default;
+
     std::vector<std::shared_ptr<Node>> getSourceNodes() {
         return impl()->getSourceNodes();
     }


### PR DESCRIPTION
This does not improve anything for the C++ side of things but improves usability for other languages via generated FFI bindings by allowing them to hold bare pointers to a pipeline object without the possibility of C++ move semantics invalidating that memory. 

It's probably worth noting that this currently this only happens in a single place and that usage is unable to affect user space, but for the purpose of future guarantees and static assertions made downstream this would be useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Improvements**
  * Pipeline objects now have clearly defined copy and move behavior, making it easier and more consistent to store, pass around, assign, and return pipeline instances in your application code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->