### PR TITLE
Fix yolov6r1 decoding

### DIFF
--- a/cmake/Depthai/DepthaiDeviceRVC4Config.cmake
+++ b/cmake/Depthai/DepthaiDeviceRVC4Config.cmake
@@ -3,4 +3,4 @@
 set(DEPTHAI_DEVICE_RVC4_MATURITY "snapshot")
 
 # "version if applicable"
-set(DEPTHAI_DEVICE_RVC4_VERSION "0.0.1+c0f6b6100c93f21e29c361cffad1f83bba0418ca")
+set(DEPTHAI_DEVICE_RVC4_VERSION "0.0.1+db33c6d3abb5a2d3dd35ed9452fa80dbb0f51cea")

--- a/include/depthai/common/YoloDecodingFamily.hpp
+++ b/include/depthai/common/YoloDecodingFamily.hpp
@@ -3,8 +3,8 @@
 #include <cstdint>
 
 enum class YoloDecodingFamily : std::int32_t {
-    TLBR,    // top left bottom right anchor free: yolo v6r2, v8 v10 v11
-    R1AF,    // anchor free: yolo v6r1
+    TLBR,    // top left bottom right anchor free: yolo v6r2, v8, v10, v11
+    R1AF,    // anchor free center/size: yolo v6, v6r1
     v5AB,    // anchor based yolo v5, v7, P
     v3AB,    // anchor based yolo v3 v3-Tiny
     YOLO26,  // already decoded TLBR model

--- a/src/pipeline/node/DetectionParser.cpp
+++ b/src/pipeline/node/DetectionParser.cpp
@@ -274,9 +274,9 @@ YoloDecodingFamily DetectionParser::yoloDecodingFamilyResolver(const std::string
     std::string subtypeStr = name;
     std::transform(subtypeStr.begin(), subtypeStr.end(), subtypeStr.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
 
-    if(subtypeStr == "yolov6r1") return YoloDecodingFamily::R1AF;
-    if(subtypeStr == "yolov6r2" || subtypeStr == "yolov8n" || subtypeStr == "yolov6" || subtypeStr == "yolov8" || subtypeStr == "yolov10"
-       || subtypeStr == "yolov11" || subtypeStr == "yolov12")
+    if(subtypeStr == "yolov6r1" || subtypeStr == "yolov6") return YoloDecodingFamily::R1AF;
+    if(subtypeStr == "yolov6r2" || subtypeStr == "yolov8n" || subtypeStr == "yolov8" || subtypeStr == "yolov10" || subtypeStr == "yolov11"
+       || subtypeStr == "yolov12")
         return YoloDecodingFamily::TLBR;
     if(subtypeStr == "yolov3" || subtypeStr == "yolov3-tiny") return YoloDecodingFamily::v3AB;
     if(subtypeStr == "yolov5" || subtypeStr == "yolov7" || subtypeStr == "yolo-p" || subtypeStr == "yolov5-u") return YoloDecodingFamily::v5AB;
@@ -670,7 +670,7 @@ void DetectionParser::decodeMobilenet(dai::NNData& nnData, dai::ImgDetections& o
 void DetectionParser::decodeYolo(dai::NNData& nnData, dai::ImgDetections& outDetections) {
     std::shared_ptr<spdlog::async_logger>& logger = ThreadedNode::pimpl->logger;
     switch(properties.parser.decodingFamily) {
-        case YoloDecodingFamily::R1AF:  // anchor free: yolo v6r1
+        case YoloDecodingFamily::R1AF:  // anchor free center/size: yolo v6, v6r1
             utilities::DetectionParserUtils::decodeR1AF(nnData, outDetections, properties, logger);
             break;
         case YoloDecodingFamily::v3AB:  // anchor based yolo v3 v3-Tiny
@@ -679,7 +679,7 @@ void DetectionParser::decodeYolo(dai::NNData& nnData, dai::ImgDetections& outDet
         case YoloDecodingFamily::v5AB:  // anchor based yolo v5, v7, P
             utilities::DetectionParserUtils::decodeV5AB(nnData, outDetections, properties, logger);
             break;
-        case YoloDecodingFamily::TLBR:  // top left bottom right anchor free: yolo v6r2, v8 v10 v11
+        case YoloDecodingFamily::TLBR:  // top left bottom right anchor free: yolo v6r2, v8, v10, v11
             utilities::DetectionParserUtils::decodeTLBR(nnData, outDetections, properties, logger);
             break;
         case YoloDecodingFamily::YOLO26:  // already decoded TLBR model

--- a/src/pipeline/utilities/DetectionParser/DetectionParserUtils.cpp
+++ b/src/pipeline/utilities/DetectionParser/DetectionParserUtils.cpp
@@ -37,7 +37,7 @@ namespace dai {
 namespace utilities {
 namespace DetectionParserUtils {
 
-// yolo v6 r1 - anchor free
+// YOLOv6 R1 predicts raw center/size values for each grid cell.
 void decodeR1AF(const dai::NNData& nnData,
                 dai::ImgDetections& outDetections,
                 DetectionParserProperties& properties,
@@ -65,6 +65,7 @@ void decodeR1AF(const dai::NNData& nnData,
 
     for(int strideIdx = 0; strideIdx < static_cast<int>(layerNames.size()); ++strideIdx) {
         std::string layerName = layerNames[strideIdx];
+        int stride = strides[strideIdx];
         auto tensorInfo = nnData.getTensorInfo(layerName);
 
         DAI_CHECK_V(tensorInfo, "Tensor info for layer {} is null.", layerName);
@@ -95,14 +96,14 @@ void decodeR1AF(const dai::NNData& nnData,
                         bestC = c;
                     }
                 }
-                if(bestConf * objectnessScore < confidenceThr) {
+                if(bestConf < confidenceThr) {
                     continue;
                 }
 
-                float cx = outputData.get(0, row, col);
-                float cy = outputData.get(1, row, col);
-                float w = outputData.get(2, row, col);
-                float h = outputData.get(3, row, col);
+                float cx = (static_cast<float>(col) + outputData.get(0, row, col)) * static_cast<float>(stride);
+                float cy = (static_cast<float>(row) + outputData.get(1, row, col)) * static_cast<float>(stride);
+                float w = std::exp(outputData.get(2, row, col)) * static_cast<float>(stride);
+                float h = std::exp(outputData.get(3, row, col)) * static_cast<float>(stride);
 
                 float xmin = cx - w * 0.5f;
                 float ymin = cy - h * 0.5f;
@@ -130,7 +131,7 @@ void decodeR1AF(const dai::NNData& nnData,
                         ymax);
                     continue;
                 }
-                DetectionCandidate candidate = DetectionCandidate{xmin, ymin, xmax, ymax, bestConf * objectnessScore, bestC, strideIdx, row, col, std::nullopt};
+                DetectionCandidate candidate = DetectionCandidate{xmin, ymin, xmax, ymax, bestConf, bestC, strideIdx, row, col, std::nullopt};
 
                 detectionCandidates.emplace_back(std::move(candidate));
             }

--- a/src/pipeline/utilities/DetectionParser/DetectionParserUtils.hpp
+++ b/src/pipeline/utilities/DetectionParser/DetectionParserUtils.hpp
@@ -19,7 +19,7 @@ struct DetectionCandidate {
     std::optional<std::string> labelName;
 };
 /**
-Decode anchor free yolo v6r1 with sigmoid assisted center detection
+Decode YOLOv6 R1 raw center/size predictions.
 */
 void decodeR1AF(const dai::NNData& nnData,
                 dai::ImgDetections& outDetections,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- This PR fixes the wrong yolov6r1 decoding
- Aligns yolov6 decoding with that of the RVC2 FW - by using yolov6r1

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested using RVC2 & RVC4 devices running affected models

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME: Codex

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YOLOv6 detection decoding for more accurate confidence scoring and bounding-box calculations.
  * Correctly categorizes YOLOv6 models using the appropriate decoding format.

* **Updates**
  * Updated the supported device version.
  * Clarified documentation for YOLO decoding formats and supported model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->