### PR TITLE
Fix cam_test.py to support any device, no matter the resolution.

### DIFF
--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -265,24 +265,27 @@ def get_default_resolution(cam_feature):
 
     if not configs:
         if cam_feature.width > 0 and cam_feature.height > 0:
-            return (min(cam_feature.width, target_width), min(cam_feature.height, target_height))
-        return DEFAULT_RESOLUTION
+            selected = (min(cam_feature.width, target_width), min(cam_feature.height, target_height))
+            return selected, f"{cam_feature.width}x{cam_feature.height} -> {selected[0]}x{selected[1]}"
+        return DEFAULT_RESOLUTION, f"default {DEFAULT_RESOLUTION[0]}x{DEFAULT_RESOLUTION[1]}"
 
     configs.sort(key=lambda cfg: (cfg.width * cfg.height, cfg.width, cfg.height))
     bounded_configs = [cfg for cfg in configs if cfg.width <= target_width and cfg.height <= target_height]
     if bounded_configs:
         best = bounded_configs[-1]
-        return (best.width, best.height)
+        return (best.width, best.height), f"{cam_feature.width}x{cam_feature.height} -> {best.width}x{best.height}"
 
     best = min(configs, key=lambda cfg: (cfg.width * cfg.height, cfg.width, cfg.height))
-    return (best.width, best.height)
+    return (best.width, best.height), f"{cam_feature.width}x{cam_feature.height} -> {best.width}x{best.height}"
 
 
 def build_socket_resolution_defaults(camera_features):
     resolutions = {}
     for cam_feature in camera_features:
         socket_name = socket_to_socket_opt(cam_feature.socket)
-        resolutions[socket_name] = get_default_resolution(cam_feature)
+        resolution, source = get_default_resolution(cam_feature)
+        resolutions[socket_name] = resolution
+        print(f"Auto resolution {socket_name}: {source}")
     return resolutions
 
 

--- a/utilities/cam_test.py
+++ b/utilities/cam_test.py
@@ -199,7 +199,7 @@ parser.add_argument('-res', '--resolution', type=resolution_entry, action='appen
                     metavar='[socket:](width,height)',
                     help="Select camera resolution as a tuple (width, height). "
                     "Use socket:(width,height) to override specific sockets (same names as -cams). "
-                    "Default is (1280, 800) for all sockets. Can be provided multiple times."
+                    "Default is auto-selected from connected camera features. Can be provided multiple times."
                     "Example is -res cama:1920,1080, -res 640,480")
 parser.add_argument('-rot', '--rotate', const='all', choices={'all', 'rgb', 'mono'}, nargs="?",
                     help="Which cameras to rotate 180 degrees. All if not filtered")
