### PR TITLE
Check if input file exists in Replay

### DIFF
--- a/src/opencv/RecordReplay.cpp
+++ b/src/opencv/RecordReplay.cpp
@@ -248,8 +248,12 @@ void VideoPlayer::init(const std::string& filePath) {
     if(initialized) {
         throw std::runtime_error("VideoPlayer already initialized");
     }
+    // Check if file exists
     if(filePath.empty()) {
         throw std::runtime_error("VideoPlayer file path is empty");
+    }
+    if(!std::filesystem::exists(filePath)) {
+        throw std::runtime_error("VideoPlayer file does not exist: " + filePath);
     }
     cvReader = std::make_unique<cv::VideoCapture>();
     cvReader->open(filePath, cv::CAP_FFMPEG);

--- a/src/opencv/RecordReplay.cpp
+++ b/src/opencv/RecordReplay.cpp
@@ -252,7 +252,7 @@ void VideoPlayer::init(const std::string& filePath) {
     if(filePath.empty()) {
         throw std::runtime_error("VideoPlayer file path is empty");
     }
-    if(!std::filesystem::exists(filePath)) {
+    if(!std::filesystem::is_regular_file(filePath)) {
         throw std::runtime_error("VideoPlayer file does not exist: " + filePath);
     }
     cvReader = std::make_unique<cv::VideoCapture>();

--- a/src/utility/RecordReplay.cpp
+++ b/src/utility/RecordReplay.cpp
@@ -97,8 +97,12 @@ std::string BytePlayer::init(const std::string& filePath) {
     if(initialized) {
         throw std::runtime_error("BytePlayer already initialized");
     }
+    // Check if file exists
     if(filePath.empty()) {
         throw std::runtime_error("BytePlayer file path is empty");
+    }
+    if(!std::filesystem::is_regular_file(filePath)) {
+        throw std::runtime_error("BytePlayer file does not exist: " + filePath);
     }
     {
         const auto res = reader.open(filePath);

--- a/src/utility/RecordReplayImpl.hpp
+++ b/src/utility/RecordReplayImpl.hpp
@@ -53,12 +53,8 @@ class ByteRecorder {
         if(initialized) {
             throw std::runtime_error("ByteRecorder already initialized");
         }
-        // Check if file exists
         if(filePath.empty()) {
             throw std::runtime_error("ByteRecorder file path is empty");
-        }
-        if(!std::filesystem::exists(filePath)) {
-            throw std::runtime_error("ByteRecorder file does not exist: " + filePath);
         }
         setWriter(filePath, compressionLevel);
         {

--- a/src/utility/RecordReplayImpl.hpp
+++ b/src/utility/RecordReplayImpl.hpp
@@ -53,8 +53,12 @@ class ByteRecorder {
         if(initialized) {
             throw std::runtime_error("ByteRecorder already initialized");
         }
+        // Check if file exists
         if(filePath.empty()) {
             throw std::runtime_error("ByteRecorder file path is empty");
+        }
+        if(!std::filesystem::exists(filePath)) {
+            throw std::runtime_error("ByteRecorder file does not exist: " + filePath);
         }
         setWriter(filePath, compressionLevel);
         {


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
On some platforms the exception thrown when replaying a video file did not make it clear what the issue was.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file validation when opening media recordings, so invalid or non-existent paths are now detected earlier.
  * Prevents playback from starting with an invalid file path, reducing later initialization failures.
  * Shows a clear error when the selected file is missing or not a regular file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->