### PR TITLE
Improve Depthai Python CI/CD workflow

### DIFF
--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -59,7 +59,7 @@ jobs:
         WHEEL_PYTHON_SETS='["cp39-cp39", "cp310-cp310", "cp311-cp311", "cp312-cp312", "cp313-cp313", "cp314-cp314"]'
         WHEEL_MACOS_RUNNERS='["macos-14"]'
 
-        if [[ "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == refs/heads/release* || "$GITHUB_REF" == refs/tags/v* ]]; then
+        if [[ "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == "refs/heads/develop" || "$GITHUB_REF" == refs/heads/release* || "$GITHUB_REF" == refs/tags/v* ]]; then
           WHEEL_MACOS_RUNNERS='["macos-15-intel", "macos-14"]'
         fi
 

--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -18,7 +18,7 @@ on:
     branches:
       - main
       - develop
-    types: [opened, reopened, labeled]
+    types: [labeled]
 
 ###################################
 ###################################
@@ -34,11 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
+      wheel_python_versions: ${{ steps.check.outputs.wheel_python_versions }}
+      wheel_python_sets: ${{ steps.check.outputs.wheel_python_sets }}
+      wheel_macos_runners: ${{ steps.check.outputs.wheel_macos_runners }}
     steps:
     - name: Evaluate trigger condition
       id: check
       run: |
         EVENT_NAME="${{ github.event_name }}"
+        GITHUB_REF="${{ github.ref }}"
 
         RAW_LABELS='${{ toJson(github.event.pull_request.labels) }}'
         if [[ "$RAW_LABELS" == "null" || -z "$RAW_LABELS" ]]; then
@@ -48,13 +52,26 @@ jobs:
         fi
 
         SHOULD_RUN="true"
+        WHEEL_PYTHON_VERSIONS='["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]'
+        WHEEL_PYTHON_SETS='["cp39-cp39", "cp310-cp310", "cp311-cp311", "cp312-cp312", "cp313-cp313", "cp314-cp314"]'
+        WHEEL_MACOS_RUNNERS='["macos-14"]'
+
+        if [[ "$GITHUB_REF" == "refs/heads/main" || "$GITHUB_REF" == refs/heads/release* || "$GITHUB_REF" == refs/tags/v* ]]; then
+          WHEEL_MACOS_RUNNERS='["macos-15-intel", "macos-14"]'
+        fi
+
         if [[ "$EVENT_NAME" == "pull_request" ]]; then
+          WHEEL_PYTHON_VERSIONS='["3.14"]'
+          WHEEL_PYTHON_SETS='["cp314-cp314"]'
           if ! echo "$LABELS" | jq -r '.[].name' | grep -q "testable"; then
             SHOULD_RUN="false"
           fi
         fi
 
         echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+        echo "wheel_python_versions=$WHEEL_PYTHON_VERSIONS" >> "$GITHUB_OUTPUT"
+        echo "wheel_python_sets=$WHEEL_PYTHON_SETS" >> "$GITHUB_OUTPUT"
+        echo "wheel_macos_runners=$WHEEL_MACOS_RUNNERS" >> "$GITHUB_OUTPUT"
 
   # Job which builds docstrings for the rest of the wheel builds
   build-docstrings:
@@ -216,11 +233,11 @@ jobs:
 
   # This job builds wheels for Windows x86_64 arch
   build-windows-x86_64:
-    needs: build-docstrings
+    needs: [precheck, build-docstrings]
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ${{ fromJson(needs.precheck.outputs.wheel_python_versions) }}
         python-architecture: [x64] # TODO(Morato) - re-enable x86
       fail-fast: false
     env:
@@ -306,11 +323,11 @@ jobs:
 
   # This job builds wheels for macOS arch
   build-macos:
-    needs: build-docstrings
+    needs: [precheck, build-docstrings]
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
-        os: [macos-15-intel, macos-14]
+        python-version: ${{ fromJson(needs.precheck.outputs.wheel_python_versions) }}
+        os: ${{ fromJson(needs.precheck.outputs.wheel_macos_runners) }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
@@ -384,14 +401,17 @@ jobs:
           path: bindings/python/wheelhouse/audited/*
 
   combine-macos-wheels:
-    needs: build-macos
+    needs: [precheck, build-macos]
     strategy:
       matrix:
-        os: [macos-15-intel, macos-14]
+        os: ${{ fromJson(needs.precheck.outputs.wheel_macos_runners) }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
       - name: Download audited wheels
         uses: actions/download-artifact@v4
         with:
@@ -431,7 +451,7 @@ jobs:
 
   # This job builds wheels for x86_64 arch
   build-linux-x86_64:
-    needs: build-docstrings
+    needs: [precheck, build-docstrings]
     runs-on: ubuntu-latest
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64:2025.11.10-2
@@ -439,7 +459,7 @@ jobs:
         PLAT: manylinux_2_28_x86_64
     strategy:
       matrix:
-        python-set: ["cp39-cp39", "cp310-cp310", "cp311-cp311", "cp312-cp312", "cp313-cp313", "cp314-cp314"]
+        python-set: ${{ fromJson(needs.precheck.outputs.wheel_python_sets) }}
     env:
       DEPTHAI_BUILD_BASALT: ON
       DEPTHAI_BUILD_PCL: ON
@@ -538,7 +558,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          PYBIN="/opt/python/cp310-cp310/bin/python"
+          PYBIN="/opt/python/cp314-cp314/bin/python"
 
           # Resolve the exact dev version (includes commit hash)
           ver=$("$PYBIN" -c "import os,sys,pathlib; sys.path.insert(0, str(pathlib.Path('bindings/python').resolve())); import find_version as v; print(v.get_package_dev_version(os.environ['BUILD_COMMIT_HASH']))")
@@ -556,7 +576,7 @@ jobs:
 
   # This job builds wheels for ARM64 arch
   build-linux-arm64:
-    needs: build-docstrings
+    needs: [precheck, build-docstrings]
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 1440  # Set timeout to 24 hours
     container:
@@ -565,7 +585,7 @@ jobs:
         PLAT: manylinux_2_28_aarch64
     strategy:
       matrix:
-        python-set: ["cp39-cp39", "cp310-cp310", "cp311-cp311", "cp312-cp312", "cp313-cp313", "cp314-cp314"]
+        python-set: ${{ fromJson(needs.precheck.outputs.wheel_python_sets) }}
     env:
       # workaround required for cache@v3, https://github.com/actions/cache/issues/1428
       VCPKG_FORCE_SYSTEM_BINARIES: "1" # Needed so vpckg can bootstrap itself
@@ -667,7 +687,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          PYBIN="/opt/python/cp310-cp310/bin/python"
+          PYBIN="/opt/python/cp314-cp314/bin/python"
 
           # Resolve the exact dev version (includes commit hash)
           ver=$("$PYBIN" -c "import os,sys,pathlib; sys.path.insert(0, str(pathlib.Path('bindings/python').resolve())); import find_version as v; print(v.get_package_dev_version(os.environ['BUILD_COMMIT_HASH']))")
@@ -697,7 +717,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Combine wheels
         run: |
           python -m pip install "delvewheel==1.12.1" # Install delvewheel for patching wheels

--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -40,9 +40,12 @@ jobs:
     steps:
     - name: Evaluate trigger condition
       id: check
+      env:
+        CHECK_EVENT_NAME: ${{ github.event_name }}
+        CHECK_GITHUB_REF: ${{ github.ref }}
       run: |
-        EVENT_NAME="${{ github.event_name }}"
-        GITHUB_REF="${{ github.ref }}"
+        EVENT_NAME="$CHECK_EVENT_NAME"
+        GITHUB_REF="$CHECK_GITHUB_REF"
 
         RAW_LABELS='${{ toJson(github.event.pull_request.labels) }}'
         if [[ "$RAW_LABELS" == "null" || -z "$RAW_LABELS" ]]; then

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -243,5 +243,5 @@
             ]
         }
     },
-    "builtin-baseline": "a9eee3b18df395dbb8be71a31bd78ea441056e42"
+    "builtin-baseline": "d015e31e90838a4c9dfa3eed45979bc70d9357fc"
 }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
* Fix the "spamming" of multiple workflows containing only precheck, by triggering the PR workflow run only on testable labels. 
* In case of workflows triggered by PRs, build only Python3.14 in order to speed up the PR check, while keeping a check that everything builds as it should. Full python set is still built for non-PR builds.
* Speed up the python CI/CD workflow by running the legacy macOS intel builds only when building:
- main
- release branches
- v* tags
- develop

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Updating the `python-main.yml` workflow file with additional conditions.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
This was tested by manually running the affected workflow with different conditions.

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME: Chat gpt

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated CI wheel build behavior to use centralized configuration and dynamically adjust macOS runner coverage based on branch/ref patterns.
  * Standardized wheel Python version/set matrix generation across Windows, macOS, and Linux build jobs.
  * For pull requests, restricted wheel configuration to CPython 3.14 and gated execution based on the presence of a testable label.

* **Tests**
  * Updated combined wheel smoke tests to use newer Python artifacts (Linux x86_64/ARM64 from `cp310` to `cp314`, and Windows from `3.12` to `3.14`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->