### PR TITLE
Fix/vcpkg update

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -155,7 +155,7 @@ jobs:
     - name: Install dependencies
       if: matrix.os == 'macos-latest'
       run: |
-        brew install opencv
+        brew install opencv@4
 
     - name: Install dependencies
       if: matrix.os == 'ubuntu-latest'
@@ -203,7 +203,7 @@ jobs:
     - name: Install dependencies
       if: matrix.os == 'macos-latest'
       run: |
-        brew install opencv
+        brew install opencv@4
 
     - name: Install dependencies
       if: matrix.os == 'ubuntu-latest'

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "a9eee3b18df395dbb8be71a31bd78ea441056e42",
+    "baseline": "6fa128f2b6e1dd260ebfb30fdb1c38a191369812",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -243,5 +243,5 @@
             ]
         }
     },
-    "builtin-baseline": "a9eee3b18df395dbb8be71a31bd78ea441056e42"
+    "builtin-baseline": "6fa128f2b6e1dd260ebfb30fdb1c38a191369812"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -243,5 +243,5 @@
             ]
         }
     },
-    "builtin-baseline": "d015e31e90838a4c9dfa3eed45979bc70d9357fc"
+    "builtin-baseline": "a9eee3b18df395dbb8be71a31bd78ea441056e42"
 }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Some of the jobs in the DepthAI Core and DepthAI Python CI/CDs were failing.

The issues were the following:
- Brew install defaulted to the OpenCV 5 after a June update
- Vcpkg which was specified and used in our repo, had some prebuilt dependencies removed

The update fixes this by:
- Specifying the use of OpenCV 4 in the brew install 
- Updating the vcpkg version to a newer still supported version, which doesn't break any dependencies

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Codex

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build and integration environments to use OpenCV 4.
  * Refreshed package registry baselines to keep dependency resolution aligned with updated package sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->