@@ -250,17 +250,48 @@ parser.add_argument("-h", "--help", action="store_true", default=False,
 
 args = parser.parse_args()
 
-resolution_default = DEFAULT_RESOLUTION
+resolution_default_override = None
 socket_resolution_overrides = {}
 for socket, resolution in args.resolution:
     if socket:
         socket_resolution_overrides[socket] = resolution
     else:
-        resolution_default = resolution
+        resolution_default_override = resolution
 
 
-def get_socket_resolution(socket):
-    return socket_resolution_overrides.get(socket, resolution_default)
+def get_default_resolution(cam_feature):
+    configs = [cfg for cfg in cam_feature.configs if cfg.width > 0 and cfg.height > 0]
+    target_width, target_height = DEFAULT_RESOLUTION
+
+    if not configs:
+        if cam_feature.width > 0 and cam_feature.height > 0:
+            return (min(cam_feature.width, target_width), min(cam_feature.height, target_height))
+        return DEFAULT_RESOLUTION
+
+    configs.sort(key=lambda cfg: (cfg.width * cfg.height, cfg.width, cfg.height))
+    bounded_configs = [cfg for cfg in configs if cfg.width <= target_width and cfg.height <= target_height]
+    if bounded_configs:
+        best = bounded_configs[-1]
+        return (best.width, best.height)
+
+    best = min(configs, key=lambda cfg: (cfg.width * cfg.height, cfg.width, cfg.height))
+    return (best.width, best.height)
+
+
+def build_socket_resolution_defaults(camera_features):
+    resolutions = {}
+    for cam_feature in camera_features:
+        socket_name = socket_to_socket_opt(cam_feature.socket)
+        resolutions[socket_name] = get_default_resolution(cam_feature)
+    return resolutions
+
+
+def get_socket_resolution(socket, socket_default_resolutions):
+    if socket in socket_resolution_overrides:
+        return socket_resolution_overrides[socket]
+    if resolution_default_override is not None:
+        return resolution_default_override
+    return socket_default_resolutions.get(socket, DEFAULT_RESOLUTION)
 
 # Set timeouts before importing depthai
 os.environ["DEPTHAI_CONNECTION_TIMEOUT"] = str(args.connection_timeout)
@@ -356,8 +387,8 @@ with dai.Pipeline(dai.Device(*dai_device_args)) as pipeline:
     cam_type_thermal = {}
 
     device: dai.Device = pipeline.getDefaultDevice()
+    connected_cameras = device.getConnectedCameraFeatures()
     if not args.cameras:
-        connected_cameras = device.getConnectedCameraFeatures()
         args.cameras = [(socket_to_socket_opt(cam.socket), cam.supportedTypes[0] ==
                          dai.CameraSensorType.COLOR, cam.supportedTypes[0] == dai.CameraSensorType.TOF, cam.supportedTypes[0] == dai.CameraSensorType.THERMAL) for cam in connected_cameras]
         if not args.cameras:
@@ -371,6 +402,7 @@ with dai.Pipeline(dai.Device(*dai_device_args)) as pipeline:
         cam_type_tof[socket] = is_tof
         cam_type_thermal[socket] = is_thermal
         print(socket.rjust(7), ':', 'tof' if is_tof else 'color' if is_color else 'thermal' if is_thermal else 'mono')
+    socket_default_resolutions = build_socket_resolution_defaults(connected_cameras)
 
     # Uncomment to get better throughput
     # pipeline.setXLinkChunkSize(0)
@@ -419,7 +451,7 @@ with dai.Pipeline(dai.Device(*dai_device_args)) as pipeline:
             cam[c].setSensorType(dai.CameraSensorType.COLOR if cam_type_color[c] else dai.CameraSensorType.MONO)
             cam[c].build(cam_socket_opts[c], sensorFps=args.fps)
             cap = dai.ImgFrameCapability()
-            cap.size.fixed(get_socket_resolution(c))
+            cap.size.fixed(get_socket_resolution(c, socket_default_resolutions))
             cap.fps.fixed(args.fps)
             stream_name = c
             xout[stream_name] = cam[c].requestOutput(cap, True)
@@ -517,7 +549,7 @@ with dai.Pipeline(dai.Device(*dai_device_args)) as pipeline:
 
     print('Connected cameras:')
     cam_name = {}
-    for p in device.getConnectedCameraFeatures():
+    for p in connected_cameras:
         print(
             f' -socket {p.socket.name:6}: {p.sensorName:6} {p.width:4} x {p.height:4} focus:', end='')
         print('auto ' if p.hasAutofocus else 'fixed', '- ', end='')


### PR DESCRIPTION
## Purpose
`cam_test.py` used a fixed default resolution for all cameras. That works poorly across boards with very different sensors, especially when connected cameras advertise supported output modes via `getConnectedCameraFeatures()`. This change makes the default selection camera-aware while keeping the utility conservative enough to avoid defaulting into very heavy 4K / 12MP pipelines.

## Specification
`cam_test.py` now derives per-socket default resolutions from `device.getConnectedCameraFeatures()` instead of relying on a single hardcoded fallback.

Behavior:
- explicit `-res` overrides still take priority
- otherwise, the script inspects each camera’s advertised `configs`
- it selects the largest advertised mode that fits within the previous default budget of `1280x800`
- if all advertised modes are larger, it selects the smallest advertised mode instead
- if no configs are reported, it falls back to a simple clamp against `1280x800`
- startup output now includes one concise auto-resolution line per socket so the selected default is visible

This keeps the old intent of lightweight defaults, but bases the choice on actual connected camera capabilities.

## Dependencies & Potential Impact
Low risk. The change is limited to `utilities/cam_test.py` and only affects default resolution selection when the user does not explicitly pass `-res`.

Potential impact:
- default stream sizes may differ from previous behavior on some devices
- boards with high-resolution sensors should now avoid defaulting into oversized pipelines
- the no-config fallback is still a simple width/height clamp, not aspect-ratio-preserving

No API or ABI changes.

## Deployment Plan
No special deployment steps. This is a utility-script change only.

Rollout:
- merge normally
- validate on additional hardware with high-resolution sensors

Rollback:
- revert this PR if any device shows incompatible auto-selected defaults

Monitoring:
- manual validation through `cam_test.py` startup output and successful pipeline start on target devices

## Testing & Validation
Validated by running `python3 utilities/cam_test.py` and checking selected auto resolutions / successful startup behavior on:
- OAK-D-PRO
- OAK-D-LITE
- OAK-4-LITE
- OAK-4-D
- OAK-TOF

Also verified script syntax with:

```bash
python3 -m py_compile utilities/cam_test.py
```

Additional validation still recommended on:
- LR / AR0234
- IMX586

## AI Usage
Assisted-by: OpenAI Codex:GPT-5

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES