### PR TITLE
Send only to opened queues

### DIFF
--- a/src/pipeline/Node.cpp
+++ b/src/pipeline/Node.cpp
@@ -246,7 +246,7 @@ void Node::Output::send(const std::shared_ptr<ADatatype>& msg) {
     // }
     auto sendToInputs = [this, &msg]() {
         for(auto& messageQueue : connectedInputs) {
-            messageQueue->send(msg);
+            if(!messageQueue->isClosed()) messageQueue->send(msg);
         }
     };
     if(pipelineEventDispatcher && pipelineEventDispatcher->sendEvents) {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
This fixes topics not sending data when removing and re-adding them.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Removing a topic closes the created queue but does not unlink it from the output (this object is not available at that point). The output then tried to send to the closed queue (before sending to the new queue) which blocked the output.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message delivery by skipping closed input queues during dispatch, preventing unnecessary send attempts and related errors.
  * Left event handling behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->