### PR TITLE
fix: ToF example colorization flicker

### DIFF
--- a/examples/cpp/ToF/tof_align.cpp
+++ b/examples/cpp/ToF/tof_align.cpp
@@ -11,7 +11,6 @@
 constexpr float FPS = 10.0f;
 const cv::Size CAMERA_SIZE(640, 400);
 
-// Show depth in range 0.1 m to 7 m.
 constexpr float MIN_DEPTH = 100.0f;
 constexpr float MAX_DEPTH = 7000.0f;
 

--- a/examples/cpp/ToF/tof_align.cpp
+++ b/examples/cpp/ToF/tof_align.cpp
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
     camOut->link(align->inputAlignTo);
 
     auto sync = pipeline.create<dai::node::Sync>();
-    sync->setSyncThreshold(std::chrono::milliseconds(static_cast<uint32_t>(500 / FPS)));
+    sync->setSyncThreshold(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(0.5 / FPS)));
     sync->setRunOnHost(true);
     camOut->link(sync->inputs["rgb"]);
     align->outputAligned.link(sync->inputs["depth_aligned"]);

--- a/examples/cpp/ToF/tof_align.cpp
+++ b/examples/cpp/ToF/tof_align.cpp
@@ -8,7 +8,7 @@
 
 #include "depthai/depthai.hpp"
 
-constexpr float FPS = 10.0f;
+constexpr float FPS = 30.0f;
 const cv::Size CAMERA_SIZE(640, 400);
 
 constexpr float MIN_DEPTH = 100.0f;

--- a/examples/cpp/ToF/tof_align.cpp
+++ b/examples/cpp/ToF/tof_align.cpp
@@ -1,200 +1,131 @@
 #include <chrono>
 #include <cmath>
-#include <deque>
 #include <iostream>
 #include <opencv2/opencv.hpp>
 #include <string>
-#include <vector>
+
+#include <argparse/argparse.hpp>
 
 #include "depthai/depthai.hpp"
 
-// Constants from the Python script
-constexpr float FPS = 30.0f;
-const dai::CameraBoardSocket RGB_SOCKET = dai::CameraBoardSocket::CAM_C;
-const dai::CameraBoardSocket TOF_SOCKET = dai::CameraBoardSocket::CAM_A;
-const cv::Size SIZE(640, 400);
+constexpr float FPS = 10.0f;
+const cv::Size CAMERA_SIZE(640, 400);
 
