### PR TITLE
Pin openCV to be less than 5 in install_requirements.py

### DIFF
--- a/examples/python/install_requirements.py
+++ b/examples/python/install_requirements.py
@@ -57,9 +57,9 @@ if requireOpenCv:
     DEPENDENCIES.append('numpy<3.0')
     # 4.5.4.58 package is broken for python 3.9
     if sys.version_info[0] == 3 and sys.version_info[1] == 9:
-        DEPENDENCIES.append('opencv-python!=4.5.4.58')
+        DEPENDENCIES.append('opencv-python<5,!=4.5.4.58')
     else:
-        DEPENDENCIES.append('opencv-python')
+        DEPENDENCIES.append('opencv-python<5')
 
 if args.install_rerun:
     DEPENDENCIES.append('rerun-sdk')

--- a/utilities/requirements.txt
+++ b/utilities/requirements.txt
@@ -1,7 +1,7 @@
 Pillow==10.4.0
 psutil==5.9.3
 numpy>=2 # For RPi Buster (last successful build) and macOS M1 (first build). But allow for higher versions, to support Python3.11 (not available in 1.21.4 yet). Likely won't work with numpy 3.x when it comes out.
-opencv-contrib-python==4.12.0.88 # Last successful RPi build, also covers M1 with above pinned numpy (otherwise 4.6.0.62 would be required, but that has a bug with charuco boards). Python version not important, abi3 wheels
+opencv-contrib-python>=4.12.0.88,<5 # Last successful RPi build, also covers M1 with above pinned numpy (otherwise 4.6.0.62 would be required, but that has a bug with charuco boards). Python version not important, abi3 wheels. Keep OpenCV on the 4.x line until 5.x compatibility is validated.
 pyqt5>5,<5.15.6 ; platform_machine != "armv6l" and platform_machine != "armv7l" and platform_machine != "aarch64" and platform_machine != "arm64"
 # Latest version (note - it's yanked)
 PySimpleGUI-4-foss==4.60.4.1 # Mirror of final open-source release.


### PR DESCRIPTION
New openCV version has different API than V4, which leads to some examples being broken, pinning the <5 version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened OpenCV package version selection for Python installs, helping avoid incompatible or problematic releases.
  * Added a safer version cap for OpenCV-related dependencies so future updates remain within supported ranges.

* **Chores**
  * Updated dependency constraints in utility requirements to allow compatible patch/minor updates without changing the expected package family.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->