### PR TITLE
Fix: TelemetrySharedState installs a fresh state for child processes

### DIFF
--- a/src/utility/Telemetry.cpp
+++ b/src/utility/Telemetry.cpp
@@ -25,6 +25,12 @@
 #include <thread>
 #include <vector>
 
+#ifdef _WIN32
+    #include <process.h>
+#else
+    #include <unistd.h>
+#endif
+
 #include "build/version.hpp"
 #include "depthai/device/DeviceBase.hpp"
 #include "depthai/pipeline/Pipeline.hpp"
@@ -59,6 +65,14 @@ constexpr auto TMP_ID_TTL = std::chrono::hours(24);
 constexpr std::int64_t RATE_LIMIT_MAX_EVENTS = 30000;
 
 std::atomic_bool telemetryUsesPython{false};
+
+std::uint64_t currentProcessId() {
+#ifdef _WIN32
+    return static_cast<std::uint64_t>(_getpid());
+#else
+    return static_cast<std::uint64_t>(getpid());
+#endif
+}
 
 std::string readEnv(const char* name) {
     const char* value = std::getenv(name);
@@ -463,9 +477,45 @@ struct TelemetrySharedState {
     void applyAggregateMetrics(nlohmann::json& properties);
 };
 
+struct ProcessTelemetryState {
+    explicit ProcessTelemetryState(std::uint64_t processId) : processId(processId) {}
+
+    std::uint64_t processId;
+    TelemetrySharedState telemetry;
+};
+
+struct TelemetryStateHolder {
+    TelemetryStateHolder() : current(new ProcessTelemetryState(currentProcessId())) {}
+
+    ~TelemetryStateHolder() {
+        auto* state = current.load();
+        if(state != nullptr && state->processId == currentProcessId()) {
+            delete state;
+        }
+    }
+
+    std::atomic<ProcessTelemetryState*> current;
+};
+
 TelemetrySharedState& telemetrySharedState() {
-    static TelemetrySharedState state;
-    return state;
+    static TelemetryStateHolder holder;
+    const auto processId = currentProcessId();
+
+    while(true) {
+        auto* state = holder.current.load(std::memory_order_acquire);
+        if(state->processId == processId) {
+            return state->telemetry;
+        }
+
+        // fork() copies the parent telemetry state but not its worker threads.
+        // Leave that inherited state untouched and install a fresh state for
+        // the child process on its first telemetry call.
+        auto* childState = new ProcessTelemetryState(processId);
+        if(holder.current.compare_exchange_strong(state, childState, std::memory_order_acq_rel, std::memory_order_acquire)) {
+            return childState->telemetry;
+        }
+        delete childState;
+    }
 }
 
 class Telemetry::Impl {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -490,6 +490,10 @@ dai_set_test_labels(platform_test onhost ci)
 target_compile_definitions(platform_test PRIVATE FSLOCK_DUMMY_PATH="$<TARGET_FILE:fslock_dummy>")
 add_dependencies(platform_test fslock_dummy)
 
+# Telemetry fork safety test
+dai_add_test(telemetry_fork_test src/onhost_tests/utility/telemetry_fork_test.cpp)
+dai_set_test_labels(telemetry_fork_test onhost ci nowindows)
+
 # Circular buffer test
 dai_add_test(circular_buffer_test src/onhost_tests/utility/circular_buffer_test.cpp)
 dai_set_test_labels(circular_buffer_test onhost ci)

--- a/tests/src/onhost_tests/utility/telemetry_fork_test.cpp
+++ b/tests/src/onhost_tests/utility/telemetry_fork_test.cpp
@@ -1,0 +1,64 @@
+#include <catch2/catch_all.hpp>
+
+#if defined(__unix__) || defined(__APPLE__)
+    #include <sys/wait.h>
+    #include <unistd.h>
+
+    #include <chrono>
+    #include <csignal>
+    #include <cstdlib>
+    #include <filesystem>
+    #include <thread>
+
+    #include "depthai/depthai.hpp"
+    #include "utility/Platform.hpp"
+#endif
+
+TEST_CASE("telemetry remains usable in a fork child") {
+#if defined(__unix__) || defined(__APPLE__)
+    const auto cacheDir = dai::platform::getTempPath();
+    REQUIRE(::setenv("DEPTHAI_CACHE_DIR", cacheDir.c_str(), 1) == 0);
+    REQUIRE(::setenv("DEPTHAI_TELEMETRY_URL", "http://127.0.0.1:1", 1) == 0);
+    REQUIRE(::setenv("DEPTHAI_TELEMETRY_API_KEY", "telemetry-fork-test", 1) == 0);
+
+    REQUIRE(dai::initialize());
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    const auto childPid = ::fork();
+    REQUIRE(childPid >= 0);
+
+    if(childPid == 0) {
+        dai::Pipeline pipeline(false);
+        pipeline.start();
+        pipeline.stop();
+        ::_exit(EXIT_SUCCESS);
+    }
+
+    int status = 0;
+    bool childExited = false;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while(std::chrono::steady_clock::now() < deadline) {
+        const auto waitResult = ::waitpid(childPid, &status, WNOHANG);
+        if(waitResult == childPid) {
+            childExited = true;
+            break;
+        }
+        REQUIRE(waitResult >= 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    if(!childExited) {
+        REQUIRE(::kill(childPid, SIGKILL) == 0);
+        REQUIRE(::waitpid(childPid, &status, 0) == childPid);
+    }
+
+    std::error_code ec;
+    std::filesystem::remove_all(cacheDir, ec);
+
+    REQUIRE(childExited);
+    REQUIRE(WIFEXITED(status));
+    REQUIRE(WEXITSTATUS(status) == EXIT_SUCCESS);
+#else
+    SKIP("fork is only available on POSIX platforms");
+#endif
+}


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fix a deadlock in pipeline.start() after fork(). The child inherited telemetry shared state from the parent but not the worker threads. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry reliability when applications create child processes, ensuring forked processes receive independent telemetry state.
  * Prevented telemetry-related issues from affecting pipeline startup and shutdown in forked child processes.

* **Tests**
  * Added coverage verifying that pipelines remain usable after a process forks on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->