### PR TITLE
Automatically turn on dot projector when StereoDepth is present

### DIFF
--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -506,7 +506,9 @@ class DeviceBase {
      * Sets the intensity of the IR Laser Dot Projector. Limits: up to 765mA at 30% frame time duty cycle when exposure time is longer than 30% frame time.
      * Otherwise, duty cycle is 100% of exposure time, with current increased up to max 1200mA to make up for shorter duty cycle.
      * The duty cycle is controlled by `left` camera STROBE, aligned to start of exposure.
-     * The emitter is turned off by default
+     * The emitter is turned off by default on device start. Pipelines that contain
+     * a `StereoDepth` node currently attempt to turn the dot projector on to 100%
+     * after startup.
      *
      * @param intensity Intensity on range 0 to 1, that will determine brightness. 0 or negative to turn off
      * @param mask Optional mask to modify only Left (0x1) or Right (0x2) sides on OAK-D-Pro-W-DEV

--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -333,7 +333,9 @@ class DeviceBase {
     bool isPipelineRunning();
 
     /**
-     * Starts the execution of a given pipeline
+     * Starts the execution of a given pipeline.
+     * Pipelines that contain a `StereoDepth` node currently attempt to turn the
+     * IR laser dot projector on to 100% after startup.
      * @param pipeline OpenVINO version of the pipeline must match the one which the device was booted with.
      *
      * @returns True if pipeline started, false otherwise

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -2462,6 +2462,8 @@ bool DeviceBase::startPipelineImpl(const Pipeline& pipeline) {
     Assets assets;
     std::vector<std::uint8_t> assetStorage;
     pipeline.serialize(schema, assets, assetStorage);
+    const bool enableDotProjectorOnStart =
+        std::any_of(schema.nodes.begin(), schema.nodes.end(), [](const auto& nodeInfo) { return nodeInfo.second.name == "StereoDepth"; });
 
     // if debug or lower
     if(getLogOutputLevel() <= LogLevel::DEBUG) {
@@ -2538,6 +2540,17 @@ bool DeviceBase::startPipelineImpl(const Pipeline& pipeline) {
     std::tie(success, errorMsg) = pimpl->rpcCallChecked<std::tuple<bool, std::string>>("buildPipeline");
     if(success) {
         pimpl->rpcCallCheckedVoid("startPipeline");
+        if(enableDotProjectorOnStart) {
+            try {
+                if(setIrLaserDotProjectorIntensity(1.0f)) {
+                    pimpl->logger.debug("Pipeline contains StereoDepth node. Turning on dot projector to 100% by default");
+                } else {
+                    pimpl->logger.debug("Enabling default dot projector intensity failed");
+                }
+            } catch(const std::exception& ex) {
+                pimpl->logger.warn("Failed to enable default dot projector intensity: {}", ex.what());
+            }
+        }
     } else {
         throw std::runtime_error("Device " + getDeviceId() + " error: " + errorMsg);
         return false;

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -34,6 +34,7 @@
 // project
 #include "DeviceLogger.hpp"
 #include "depthai/device/EepromError.hpp"
+#include "depthai/pipeline/node/StereoDepth.hpp"
 #include "depthai/pipeline/node/internal/XLinkIn.hpp"
 #include "depthai/pipeline/node/internal/XLinkOut.hpp"
 #include "device/DeviceGate.hpp"
@@ -2463,7 +2464,7 @@ bool DeviceBase::startPipelineImpl(const Pipeline& pipeline) {
     std::vector<std::uint8_t> assetStorage;
     pipeline.serialize(schema, assets, assetStorage);
     const bool enableDotProjectorOnStart =
-        std::any_of(schema.nodes.begin(), schema.nodes.end(), [](const auto& nodeInfo) { return nodeInfo.second.name == "StereoDepth"; });
+        std::any_of(schema.nodes.begin(), schema.nodes.end(), [](const auto& nodeInfo) { return nodeInfo.second.name == dai::node::StereoDepth::NAME; });
 
     // if debug or lower
     if(getLogOutputLevel() <= LogLevel::DEBUG) {
@@ -2545,7 +2546,7 @@ bool DeviceBase::startPipelineImpl(const Pipeline& pipeline) {
                 if(setIrLaserDotProjectorIntensity(1.0f)) {
                     pimpl->logger.debug("Pipeline contains StereoDepth node. Turning on dot projector to 100% by default");
                 } else {
-                    pimpl->logger.debug("Enabling default dot projector intensity failed");
+                    pimpl->logger.warn("Failed to enable default dot projector intensity");
                 }
             } catch(const std::exception& ex) {
                 pimpl->logger.warn("Failed to enable default dot projector intensity: {}", ex.what());


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
DeviceBase pipeline start will automatically turn on dotProjector in case StereoDepth node is present

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested using both RVC2 and RVC4 devices.

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME: Codex 5.4

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * When a pipeline contains stereo depth, the system now attempts to enable the IR dot projector at full intensity immediately after successful pipeline startup.
  * Pipeline startup remains resilient: projector enable failures or exceptions won’t prevent the pipeline from starting.
* **Documentation**
  * Updated Doxygen guidance to clarify IR dot projector behavior for pipelines using stereo depth and the default emitter state on device start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->