### PR TITLE
StereoDepth platform docstrings

### DIFF
--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -55,7 +55,7 @@ class StereoDepthConfig : public Buffer {
         bool enableLeftRightCheck = true;
 
         /**
-         * Enables software left right check. Applicable to RVC4 only.
+         * Enables software left right check. Not used on RVC2.
          */
         bool enableSwLeftRightCheck = false;
 
@@ -135,6 +135,9 @@ class StereoDepthConfig : public Buffer {
                           numInvalidateEdgePixels);
     };
 
+    /**
+     * Confidence metrics settings. Not used on RVC2.
+     */
     struct ConfidenceMetrics {
         /**
          * Weight used with occlusion estimation to generate final confidence map.
@@ -290,6 +293,9 @@ class StereoDepthConfig : public Buffer {
          */
         DecimationFilter decimationFilter;
 
+        /**
+         * Hole-filling configuration. Not used on RVC2.
+         */
         struct HoleFilling {
             /**
              * Flag to enable post-processing hole-filling.
@@ -324,8 +330,14 @@ class StereoDepthConfig : public Buffer {
             DEPTHAI_SERIALIZE(HoleFilling, enable, highConfidenceThreshold, fillConfidenceThreshold, minValidDisparity, invalidateDisparities);
         };
 
+        /**
+         * Hole-filling configuration. Not used on RVC2.
+         */
         HoleFilling holeFilling;
 
+        /**
+         * Adaptive median filter configuration. Not used on RVC2.
+         */
         struct AdaptiveMedianFilter {
             /**
              * Flag to enable adaptive median filtering for a final pass of filtering on low confidence pixels.
@@ -342,6 +354,9 @@ class StereoDepthConfig : public Buffer {
             DEPTHAI_SERIALIZE(AdaptiveMedianFilter, enable, confidenceThreshold);
         };
 
+        /**
+         * Adaptive median filter configuration. Not used on RVC2.
+         */
         AdaptiveMedianFilter adaptiveMedianFilter;
 
         DEPTHAI_SERIALIZE(PostProcessing,
@@ -412,12 +427,14 @@ class StereoDepthConfig : public Buffer {
          * Used to reduce small fixed levels of noise across all luminance values
          * in the current image.
          * Valid range is [0,127]. Default value is 0.
+         * Not used on RVC2.
          */
         int8_t noiseThresholdOffset = 1;
         /**
          * Used to reduce noise values that increase with luminance in the
          * current image.
          * Valid range is [-128,127]. Default value is 0.
+         * Not used on RVC2.
          */
         int8_t noiseThresholdScale = 1;
 
@@ -462,7 +479,7 @@ class StereoDepthConfig : public Buffer {
         uint8_t confidenceThreshold = 55;
 
         /**
-         * Enable software confidence thresholding. Applicable to RVC4 only.
+         * Enable software confidence thresholding. Not used on RVC2.
          */
         bool enableSwConfidenceThresholding = false;
 
@@ -531,7 +548,7 @@ class StereoDepthConfig : public Buffer {
         uint16_t verticalPenaltyCostP2 = defaultPenaltyP2;
 
         /**
-         * Structure for adaptive P1 penalty configuration.
+         * Adaptive P1 penalty configuration. Not used on RVC2.
          */
         struct P1Config {
             /**
@@ -577,10 +594,13 @@ class StereoDepthConfig : public Buffer {
             DEPTHAI_SERIALIZE(P1Config, enableAdaptive, defaultValue, edgeValue, smoothValue, edgeThreshold, smoothThreshold);
         };
 
+        /**
+         * Adaptive P1 penalty configuration. Not used on RVC2.
+         */
         P1Config p1Config;
 
         /**
-         * Structure for adaptive P2 penalty configuration.
+         * Adaptive P2 penalty configuration. Not used on RVC2.
          */
         struct P2Config {
             /**
@@ -612,6 +632,9 @@ class StereoDepthConfig : public Buffer {
             DEPTHAI_SERIALIZE(P2Config, enableAdaptive, defaultValue, edgeValue, smoothValue);
         };
 
+        /**
+         * Adaptive P2 penalty configuration. Not used on RVC2.
+         */
         P2Config p2Config;
 
         DEPTHAI_SERIALIZE(CostAggregation,
@@ -759,11 +782,13 @@ class StereoDepthConfig : public Buffer {
 
     /**
      * Set filters compute backend
+     * Not used on RVC2.
      */
     StereoDepthConfig& setFiltersComputeBackend(dai::ProcessorType filtersBackend);
 
     /**
      * Get filters compute backend
+     * Not used on RVC2.
      */
     dai::ProcessorType getFiltersComputeBackend() const;
 
@@ -799,10 +824,13 @@ class StereoDepthConfig : public Buffer {
     CostAggregation costAggregation;
 
     /**
-     * Confidence metrics settings.
+     * Confidence metrics settings. Not used on RVC2.
      */
     ConfidenceMetrics confidenceMetrics;
 
+    /**
+     * Compute backend for post-processing filters. Not used on RVC2.
+     */
     dai::ProcessorType filtersBackend = dai::ProcessorType::CPU;
 
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override;

--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -55,7 +55,7 @@ class StereoDepthConfig : public Buffer {
         bool enableLeftRightCheck = true;
 
         /**
-         * Enables software left right check. Not used on RVC2.
+         * Enables software left right check. RVC4 only.
          */
         bool enableSwLeftRightCheck = false;
 
@@ -67,6 +67,7 @@ class StereoDepthConfig : public Buffer {
 
         /**
          * Computes disparity with sub-pixel interpolation (5 fractional bits), suitable for long range
+         * RVC2 only.
          */
         bool enableSubpixel = true;
 
@@ -85,6 +86,7 @@ class StereoDepthConfig : public Buffer {
          * Defines the number of fractional disparities: 2^x
          *
          * Median filter postprocessing is supported only for 3 fractional bits
+         * RVC2 only.
          */
         std::int32_t subpixelFractionalBits = 5;
 
@@ -95,6 +97,7 @@ class StereoDepthConfig : public Buffer {
          * We normally only recommend doing this when it is known that there will be no objects
          * farther away than MaxZ, such as having a depth camera mounted above a table
          * pointing down at the table surface.
+         * RVC2 only.
          */
         std::int32_t disparityShift = 0;
 
@@ -110,6 +113,7 @@ class StereoDepthConfig : public Buffer {
          * 2. Warping the image to counter rotate and scaling to match the FOV.
          * Center alignment factor 1 is equivalent to RECTIFIED_RIGHT
          * Center alignment factor 0 is equivalent to RECTIFIED_LEFT
+         * RVC2 only.
          */
         std::optional<float> centerAlignmentShiftFactor;
 
@@ -117,6 +121,7 @@ class StereoDepthConfig : public Buffer {
          * Invalidate X amount of pixels at the edge of disparity frame.
          * For right and center alignment X pixels will be invalidated from the right edge,
          * for left alignment from the left edge.
+         * RVC2 only.
          */
         std::int32_t numInvalidateEdgePixels = 0;
 
@@ -136,7 +141,7 @@ class StereoDepthConfig : public Buffer {
     };
 
     /**
-     * Confidence metrics settings. Not used on RVC2.
+     * Confidence metrics settings. RVC4 only.
      */
     struct ConfidenceMetrics {
         /**
@@ -198,6 +203,7 @@ class StereoDepthConfig : public Buffer {
         /**
          * Sigma value for bilateral filter. 0 means disabled.
          * A larger value of the parameter means that farther colors within the pixel neighborhood will be mixed together.
+         * RVC2 only.
          */
         std::int16_t bilateralSigmaValue = 0;
 
@@ -294,7 +300,7 @@ class StereoDepthConfig : public Buffer {
         DecimationFilter decimationFilter;
 
         /**
-         * Hole-filling configuration. Not used on RVC2.
+         * Hole-filling configuration. RVC4 only.
          */
         struct HoleFilling {
             /**
@@ -331,12 +337,12 @@ class StereoDepthConfig : public Buffer {
         };
 
         /**
-         * Hole-filling configuration. Not used on RVC2.
+         * Hole-filling configuration. RVC4 only.
          */
         HoleFilling holeFilling;
 
         /**
-         * Adaptive median filter configuration. Not used on RVC2.
+         * Adaptive median filter configuration. RVC4 only.
          */
         struct AdaptiveMedianFilter {
             /**
@@ -355,7 +361,7 @@ class StereoDepthConfig : public Buffer {
         };
 
         /**
-         * Adaptive median filter configuration. Not used on RVC2.
+         * Adaptive median filter configuration. RVC4 only.
          */
         AdaptiveMedianFilter adaptiveMedianFilter;
 
@@ -399,6 +405,7 @@ class StereoDepthConfig : public Buffer {
 
         /**
          * Census transform kernel size.
+         * RVC2 only.
          */
         KernelSize kernelSize = KernelSize::AUTO;
 
@@ -410,16 +417,19 @@ class StereoDepthConfig : public Buffer {
          * 0XAA02A8154055 for 7x7 census transform kernel.
          * 0X2AA00AA805540155 for 7x9 census transform kernel.
          * Empirical values.
+         * RVC2 only.
          */
         uint64_t kernelMask = 0;
 
         /**
          * If enabled, each pixel in the window is compared with the mean window value instead of the central pixel.
+         * RVC2 only.
          */
         bool enableMeanMode = true;
 
         /**
          * Census transform comparison threshold value.
+         * RVC2 only.
          */
         uint32_t threshold = 0;
 
@@ -427,14 +437,14 @@ class StereoDepthConfig : public Buffer {
          * Used to reduce small fixed levels of noise across all luminance values
          * in the current image.
          * Valid range is [0,127]. Default value is 0.
-         * Not used on RVC2.
+         * RVC4 only.
          */
         int8_t noiseThresholdOffset = 1;
         /**
          * Used to reduce noise values that increase with luminance in the
          * current image.
          * Valid range is [-128,127]. Default value is 0.
-         * Not used on RVC2.
+         * RVC4 only.
          */
         int8_t noiseThresholdScale = 1;
 
@@ -454,6 +464,7 @@ class StereoDepthConfig : public Buffer {
 
         /**
          * Disparity search range, default 96 pixels.
+         * RVC2 only.
          */
         DisparityWidth disparityWidth = DisparityWidth::DISPARITY_96;
 
@@ -465,11 +476,13 @@ class StereoDepthConfig : public Buffer {
          * In case of 96 disparities: N=48, M=32, T=16.
          * This way the search range is extended to 176 disparities, by sparse matching.
          * Note: when enabling this flag only depth map will be affected, disparity map is not.
+         * RVC2 only.
          */
         bool enableCompanding = false;
 
         /**
          * Used only for debug purposes, SW postprocessing handled only invalid value of 0 properly.
+         * RVC2 only.
          */
         uint8_t invalidDisparityValue = 0;
 
@@ -479,7 +492,7 @@ class StereoDepthConfig : public Buffer {
         uint8_t confidenceThreshold = 55;
 
         /**
-         * Enable software confidence thresholding. Not used on RVC2.
+         * Enable software confidence thresholding. RVC4 only.
          */
         bool enableSwConfidenceThresholding = false;
 
@@ -490,6 +503,7 @@ class StereoDepthConfig : public Buffer {
          * Where AD is the Absolute Difference between 2 pixels values.
          * CTC is the Census Transform Cost between 2 pixels, based on Hamming distance (xor).
          * The α and β parameters are subject to fine tuning by the user.
+         * RVC2 only.
          */
         struct LinearEquationParameters {
             uint8_t alpha = 0;
@@ -501,6 +515,7 @@ class StereoDepthConfig : public Buffer {
 
         /**
          * Cost calculation linear equation parameters.
+         * RVC2 only.
          */
         LinearEquationParameters linearEquationParameters;
 
@@ -526,29 +541,34 @@ class StereoDepthConfig : public Buffer {
 
         /**
          * Cost calculation linear equation parameters.
+         * RVC2 only.
          */
         uint8_t divisionFactor = 1;
 
         /**
          * Horizontal P1 penalty cost parameter.
+         * RVC2 only.
          */
         uint16_t horizontalPenaltyCostP1 = defaultPenaltyP1;
         /**
          * Horizontal P2 penalty cost parameter.
+         * RVC2 only.
          */
         uint16_t horizontalPenaltyCostP2 = defaultPenaltyP2;
 
         /**
          * Vertical P1 penalty cost parameter.
+         * RVC2 only.
          */
         uint16_t verticalPenaltyCostP1 = defaultPenaltyP1;
         /**
          * Vertical P2 penalty cost parameter.
+         * RVC2 only.
          */
         uint16_t verticalPenaltyCostP2 = defaultPenaltyP2;
 
         /**
-         * Adaptive P1 penalty configuration. Not used on RVC2.
+         * Adaptive P1 penalty configuration. RVC4 only.
          */
         struct P1Config {
             /**
@@ -595,12 +615,12 @@ class StereoDepthConfig : public Buffer {
         };
 
         /**
-         * Adaptive P1 penalty configuration. Not used on RVC2.
+         * Adaptive P1 penalty configuration. RVC4 only.
          */
         P1Config p1Config;
 
         /**
-         * Adaptive P2 penalty configuration. Not used on RVC2.
+         * Adaptive P2 penalty configuration. RVC4 only.
          */
         struct P2Config {
             /**
@@ -633,7 +653,7 @@ class StereoDepthConfig : public Buffer {
         };
 
         /**
-         * Adaptive P2 penalty configuration. Not used on RVC2.
+         * Adaptive P2 penalty configuration. RVC4 only.
          */
         P2Config p2Config;
 
@@ -782,13 +802,13 @@ class StereoDepthConfig : public Buffer {
 
     /**
      * Set filters compute backend
-     * Not used on RVC2.
+     * RVC4 only.
      */
     StereoDepthConfig& setFiltersComputeBackend(dai::ProcessorType filtersBackend);
 
     /**
      * Get filters compute backend
-     * Not used on RVC2.
+     * RVC4 only.
      */
     dai::ProcessorType getFiltersComputeBackend() const;
 
@@ -824,12 +844,12 @@ class StereoDepthConfig : public Buffer {
     CostAggregation costAggregation;
 
     /**
-     * Confidence metrics settings. Not used on RVC2.
+     * Confidence metrics settings. RVC4 only.
      */
     ConfidenceMetrics confidenceMetrics;
 
     /**
-     * Compute backend for post-processing filters. Not used on RVC2.
+     * Compute backend for post-processing filters. RVC4 only.
      */
     dai::ProcessorType filtersBackend = dai::ProcessorType::CPU;
 

--- a/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
+++ b/include/depthai/pipeline/datatype/StereoDepthConfig.hpp
@@ -436,14 +436,14 @@ class StereoDepthConfig : public Buffer {
         /**
          * Used to reduce small fixed levels of noise across all luminance values
          * in the current image.
-         * Valid range is [0,127]. Default value is 0.
+         * Valid range is [0,127]. Default value is 1.
          * RVC4 only.
          */
         int8_t noiseThresholdOffset = 1;
         /**
          * Used to reduce noise values that increase with luminance in the
          * current image.
-         * Valid range is [-128,127]. Default value is 0.
+         * Valid range is [-128,127]. Default value is 1.
          * RVC4 only.
          */
         int8_t noiseThresholdScale = 1;

--- a/include/depthai/properties/StereoDepthProperties.hpp
+++ b/include/depthai/properties/StereoDepthProperties.hpp
@@ -146,7 +146,7 @@ struct StereoDepthProperties : PropertiesSerializable<Properties, StereoDepthPro
 
     /**
      * Whether to enable frame syncing inside stereo node or not. Suitable if inputs are known to be synced.
-     * RVC4 only.
+     * RVC3 only.
      */
     bool enableFrameSync = true;
 

--- a/include/depthai/properties/StereoDepthProperties.hpp
+++ b/include/depthai/properties/StereoDepthProperties.hpp
@@ -143,6 +143,7 @@ struct StereoDepthProperties : PropertiesSerializable<Properties, StereoDepthPro
 
     /**
      * Whether to enable frame syncing inside stereo node or not. Suitable if inputs are known to be synced.
+     * Not used on RVC2.
      */
     bool enableFrameSync = true;
 

--- a/include/depthai/properties/StereoDepthProperties.hpp
+++ b/include/depthai/properties/StereoDepthProperties.hpp
@@ -95,6 +95,7 @@ struct StereoDepthProperties : PropertiesSerializable<Properties, StereoDepthPro
      * Note: It will allocate resources for worst cases scenario,
      * should be enabled only if dynamic mode switch is required.
      * Default value: false.
+     * RVC2 only.
      */
     bool enableRuntimeStereoModeSwitch = false;
 
@@ -109,6 +110,7 @@ struct StereoDepthProperties : PropertiesSerializable<Properties, StereoDepthPro
      * For optimal performance it's recommended to allocate more than 0,
      * so post processing will run in parallel with main stereo algorithm.
      * Minimum 1, maximum 10.
+     * RVC2 only.
      */
     std::int32_t numPostProcessingShaves = AUTO;
 
@@ -119,6 +121,7 @@ struct StereoDepthProperties : PropertiesSerializable<Properties, StereoDepthPro
      * For optimal performance it's recommended to allocate more than 0,
      * so post processing will run in parallel with main stereo algorithm.
      * Minimum 1, maximum 6.
+     * RVC2 only.
      */
     std::int32_t numPostProcessingMemorySlices = AUTO;
 
@@ -143,7 +146,7 @@ struct StereoDepthProperties : PropertiesSerializable<Properties, StereoDepthPro
 
     /**
      * Whether to enable frame syncing inside stereo node or not. Suitable if inputs are known to be synced.
-     * Not used on RVC2.
+     * RVC4 only.
      */
     bool enableFrameSync = true;
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Adds labels RVC2 only and RVC4 only to `StereoDepthConfig` and `StereoDepthProperties` to clearly denote what is available on each platform.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Codex:gpt-5.6-terra

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which device generations support stereo depth settings and properties.
  * Added applicability notes for filtering, confidence, post-processing, frame synchronization, and runtime stereo mode features.
  * Improved documentation for hole filling, adaptive median filtering, and related stereo configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->