### PR TITLE
Telemetry rate limit

### DIFF
--- a/include/depthai/device/DeviceBase.hpp
+++ b/include/depthai/device/DeviceBase.hpp
@@ -1266,7 +1266,6 @@ class DeviceBase {
     void startTelemetryLifecycle(bool reconnect);
     void stopTelemetryLifecycle();
     void telemetryEventLoop();
-    void telemetryPingLoop();
     struct PrevInfo {
         DeviceInfo deviceInfo;
         Config cfg;
@@ -1339,10 +1338,6 @@ class DeviceBase {
     std::atomic<bool> telemetryEventRunning{false};
     std::mutex telemetryEventStreamMtx;
     std::shared_ptr<XLinkStream> telemetryEventStream;
-    std::thread telemetryPingThread;
-    std::atomic<bool> telemetryPingRunning{false};
-    std::condition_variable telemetryPingCondVar;
-    std::mutex telemetryPingMtx;
     std::string tmpDeviceId;
     std::chrono::steady_clock::time_point telemetryCreatedAt;
     bool telemetryLifecycleStarted = false;

--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -593,8 +593,6 @@ void DeviceBase::close() {
             // request stop now, but only join after closeImpl() closes the
             // connection and unblocks any blocking XLink reads.
             telemetryEventRunning = false;
-            telemetryPingRunning = false;
-            telemetryPingCondVar.notify_all();
         }
         closeImpl();
         stopTelemetryLifecycle();
@@ -665,22 +663,6 @@ void DeviceBase::telemetryEventLoop() {
     }
 }
 
-void DeviceBase::telemetryPingLoop() {
-    using namespace std::chrono_literals;
-    constexpr auto TELEMETRY_PING_INTERVAL = 5min;
-
-    std::unique_lock<std::mutex> lock(telemetryPingMtx);
-    while(telemetryPingRunning) {
-        if(telemetryPingCondVar.wait_for(lock, TELEMETRY_PING_INTERVAL, [this]() { return !telemetryPingRunning.load(); })) {
-            break;
-        }
-
-        lock.unlock();
-        dai::utility::Telemetry::getInstance().event(*this, "depthai_ping", nlohmann::json::object());
-        lock.lock();
-    }
-}
-
 void DeviceBase::startTelemetryLifecycle(bool reconnect) {
     if(reconnect || dumpOnly || telemetryLifecycleStarted || !dai::utility::Telemetry::isTelemetryEnabled()) {
         return;
@@ -712,8 +694,6 @@ void DeviceBase::startTelemetryLifecycle(bool reconnect) {
 
     telemetryEventRunning = true;
     telemetryEventThread = std::thread(&DeviceBase::telemetryEventLoop, this);
-    telemetryPingRunning = true;
-    telemetryPingThread = std::thread(&DeviceBase::telemetryPingLoop, this);
 }
 
 void DeviceBase::stopTelemetryLifecycle() {
@@ -724,11 +704,6 @@ void DeviceBase::stopTelemetryLifecycle() {
     telemetryEventRunning = false;
     if(telemetryEventThread.joinable()) {
         telemetryEventThread.join();
-    }
-    telemetryPingRunning = false;
-    telemetryPingCondVar.notify_all();
-    if(telemetryPingThread.joinable()) {
-        telemetryPingThread.join();
     }
 
     const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - telemetryCreatedAt).count();

--- a/src/utility/Initialization.cpp
+++ b/src/utility/Initialization.cpp
@@ -157,7 +157,7 @@ bool initialize(const char* additionalInfo, bool installSignalHandler, void* jav
 
         logger::debug("Initialize - finished");
 
-        utility::Telemetry::emitDepthaiTelemetryLoadEvent();
+        utility::Telemetry::getInstance().init();
 
         return true;
     }();

--- a/src/utility/Telemetry.cpp
+++ b/src/utility/Telemetry.cpp
@@ -48,16 +48,15 @@ constexpr std::size_t DEFAULT_FLUSH_AT = 20;
 constexpr std::size_t DEFAULT_MAX_QUEUE_SIZE = 1000;
 constexpr std::size_t DEFAULT_MAX_BATCH_SIZE = 50;
 constexpr std::chrono::seconds DEFAULT_FLUSH_INTERVAL{30};
+constexpr std::chrono::seconds DEFAULT_PING_INTERVAL{std::chrono::minutes(5)};
 constexpr std::chrono::seconds RETRY_DELAY{5};
 constexpr std::chrono::seconds MAX_RETRY_DELAY{30};
 constexpr char DEFAULT_POSTHOG_HOST[] = "https://b.luxonis.com";
 constexpr char DEFAULT_POSTHOG_API_KEY[] = "phc_ojEByaCiZZ5eigzaM43PaEVbfLfFDF5NgkXEMPabrT9a";
 constexpr char DEFAULT_TELEMETRY_ROOT_DIR[] = "telemetry";
 constexpr char TMP_IDS_FILENAME[] = "tmpIds.json";
-//constexpr auto TMP_ID_TTL = std::chrono::hours(24);
-constexpr auto TMP_ID_TTL = std::chrono::minutes(10);
-// constexpr std::int64_t RATE_LIMIT_MAX_EVENTS = 30000;
-constexpr std::int64_t RATE_LIMIT_MAX_EVENTS = 5;
+constexpr auto TMP_ID_TTL = std::chrono::hours(24);
+constexpr std::int64_t RATE_LIMIT_MAX_EVENTS = 30000;
 
 std::atomic_bool telemetryUsesPython{false};
 
@@ -437,18 +436,23 @@ struct TelemetrySharedState {
     std::mutex aggregateMetricsMtx;
     std::condition_variable condition;
     std::thread worker;
+    std::thread pingWorker;
     bool stopRequested{false};
+    bool pingStopRequested{false};
     bool flushRequested{false};
+    bool initialized{false};
     std::size_t retryCount{0};
     std::optional<Clock::time_point> pausedUntil;
 
     TelemetrySharedState();
     ~TelemetrySharedState();
 
+    void init();
     void event(std::string eventName, nlohmann::json properties);
     void addAggregateMetrics(Telemetry::AggregateMetricsCallback functionLikeCb);
     void loadQueueFromDisk();
     void workerLoop();
+    void pingWorkerLoop();
     void flushOneBatch();
     void cleanupRunDirectory();
     void removeFileFromQueueLocked(const std::string& filename);
@@ -464,6 +468,10 @@ TelemetrySharedState& telemetrySharedState() {
 
 class Telemetry::Impl {
    public:
+    void init() {
+        telemetrySharedState().init();
+    }
+
     void event(std::string eventName, nlohmann::json properties) {
         telemetrySharedState().event(std::move(eventName), std::move(properties));
     }
@@ -510,16 +518,44 @@ TelemetrySharedState::TelemetrySharedState() {
 TelemetrySharedState::~TelemetrySharedState() {
     {
         std::lock_guard<std::mutex> lock(mutex);
+        pingStopRequested = true;
         stopRequested = true;
         flushRequested = true;
     }
     condition.notify_all();
+
+    if(pingWorker.joinable()) {
+        pingWorker.join();
+    }
 
     if(worker.joinable()) {
         worker.join();
     }
 
     cleanupRunDirectory();
+}
+
+void TelemetrySharedState::init() {
+    bool shouldEmitLoad = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        if(initialized || !enabled) {
+            return;
+        }
+        initialized = true;
+        shouldEmitLoad = true;
+        pingWorker = std::thread([this]() { pingWorkerLoop(); });
+    }
+
+    if(shouldEmitLoad) {
+        event("depthai_load",
+              nlohmann::json{
+                  {"host_os", getTelemetryHostOS()},
+                  {"host_os_version", getTelemetryHostOSVersion()},
+                  {"is_oak_app", !readEnv("OAKAGENT_PRIVATE_HTTP_PWD").empty()},
+                  {"uses_python", telemetryUsesPython.load()},
+              });
+    }
 }
 
 void TelemetrySharedState::event(std::string eventName, nlohmann::json properties) {
@@ -652,6 +688,19 @@ void TelemetrySharedState::event(std::string eventName, nlohmann::json propertie
             logger::debug("Failed to update telemetry rate limit for '{}': {}", eventName, ex.what());
         }
         condition.notify_one();
+    }
+}
+
+void TelemetrySharedState::pingWorkerLoop() {
+    std::unique_lock<std::mutex> lock(mutex);
+    while(!pingStopRequested) {
+        if(condition.wait_for(lock, DEFAULT_PING_INTERVAL, [this]() { return pingStopRequested; })) {
+            break;
+        }
+
+        lock.unlock();
+        event("depthai_ping", nlohmann::json::object());
+        lock.lock();
     }
 }
 
@@ -967,14 +1016,10 @@ void Telemetry::setTelemetryUsesPython(bool value) {
     telemetryUsesPython.store(value);
 }
 
-void Telemetry::emitDepthaiTelemetryLoadEvent() {
-    Telemetry::getInstance().event("depthai_load",
-                                   nlohmann::json{
-                                       {"host_os", getTelemetryHostOS()},
-                                       {"host_os_version", getTelemetryHostOSVersion()},
-                                       {"is_oak_app", !readEnv("OAKAGENT_PRIVATE_HTTP_PWD").empty()},
-                                       {"uses_python", telemetryUsesPython.load()},
-                                   });
+void Telemetry::init() {
+    if(impl) {
+        impl->init();
+    }
 }
 
 void Telemetry::event(std::string eventName, nlohmann::json properties) {

--- a/src/utility/Telemetry.cpp
+++ b/src/utility/Telemetry.cpp
@@ -54,7 +54,10 @@ constexpr char DEFAULT_POSTHOG_HOST[] = "https://b.luxonis.com";
 constexpr char DEFAULT_POSTHOG_API_KEY[] = "phc_ojEByaCiZZ5eigzaM43PaEVbfLfFDF5NgkXEMPabrT9a";
 constexpr char DEFAULT_TELEMETRY_ROOT_DIR[] = "telemetry";
 constexpr char TMP_IDS_FILENAME[] = "tmpIds.json";
-constexpr auto TMP_ID_TTL = std::chrono::hours(24);
+//constexpr auto TMP_ID_TTL = std::chrono::hours(24);
+constexpr auto TMP_ID_TTL = std::chrono::minutes(10);
+// constexpr std::int64_t RATE_LIMIT_MAX_EVENTS = 30000;
+constexpr std::int64_t RATE_LIMIT_MAX_EVENTS = 5;
 
 std::atomic_bool telemetryUsesPython{false};
 
@@ -167,9 +170,16 @@ struct TemporaryDeviceIdEntry {
     int64_t expiresAtMs = 0;
 };
 
+struct RateLimitEntry {
+    int64_t expiresAtMs = 0;
+    int64_t value = 0;
+    bool triggered = false;
+};
+
 struct TemporaryIdsDocument {
     TemporaryIdEntry host;
     std::vector<TemporaryDeviceIdEntry> devices;
+    RateLimitEntry rateLimit;
 };
 
 bool isExpired(const TemporaryIdEntry& entry, int64_t currentMs) {
@@ -178,6 +188,33 @@ bool isExpired(const TemporaryIdEntry& entry, int64_t currentMs) {
 
 bool isExpired(const TemporaryDeviceIdEntry& entry, int64_t currentMs) {
     return entry.tmpDeviceId.empty() || entry.expiresAtMs <= currentMs;
+}
+
+bool isExpired(const RateLimitEntry& entry, int64_t currentMs) {
+    return entry.expiresAtMs <= currentMs;
+}
+
+void normalizeTemporaryIdsDocument(TemporaryIdsDocument& document, int64_t currentMs, bool& changed) {
+    const auto originalSize = document.devices.size();
+    document.devices.erase(std::remove_if(document.devices.begin(),
+                                          document.devices.end(),
+                                          [&](const TemporaryDeviceIdEntry& entry) { return entry.mxid.empty() || isExpired(entry, currentMs); }),
+                           document.devices.end());
+    changed = changed || document.devices.size() != originalSize;
+}
+
+void normalizeRateLimitEntry(RateLimitEntry& rateLimit, int64_t currentMs, bool& changed) {
+    if(rateLimit.value < 0) {
+        rateLimit.value = 0;
+        changed = true;
+    }
+
+    if(isExpired(rateLimit, currentMs)) {
+        rateLimit.expiresAtMs = currentMs + std::chrono::duration_cast<std::chrono::milliseconds>(TMP_ID_TTL).count();
+        rateLimit.value = 0;
+        rateLimit.triggered = false;
+        changed = true;
+    }
 }
 
 std::string getTelemetryHostOSImpl() {
@@ -242,6 +279,13 @@ TemporaryIdsDocument readTemporaryIdsDocument(const std::filesystem::path& path)
         }
     }
 
+    if(json.contains("rate_limit") && json["rate_limit"].is_object()) {
+        const auto& rateLimit = json["rate_limit"];
+        document.rateLimit.expiresAtMs = rateLimit.value("expires_at_ms", int64_t{0});
+        document.rateLimit.value = rateLimit.value("value", int64_t{0});
+        document.rateLimit.triggered = rateLimit.value("triggered", false);
+    }
+
     return document;
 }
 
@@ -260,6 +304,12 @@ nlohmann::json writeTemporaryIdsDocument(const TemporaryIdsDocument& document) {
             {"expires_at_ms", entry.expiresAtMs},
         });
     }
+
+    json["rate_limit"] = {
+        {"expires_at_ms", document.rateLimit.expiresAtMs},
+        {"value", document.rateLimit.value},
+        {"triggered", document.rateLimit.triggered},
+    };
 
     return json;
 }
@@ -339,12 +389,7 @@ class TemporaryIdsManager {
 
     TemporaryIdsDocument loadLocked(int64_t currentMs, bool& changed) {
         auto document = readTemporaryIdsDocument(tmpIdsPath());
-        const auto originalSize = document.devices.size();
-        document.devices.erase(std::remove_if(document.devices.begin(),
-                                              document.devices.end(),
-                                              [&](const TemporaryDeviceIdEntry& entry) { return entry.mxid.empty() || isExpired(entry, currentMs); }),
-                               document.devices.end());
-        changed = changed || document.devices.size() != originalSize;
+        normalizeTemporaryIdsDocument(document, currentMs, changed);
         return document;
     }
 
@@ -500,6 +545,45 @@ void TelemetrySharedState::event(std::string eventName, nlohmann::json propertie
         }
     }
 
+    const auto hostId = safeTemporaryTelemetryHostId();
+    std::unique_ptr<dai::platform::FileLock> rateLimitLock;
+    TemporaryIdsDocument rateLimitDocument;
+    bool trackRateLimit = false;
+
+    try {
+        std::filesystem::create_directories(defaultTelemetryBaseDir());
+        rateLimitLock = dai::platform::FileLock::lock(tmpIdsLockPath(), true);
+
+        const auto currentMs = nowMs();
+        bool changed = false;
+        rateLimitDocument = readTemporaryIdsDocument(tmpIdsPath());
+        normalizeTemporaryIdsDocument(rateLimitDocument, currentMs, changed);
+        normalizeRateLimitEntry(rateLimitDocument.rateLimit, currentMs, changed);
+
+        if(eventName != "depthai_rate_limit" && rateLimitDocument.rateLimit.expiresAtMs > currentMs
+           && rateLimitDocument.rateLimit.value > RATE_LIMIT_MAX_EVENTS) {
+            if(rateLimitDocument.rateLimit.triggered) {
+                if(changed) {
+                    persistTemporaryIdsDocument(tmpIdsPath(), rateLimitDocument);
+                }
+                return;
+            }
+
+            rateLimitDocument.rateLimit.triggered = true;
+            persistTemporaryIdsDocument(tmpIdsPath(), rateLimitDocument);
+            rateLimitLock.reset();
+            event("depthai_rate_limit", nlohmann::json{{"time_till_reset", nowMs() - rateLimitDocument.rateLimit.expiresAtMs}});
+            return;
+        }
+
+        if(changed) {
+            persistTemporaryIdsDocument(tmpIdsPath(), rateLimitDocument);
+        }
+        trackRateLimit = true;
+    } catch(const std::exception& ex) {
+        logger::debug("Failed to evaluate telemetry rate limit for '{}': {}", eventName, ex.what());
+    }
+
     if(!properties.contains("$lib")) {
         properties["$lib"] = "depthai-core";
     }
@@ -515,8 +599,6 @@ void TelemetrySharedState::event(std::string eventName, nlohmann::json propertie
     properties["source_product"] = "depthai";
     properties["source_component"] = "depthai-core";
 
-    const auto hostId = safeTemporaryTelemetryHostId();
-
     const auto payload = nlohmann::json{
         {"event", eventName},
         {"distinct_id", hostId},
@@ -525,7 +607,7 @@ void TelemetrySharedState::event(std::string eventName, nlohmann::json propertie
         {"uuid", generateUuidV4()},
     };
 
-    std::string filename;
+    bool queued = false;
     {
         std::lock_guard<std::mutex> lock(mutex);
 
@@ -536,7 +618,7 @@ void TelemetrySharedState::event(std::string eventName, nlohmann::json propertie
             logger::debug("Telemetry queue is full, dropping oldest event '{}'", oldest);
         }
 
-        filename = makeQueueFilename();
+        const auto filename = makeQueueFilename();
         const auto eventPath = queueDir / filename;
         std::ofstream output(eventPath, std::ios::binary | std::ios::trunc);
         if(!output) {
@@ -557,9 +639,20 @@ void TelemetrySharedState::event(std::string eventName, nlohmann::json propertie
         if(queuedFiles.size() >= flushAt) {
             flushRequested = true;
         }
+        queued = true;
     }
 
-    condition.notify_one();
+    if(queued) {
+        try {
+            if(trackRateLimit) {
+                rateLimitDocument.rateLimit.value += 1;
+                persistTemporaryIdsDocument(tmpIdsPath(), rateLimitDocument);
+            }
+        } catch(const std::exception& ex) {
+            logger::debug("Failed to update telemetry rate limit for '{}': {}", eventName, ex.what());
+        }
+        condition.notify_one();
+    }
 }
 
 void TelemetrySharedState::addAggregateMetrics(Telemetry::AggregateMetricsCallback functionLikeCb) {

--- a/src/utility/Telemetry.cpp
+++ b/src/utility/Telemetry.cpp
@@ -608,7 +608,7 @@ void TelemetrySharedState::event(std::string eventName, nlohmann::json propertie
             rateLimitDocument.rateLimit.triggered = true;
             persistTemporaryIdsDocument(tmpIdsPath(), rateLimitDocument);
             rateLimitLock.reset();
-            event("depthai_rate_limit", nlohmann::json{{"time_till_reset", nowMs() - rateLimitDocument.rateLimit.expiresAtMs}});
+            event("depthai_rate_limit", nlohmann::json{{"time_till_reset", rateLimitDocument.rateLimit.expiresAtMs - nowMs()}});
             return;
         }
 

--- a/src/utility/Telemetry.hpp
+++ b/src/utility/Telemetry.hpp
@@ -21,7 +21,7 @@ class Telemetry {
     static std::string getTemporaryTelemetryDeviceId(const std::string& mxid);
     static bool isTelemetryEnabled();
     static void setTelemetryUsesPython(bool value);
-    static void emitDepthaiTelemetryLoadEvent();
+    void init();
 
     Telemetry(const Telemetry&) = delete;
     Telemetry& operator=(const Telemetry&) = delete;


### PR DESCRIPTION
## Purpose
rate limit telemetry

## Specification
None / not applicable

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
Tested by hand a few scenarios that could break

## AI Usage
Assisted-by: codex-cli:chatgpt5.4 xhigh [1M context] 

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved telemetry initialization during startup and refined device telemetry lifecycle handling.
  * Introduced disk-backed telemetry rate limiting to suppress excessive repeated reporting, including a reset-timing notice when limits are reached.
* **Bug Fixes**
  * Improved reliability during device shutdown by simplifying telemetry cleanup and reducing the likelihood of shutdown-related hangs.
  * Updated telemetry startup flow so telemetry load behavior is handled via the new initialization path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->