-// FPSCounter class, similar to the one in the Python script
-class FPSCounter {
-   public:
-    void tick() {
-        auto now = std::chrono::steady_clock::now();
-        frameTimes.push_back(now);
-        // Keep the last 100 timestamps, similar to the Python example
-        while(frameTimes.size() > 100) {
-            frameTimes.pop_front();
-        }
-    }
+// Show depth in range 0.1 m to 7 m.
+constexpr float MIN_DEPTH = 100.0f;
+constexpr float MAX_DEPTH = 7000.0f;
 
-    double getFps() {
-        if(frameTimes.size() <= 1) {
-            return 0.0;
-        }
-        auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(frameTimes.back() - frameTimes.front()).count();
-        return (static_cast<double>(frameTimes.size()) - 1.0) / duration;
-    }
-
-   private:
-    std::deque<std::chrono::steady_clock::time_point> frameTimes;
-};
-
-cv::Mat colorizeDepth(const cv::Mat& frameDepth) {
-    // -----------------------------------------------------------------------
-    // 1.  Basic checks & convert to CV_32F
-    // -----------------------------------------------------------------------
-    if(frameDepth.empty() || frameDepth.channels() != 1) return cv::Mat::zeros(frameDepth.size(), CV_8UC3);
-
+cv::Mat colorizeDepth(const cv::Mat& frame, float minDepth, float maxDepth) {
     cv::Mat depth32f;
-    frameDepth.convertTo(depth32f, CV_32F);  // safe for any input type
+    frame.convertTo(depth32f, CV_32F);
 
-    // -----------------------------------------------------------------------
-    // 2.  Build mask of valid (non-zero) pixels
-    // -----------------------------------------------------------------------
-    const cv::Mat nonZeroMask = depth32f != 0.0f;
-    const int nz = cv::countNonZero(nonZeroMask);
-    if(nz == 0) return cv::Mat::zeros(frameDepth.size(), CV_8UC3);
+    cv::Mat invalidMask = depth32f == 0.0f;
 
-    // -----------------------------------------------------------------------
-    // 3.  3 % / 95 % percentiles (identical to Python version)
-    // -----------------------------------------------------------------------
-    std::vector<float> values;
-    values.reserve(nz);
-    for(int r = 0; r < depth32f.rows; ++r) {
-        const float* d = depth32f.ptr<float>(r);
-        const uchar* m = nonZeroMask.ptr<uchar>(r);
-        for(int c = 0; c < depth32f.cols; ++c)
-            if(m[c]) values.push_back(d[c]);
+    try {
+        cv::Mat logDepth = depth32f + 1e-6f;
+        cv::log(logDepth, logDepth);
+        logDepth.setTo(0.0f, invalidMask);
+
+        const float logMinDepth = std::log(minDepth + 1e-6f);
+        const float logMaxDepth = std::log(maxDepth + 1e-6f);
+
+        cv::min(logDepth, logMaxDepth, logDepth);
+        cv::max(logDepth, logMinDepth, logDepth);
+
+        cv::Mat colored;
+        logDepth.convertTo(
+            colored, CV_8U, 255.0 / (logMaxDepth - logMinDepth), -logMinDepth * 255.0 / (logMaxDepth - logMinDepth));
+        cv::applyColorMap(colored, colored, cv::COLORMAP_JET);
+        colored.setTo(cv::Scalar::all(0), invalidMask);
+        return colored;
+    } catch(const cv::Exception&) {
+        return cv::Mat::zeros(frame.size(), CV_8UC3);
     }
-
-    std::sort(values.begin(), values.end());
-    auto pct = [&](double p) {
-        size_t idx = static_cast<size_t>(std::round((p / 100.0) * (values.size() - 1)));
-        return values[idx];
-    };
-
-    const float minDepth = pct(3.0);
-    const float maxDepth = pct(95.0);
-
-    // -----------------------------------------------------------------------
-    // 4.  Logarithm (zeros replaced by minDepth to avoid -inf)
-    // -----------------------------------------------------------------------
-    cv::Mat logDepth;
-    depth32f.copyTo(logDepth);
-    logDepth.setTo(minDepth, ~nonZeroMask);  // overwrite zeros
-    cv::log(logDepth, logDepth);
-
-    const float logMinDepth = std::log(minDepth);
-    const float logMaxDepth = std::log(maxDepth);
-
-    // -----------------------------------------------------------------------
-    // 5.  Clip & linearly scale to [0,255]  (same as np.interp)
-    // -----------------------------------------------------------------------
-    cv::min(logDepth, logMaxDepth, logDepth);
-    cv::max(logDepth, logMinDepth, logDepth);
-    logDepth = (logDepth - logMinDepth) * (255.0f / (logMaxDepth - logMinDepth));
-
-    cv::Mat depth8U;
-    logDepth.convertTo(depth8U, CV_8U);
-
-    // -----------------------------------------------------------------------
-    // 6.  Colour map + set invalid pixels to black
-    // -----------------------------------------------------------------------
-    cv::Mat depthFrameColor;
-    cv::applyColorMap(depth8U, depthFrameColor, cv::COLORMAP_JET);
-    depthFrameColor.setTo(cv::Scalar::all(0), ~nonZeroMask);
-
-    return depthFrameColor;
 }
 
-// Global variables for blending weights
-float rgbWeight = 0.4f;
-float depthWeight = 0.6f;
+float rgbWeight = 0.5f;
+float depthWeight = 0.5f;
 
-// Callback function for the trackbar
 void updateBlendWeights(int percentRgb, void*) {
     rgbWeight = static_cast<float>(percentRgb) / 100.0f;
     depthWeight = 1.0f - rgbWeight;
 }
 
-int main() {
+int main(int argc, char** argv) {
+    argparse::ArgumentParser program("tof_align");
+    program.add_description("Align ToF depth over left or right camera and show a blended overlay.");
+    program.add_argument("--camera")
+        .default_value(std::string("left"))
+        .choices("left", "right")
+        .help("Camera to align depth onto: left=CAM_B, right=CAM_C (default: left)");
+
+    try {
+        program.parse_args(argc, argv);
+    } catch(const std::runtime_error& err) {
+        std::cerr << err.what() << '\n';
+        std::cerr << program;
+        return EXIT_FAILURE;
+    }
+
+    const std::string cameraArg = program.get<std::string>("--camera");
+    const dai::CameraBoardSocket alignSocket = (cameraArg == "right") ? dai::CameraBoardSocket::CAM_C : dai::CameraBoardSocket::CAM_B;
+    std::cout << "Aligning ToF depth over " << cameraArg << " camera\n";
+
     dai::Pipeline pipeline;
 
-    // Define sources and outputs
-    auto camRgb = pipeline.create<dai::node::Camera>();
     auto tof = pipeline.create<dai::node::ToF>();
-    auto sync = pipeline.create<dai::node::Sync>();
+    tof->build(dai::CameraBoardSocket::AUTO, dai::ToFConfig::Profile::MID_RANGE, FPS);
+
+    auto cam = pipeline.create<dai::node::Camera>()->build(alignSocket);
+    auto camOut = cam->requestOutput(std::make_pair(CAMERA_SIZE.width, CAMERA_SIZE.height), std::nullopt, dai::ImgResizeMode::CROP, FPS, true);
+
     auto align = pipeline.create<dai::node::ImageAlign>();
     align->setRunOnHost(true);
+    tof->depth.link(align->input);
+    camOut->link(align->inputAlignTo);
 
-    camRgb->build(RGB_SOCKET);
-    const auto profile = dai::ToFConfig::Profile::MID_RANGE;
-    tof->build(TOF_SOCKET, profile, FPS);
-
-    // Set sync threshold
+    auto sync = pipeline.create<dai::node::Sync>();
     sync->setSyncThreshold(std::chrono::milliseconds(static_cast<uint32_t>(500 / FPS)));
     sync->setRunOnHost(true);
-
-    // Linking
-    auto cameraOutput = camRgb->requestOutput(std::make_pair(SIZE.width, SIZE.height), std::nullopt, dai::ImgResizeMode::CROP, FPS, true);
-
-    cameraOutput->link(sync->inputs["rgb"]);
-    tof->depth.link(align->input);
+    camOut->link(sync->inputs["rgb"]);
     align->outputAligned.link(sync->inputs["depth_aligned"]);
     sync->inputs["rgb"].setBlocking(false);
-    cameraOutput->link(align->inputAlignTo);
+
     auto syncQueue = sync->out.createOutputQueue();
 
-    auto confFilter = pipeline.create<dai::node::ToFDepthConfidenceFilter>();
-    tof->depth.link(confFilter->depth);
-    tof->amplitude.link(confFilter->amplitude);
-    confFilter->setRunOnHost(true);
+    const std::string windowBlend = "tof-overlay-" + cameraArg;
+    const std::string windowDepth = "depth-aligned";
 
-    auto filteredDepthQ = confFilter->filteredDepth.createOutputQueue();
-
-    // Start the pipeline
     pipeline.start();
+    cv::namedWindow(windowBlend);
+    cv::namedWindow(windowDepth);
+    cv::createTrackbar("RGB Weight %", windowBlend, nullptr, 100, updateBlendWeights);
+    cv::setTrackbarPos("RGB Weight %", windowBlend, static_cast<int>(rgbWeight * 100));
 
-    // Configure windows and trackbar
-    const std::string rgbDepthWindowName = "rgb-depth";
-    cv::namedWindow(rgbDepthWindowName);
-    cv::createTrackbar("RGB Weight %", rgbDepthWindowName, nullptr, 100, updateBlendWeights);
-    cv::setTrackbarPos("RGB Weight %", rgbDepthWindowName, static_cast<int>(rgbWeight * 100));
-
-    FPSCounter fpsCounter;
-
-    while(true) {
+    while(pipeline.isRunning()) {
         auto messageGroup = syncQueue->get<dai::MessageGroup>();
         if(messageGroup == nullptr) continue;
 
-        fpsCounter.tick();
-
         auto frameRgb = messageGroup->get<dai::ImgFrame>("rgb");
         auto frameDepth = messageGroup->get<dai::ImgFrame>("depth_aligned");
-        auto filteredDepthMsg = filteredDepthQ->get<dai::ImgFrame>();
 
-        if(filteredDepthMsg) {
-            cv::Mat filteredDepthMat = filteredDepthMsg->getCvFrame();
-            // Display filtered depth map
-            cv::imshow("Filtered Depth", colorizeDepth(filteredDepthMat));
+        cv::Mat cvFrame = frameRgb->getCvFrame();
+        if(cvFrame.channels() == 1) {
+            cv::cvtColor(cvFrame, cvFrame, cv::COLOR_GRAY2BGR);
         }
 
-        if(frameRgb && frameDepth) {
-            cv::Mat cvFrame = frameRgb->getCvFrame();
-            cv::Mat alignedDepthColorized = colorizeDepth(frameDepth->getFrame());
-
-            // Add FPS text to the depth frame
-            std::string fpsText = "FPS: " + std::to_string(fpsCounter.getFps());
-            cv::putText(alignedDepthColorized, fpsText, cv::Point(10, 30), cv::FONT_HERSHEY_SIMPLEX, 1, cv::Scalar(255, 255, 255), 2);
-            cv::imshow("depth", alignedDepthColorized);
-
-            // Blend the RGB and depth frames
-            cv::Mat blended;
-            cv::addWeighted(cvFrame, rgbWeight, alignedDepthColorized, depthWeight, 0, blended);
-            cv::imshow(rgbDepthWindowName, blended);
+        cv::Mat depthColorized = colorizeDepth(frameDepth->getFrame(), MIN_DEPTH, MAX_DEPTH);
+        if(depthColorized.size() != cvFrame.size()) {
+            cv::resize(depthColorized, depthColorized, cvFrame.size());
         }
 
-        int key = cv::waitKey(1);
-        if(key == 'q' || key == 27) {  // 'q' or ESC
+        cv::imshow(windowDepth, depthColorized);
+
+        cv::Mat blended;
+        cv::addWeighted(cvFrame, rgbWeight, depthColorized, depthWeight, 0, blended);
+        cv::imshow(windowBlend, blended);
+
+        if(cv::waitKey(1) == 'q') {
             break;
         }
     }

--- a/examples/cpp/ToF/tof_all_queues.cpp
+++ b/examples/cpp/ToF/tof_all_queues.cpp
@@ -42,11 +42,9 @@ cv::Mat normalizeFrame(const cv::Mat& frame) {
 int main() {
     dai::Pipeline pipeline;
 
-    // show depth in range 0.1m - 7m
     constexpr float minDepth = 100.0f;
     constexpr float maxDepth = 7000.0f;
 
-    // choose one of profiles LOW_RANGE / MID_RANGE / HIGH_RANGE
     auto profile = dai::ToFConfig::Profile::MID_RANGE;
 
     auto tof = pipeline.create<dai::node::ToF>()->build(dai::CameraBoardSocket::AUTO, profile);
@@ -55,8 +53,6 @@ int main() {
         {"depth", tof->depth.createOutputQueue(1, false)},
         {"amplitude", tof->amplitude.createOutputQueue(1, false)},
         {"intensity", tof->intensity.createOutputQueue(1, false)},
-        // {"rawDepth", tof->rawDepth.createOutputQueue(1, false)},  // not supported on RVC4
-        // {"confidence", tof->confidence.createOutputQueue(1, false)},  // not supported on RVC2
     };
 
     pipeline.start();

--- a/examples/cpp/ToF/tof_all_queues.cpp
+++ b/examples/cpp/ToF/tof_all_queues.cpp
@@ -1,9 +1,12 @@
 #include <cmath>
+#include <iostream>
 #include <map>
 #include <opencv2/opencv.hpp>
 #include <string>
 
 #include "depthai/depthai.hpp"
+
+constexpr float FPS = 30.0f;
 
 cv::Mat colorizeDepth(const cv::Mat& frame, float minDepth, float maxDepth) {
     cv::Mat depth32f;
@@ -47,13 +50,22 @@ int main() {
 
     auto profile = dai::ToFConfig::Profile::MID_RANGE;
 
-    auto tof = pipeline.create<dai::node::ToF>()->build(dai::CameraBoardSocket::AUTO, profile);
+    auto tof = pipeline.create<dai::node::ToF>()->build(dai::CameraBoardSocket::AUTO, profile, FPS);
+
+    bool isRVC2 = pipeline.getDefaultDevice()->getPlatform() == dai::Platform::RVC2;
 
     std::map<std::string, std::shared_ptr<dai::MessageQueue>> outputQueues = {
         {"depth", tof->depth.createOutputQueue(1, false)},
         {"amplitude", tof->amplitude.createOutputQueue(1, false)},
         {"intensity", tof->intensity.createOutputQueue(1, false)},
     };
+    if(isRVC2) {
+        outputQueues["rawDepth"] = tof->rawDepth.createOutputQueue(1, false);
+    } else {
+        outputQueues["confidence"] = tof->confidence.createOutputQueue(1, false);
+    }
+
+    std::cout << "Detected " << (isRVC2 ? "RVC2" : "RVC4") << std::endl;
 
     pipeline.start();
     while(pipeline.isRunning()) {

--- a/examples/cpp/ToF/tof_all_queues.cpp
+++ b/examples/cpp/ToF/tof_all_queues.cpp
@@ -22,17 +22,9 @@ cv::Mat colorizeDepth(const cv::Mat& frame, float minDepth, float maxDepth) {
         cv::min(logDepth, logMaxDepth, logDepth);
         cv::max(logDepth, logMinDepth, logDepth);
 
-        cv::Mat validMask = invalidMask == 0;
-        double validMin = 0.0;
-        double validMax = 0.0;
-        cv::minMaxLoc(logDepth, &validMin, &validMax, nullptr, nullptr, validMask);
-
-        if(validMax <= validMin) {
-            return cv::Mat::zeros(frame.size(), CV_8UC3);
-        }
-
         cv::Mat colored;
-        logDepth.convertTo(colored, CV_8U, 255.0 / (validMax - validMin), -validMin * 255.0 / (validMax - validMin));
+        logDepth.convertTo(
+            colored, CV_8U, 255.0 / (logMaxDepth - logMinDepth), -logMinDepth * 255.0 / (logMaxDepth - logMinDepth));
         cv::applyColorMap(colored, colored, cv::COLORMAP_JET);
         colored.setTo(cv::Scalar::all(0), invalidMask);
         return colored;

--- a/examples/cpp/ToF/tof_minimal.cpp
+++ b/examples/cpp/ToF/tof_minimal.cpp
@@ -20,17 +20,9 @@ cv::Mat colorizeDepth(const cv::Mat& frame, float minDepth, float maxDepth) {
         cv::min(logDepth, logMaxDepth, logDepth);
         cv::max(logDepth, logMinDepth, logDepth);
 
-        cv::Mat validMask = invalidMask == 0;
-        double validMin = 0.0;
-        double validMax = 0.0;
-        cv::minMaxLoc(logDepth, &validMin, &validMax, nullptr, nullptr, validMask);
-
-        if(validMax <= validMin) {
-            return cv::Mat::zeros(frame.size(), CV_8UC3);
-        }
-
         cv::Mat colored;
-        logDepth.convertTo(colored, CV_8U, 255.0 / (validMax - validMin), -validMin * 255.0 / (validMax - validMin));
+        logDepth.convertTo(
+            colored, CV_8U, 255.0 / (logMaxDepth - logMinDepth), -logMinDepth * 255.0 / (logMaxDepth - logMinDepth));
         cv::applyColorMap(colored, colored, cv::COLORMAP_JET);
         colored.setTo(cv::Scalar::all(0), invalidMask);
         return colored;

--- a/examples/cpp/ToF/tof_minimal.cpp
+++ b/examples/cpp/ToF/tof_minimal.cpp
@@ -35,11 +35,9 @@ int main() {
     auto device = std::make_shared<dai::Device>();
     dai::Pipeline pipeline(device);
 
-    // Show depth in range 0.1 m to 7 m.
     constexpr float minDepth = 100.0f;
     constexpr float maxDepth = 7000.0f;
 
-    // Choose one of the profiles: LOW_RANGE, MID_RANGE, or HIGH_RANGE.
     auto profile = dai::ToFConfig::Profile::MID_RANGE;
 
     auto tof = pipeline.create<dai::node::ToF>()->build(dai::CameraBoardSocket::AUTO, profile);

--- a/examples/cpp/ToF/tof_minimal.cpp
+++ b/examples/cpp/ToF/tof_minimal.cpp
@@ -3,6 +3,8 @@
 
 #include "depthai/depthai.hpp"
 
+constexpr float FPS = 30.0f;
+
 cv::Mat colorizeDepth(const cv::Mat& frame, float minDepth, float maxDepth) {
     cv::Mat depth32f;
     frame.convertTo(depth32f, CV_32F);
@@ -40,7 +42,7 @@ int main() {
 
     auto profile = dai::ToFConfig::Profile::MID_RANGE;
 
-    auto tof = pipeline.create<dai::node::ToF>()->build(dai::CameraBoardSocket::AUTO, profile);
+    auto tof = pipeline.create<dai::node::ToF>()->build(dai::CameraBoardSocket::AUTO, profile, FPS);
 
     auto depthOutputQueue = tof->depth.createOutputQueue();
 

--- a/examples/python/ToF/tof_align.py
+++ b/examples/python/ToF/tof_align.py
@@ -27,8 +27,12 @@ def colorizeDepth(frameDepth: np.ndarray, minDepth: float, maxDepth: float) -> n
     try:
         logDepth = np.log(frameDepth.astype(np.float32) + 1e-6)
         logDepth[invalidMask] = 0.0
-        logDepth = np.clip(logDepth, np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6))
-        depthFrameColor = np.interp(logDepth, (logDepth[~invalidMask].min(), logDepth[~invalidMask].max()), (0, 255))
+        logMin, logMax = np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6)
+        logDepth = np.clip(logDepth, logMin, logMax)
+        # Map from the FIXED depth range (not the per-frame min/max) so a given depth
+        # always maps to the same color -- otherwise the mapping shifts every frame and
+        # the image flickers.
+        depthFrameColor = np.interp(logDepth, (logMin, logMax), (0, 255))
         depthFrameColor = depthFrameColor.astype(np.uint8)
         depthFrameColor = cv2.applyColorMap(depthFrameColor, cv2.COLORMAP_JET)
         depthFrameColor[invalidMask] = 0

--- a/examples/python/ToF/tof_align.py
+++ b/examples/python/ToF/tof_align.py
@@ -17,7 +17,6 @@ import numpy as np
 FPS = 10.0
 CAMERA_SIZE = (640, 400)
 
-# show depth in range 0.1m - 7m
 MIN_DEPTH = 100
 MAX_DEPTH = 7000
 

--- a/examples/python/ToF/tof_align.py
+++ b/examples/python/ToF/tof_align.py
@@ -29,9 +29,6 @@ def colorizeDepth(frameDepth: np.ndarray, minDepth: float, maxDepth: float) -> n
         logDepth[invalidMask] = 0.0
         logMin, logMax = np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6)
         logDepth = np.clip(logDepth, logMin, logMax)
-        # Map from the FIXED depth range (not the per-frame min/max) so a given depth
-        # always maps to the same color -- otherwise the mapping shifts every frame and
-        # the image flickers.
         depthFrameColor = np.interp(logDepth, (logMin, logMax), (0, 255))
         depthFrameColor = depthFrameColor.astype(np.uint8)
         depthFrameColor = cv2.applyColorMap(depthFrameColor, cv2.COLORMAP_JET)

--- a/examples/python/ToF/tof_align.py
+++ b/examples/python/ToF/tof_align.py
@@ -2,8 +2,8 @@
 """Align ToF depth over left or right camera and show a blended overlay.
 
 Usage:
-    python tof_align_overlay.py --camera left   # align over CAM_B (default)
-    python tof_align_overlay.py --camera right  # align over CAM_C
+    python tof_align.py --camera left
+    python tof_align.py --camera right
 """
 
 import argparse
@@ -14,7 +14,7 @@ import depthai as dai
 import numpy as np
 
 
-FPS = 10.0
+FPS = 30.0
 CAMERA_SIZE = (640, 400)
 
 MIN_DEPTH = 100

--- a/examples/python/ToF/tof_all_queues.py
+++ b/examples/python/ToF/tof_all_queues.py
@@ -11,6 +11,8 @@ import cv2
 import numpy as np
 import depthai as dai
 
+FPS = 30.0
+
 
 def colorizeDepth(frame: np.ndarray, minDepth: float, maxDepth: float) -> np.ndarray:
     invalidMask = frame == 0
@@ -42,7 +44,8 @@ def main():
 
     tof = pipeline.create(dai.node.ToF).build(
         boardSocket=dai.CameraBoardSocket.AUTO,
-        profile=profile
+        profile=profile,
+        fps=FPS,
     )
 
     with pipeline as p:
@@ -55,10 +58,8 @@ def main():
             "intensity": tof.intensity.createOutputQueue(maxSize=1, blocking=False),
         }
         if isRVC2:
-            # rawDepth are only supported on RVC2
             outputQueues["rawDepth"] = tof.rawDepth.createOutputQueue(maxSize=1, blocking=False)
         else:
-            # confidence is only supported on RVC4
             outputQueues["confidence"] = tof.confidence.createOutputQueue(maxSize=1, blocking=False)
 
         platformName = "RVC2" if isRVC2 else "RVC4"

--- a/examples/python/ToF/tof_all_queues.py
+++ b/examples/python/ToF/tof_all_queues.py
@@ -17,8 +17,12 @@ def colorizeDepth(frame: np.ndarray, minDepth: float, maxDepth: float) -> np.nda
     try:
         logDepth = np.log(frame.astype(np.float32) + 1e-6)
         logDepth[invalidMask] = 0.0
-        logDepth = np.clip(logDepth, np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6))
-        colored = np.interp(logDepth, (logDepth[~invalidMask].min(), logDepth[~invalidMask].max()), (0, 255))
+        logMin, logMax = np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6)
+        logDepth = np.clip(logDepth, logMin, logMax)
+        # Map from the FIXED depth range (not the per-frame min/max) so a given depth
+        # always maps to the same color -- otherwise the mapping shifts every frame and
+        # the image flickers.
+        colored = np.interp(logDepth, (logMin, logMax), (0, 255))
         colored = colored.astype(np.uint8)
         colored = cv2.applyColorMap(colored, cv2.COLORMAP_JET)
         colored[invalidMask] = 0

--- a/examples/python/ToF/tof_all_queues.py
+++ b/examples/python/ToF/tof_all_queues.py
@@ -19,9 +19,6 @@ def colorizeDepth(frame: np.ndarray, minDepth: float, maxDepth: float) -> np.nda
         logDepth[invalidMask] = 0.0
         logMin, logMax = np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6)
         logDepth = np.clip(logDepth, logMin, logMax)
-        # Map from the FIXED depth range (not the per-frame min/max) so a given depth
-        # always maps to the same color -- otherwise the mapping shifts every frame and
-        # the image flickers.
         colored = np.interp(logDepth, (logMin, logMax), (0, 255))
         colored = colored.astype(np.uint8)
         colored = cv2.applyColorMap(colored, cv2.COLORMAP_JET)

--- a/examples/python/ToF/tof_all_queues.py
+++ b/examples/python/ToF/tof_all_queues.py
@@ -35,11 +35,9 @@ def normalizeFrame(frame: np.ndarray) -> np.ndarray:
 def main():
     pipeline = dai.Pipeline()
 
-    # show depth in range 0.1m - 7m
     minDepth = 100
     maxDepth = 7000
 
-    # choose one of profiles LOW_RANGE / MID_RANGE / HIGH_RANGE
     profile = dai.ToFConfig.Profile.MID_RANGE
 
     tof = pipeline.create(dai.node.ToF).build(

--- a/examples/python/ToF/tof_minimal.py
+++ b/examples/python/ToF/tof_minimal.py
@@ -11,6 +11,8 @@ import cv2
 import numpy as np
 import depthai as dai
 
+FPS = 30.0
+
 
 def colorizeDepth(frame: np.ndarray, minDepth: float, maxDepth: float) -> np.ndarray:
     invalidMask = frame == 0
@@ -38,7 +40,8 @@ def main():
 
     tof = pipeline.create(dai.node.ToF).build(
         boardSocket=dai.CameraBoardSocket.AUTO,
-        profile=profile
+        profile=profile,
+        fps=FPS,
     )
 
     depthOutputQueue = tof.depth.createOutputQueue()

--- a/examples/python/ToF/tof_minimal.py
+++ b/examples/python/ToF/tof_minimal.py
@@ -17,8 +17,12 @@ def colorizeDepth(frame: np.ndarray, minDepth: float, maxDepth: float) -> np.nda
     try:
         logDepth = np.log(frame.astype(np.float32) + 1e-6)
         logDepth[invalidMask] = 0.0
-        logDepth = np.clip(logDepth, np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6))
-        colored = np.interp(logDepth, (logDepth[~invalidMask].min(), logDepth[~invalidMask].max()), (0, 255))
+        logMin, logMax = np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6)
+        logDepth = np.clip(logDepth, logMin, logMax)
+        # Map from the FIXED depth range (not the per-frame min/max) so a given depth
+        # always maps to the same color -- otherwise the mapping shifts every frame and
+        # the image flickers.
+        colored = np.interp(logDepth, (logMin, logMax), (0, 255))
         colored = colored.astype(np.uint8)
         colored = cv2.applyColorMap(colored, cv2.COLORMAP_JET)
         colored[invalidMask] = 0

--- a/examples/python/ToF/tof_minimal.py
+++ b/examples/python/ToF/tof_minimal.py
@@ -31,11 +31,9 @@ def colorizeDepth(frame: np.ndarray, minDepth: float, maxDepth: float) -> np.nda
 def main():
     pipeline = dai.Pipeline()
 
-    # show depth in range 0.1m - 7m
     minDepth = 100
     maxDepth = 7000
 
-    # choose one of profiles LOW_RANGE / MID_RANGE / HIGH_RANGE
     profile = dai.ToFConfig.Profile.MID_RANGE
 
     tof = pipeline.create(dai.node.ToF).build(

--- a/examples/python/ToF/tof_minimal.py
+++ b/examples/python/ToF/tof_minimal.py
@@ -19,9 +19,6 @@ def colorizeDepth(frame: np.ndarray, minDepth: float, maxDepth: float) -> np.nda
         logDepth[invalidMask] = 0.0
         logMin, logMax = np.log(minDepth + 1e-6), np.log(maxDepth + 1e-6)
         logDepth = np.clip(logDepth, logMin, logMax)
-        # Map from the FIXED depth range (not the per-frame min/max) so a given depth
-        # always maps to the same color -- otherwise the mapping shifts every frame and
-        # the image flickers.
         colored = np.interp(logDepth, (logMin, logMax), (0, 255))
         colored = colored.astype(np.uint8)
         colored = cv2.applyColorMap(colored, cv2.COLORMAP_JET)

--- a/examples/python/ToF/tof_pointcloud.py
+++ b/examples/python/ToF/tof_pointcloud.py
@@ -6,7 +6,7 @@ Open http://localhost:8082 in a browser after starting this script.
 
 import depthai as dai
 
-FPS = 10.0
+FPS = 30.0
 SIZE = (640, 400)
 
 with dai.Pipeline() as p:
@@ -18,7 +18,7 @@ with dai.Pipeline() as p:
         RGB_SOCKET = dai.CameraBoardSocket.CAM_A
 
     color = p.create(dai.node.Camera).build(RGB_SOCKET, sensorFps=FPS)
-    colorOut = color.requestOutput(SIZE, fps=FPS, type=dai.ImgFrame.Type.RGB888i, enableUndistortion =True)
+    colorOut = color.requestOutput(SIZE, fps=FPS, type=dai.ImgFrame.Type.RGB888i, enableUndistortion=True)
 
     tof = p.create(dai.node.ToF)
     tof.build(

--- a/examples/python/ToF/tof_pointcloud.py
+++ b/examples/python/ToF/tof_pointcloud.py
@@ -27,7 +27,6 @@ with dai.Pipeline() as p:
         fps=FPS
     )
 
-    # Align depth into colour frame so both inputs to PointCloud share the same dimensions
     align = p.create(dai.node.ImageAlign)
     align.setRunOnHost(True)
     tof.depth.link(align.input)


### PR DESCRIPTION
## Summary
- Fixes flickering depth colorization in the ToF examples by mapping colors from the fixed minDepth/maxDepth range instead of each frame's own min/max

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized depth-to-color visualization across frames by switching to a consistent, configured logarithmic depth window (min/max) instead of per-frame scaling.
  * Preserved invalid (zero) depth pixels as black in depth visualizations.
* **New Features**
  * Refreshed the ToF depth alignment/blending example with fixed log-depth mapping, command-line camera selection (left/right), separate aligned-vs-blended views, and a blend-weight trackbar.
  * Increased the default FPS to 30 across the updated ToF Python/C++ examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->