### PR TITLE
Python CI/CD workflow will no longer build python version 3.9

### DIFF
--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -220,7 +220,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         python-architecture: [x64] # TODO(Morato) - re-enable x86
       fail-fast: false
     env:
@@ -309,7 +309,7 @@ jobs:
     needs: build-docstrings
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [macos-15-intel, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Due to python 3.9 no longer being supported for a while with security updates stopped as well, we should discontinue building python wheels for this specific version. Version 3.10 should now be the oldest python version supported.

Merge this for release 3.10 of depthai-core.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable
