### PR TITLE
Fix MSVC deprecation error in DeviceNodeCRTP

### DIFF
--- a/include/depthai/pipeline/DeviceNode.hpp
+++ b/include/depthai/pipeline/DeviceNode.hpp
@@ -5,6 +5,7 @@
 #include "depthai/device/Device.hpp"
 #include "depthai/pipeline/Node.hpp"
 #include "depthai/pipeline/ThreadedNode.hpp"
+#include "depthai/utility/CompilerWarnings.hpp"
 
 namespace dai {
 
@@ -63,9 +64,11 @@ class DeviceNodeCRTP : public Base {
     virtual ~DeviceNodeCRTP() = default;
     /// Underlying properties
     Properties& properties;
+    DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
     const char* getName() const override {
         return Derived::NAME;
     };
+    DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
 
     bool isBuiltInNode() const override {
         return BuiltInNode;


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fix an MSVC compilation error triggered when including DepthAI headers in a custom project. The error is caused when MSVC instantiates DeviceNodeCRTP::getName() for deprecated MonoCamera and ColorCamera nodes. This happens even when application code uses the replacement Camera node.

Linked to:
https://github.com/luxonis/depthai-core/issues/1910

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Suppress deprecation warnings only around the internal Derived::NAME access in DeviceNodeCRTP::getName(). User code that directly uses deprecated nodes will continue to receive deprecation warnings.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Codex

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility with compiler deprecation warnings without changing user-facing behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->