### PR TITLE
Fix: ImageCorner indexes in ImageManip

### DIFF
--- a/include/depthai/utility/ImageManipImpl.hpp
+++ b/include/depthai/utility/ImageManipImpl.hpp
@@ -701,7 +701,7 @@ std::tuple<std::array<std::array<float, 3>, 3>, std::array<std::array<float, 2>,
         auto [minx, maxx, miny, maxy] = getOuterRect(std::vector(imageCorners.begin(), imageCorners.end()));
         auto mat = getResizeMat(res, maxx - minx, maxy - miny, base.outputWidth, base.outputHeight);
         imageCorners = {
-            {{matvecmul(mat, imageCorners[0])}, {matvecmul(mat, imageCorners[1])}, {matvecmul(mat, imageCorners[2])}, {matvecmul(mat, imageCorners[2])}}};
+            {{matvecmul(mat, imageCorners[0])}, {matvecmul(mat, imageCorners[1])}, {matvecmul(mat, imageCorners[2])}, {matvecmul(mat, imageCorners[3])}}};
         matrix = matmul(mat, matrix);
         outputOps.emplace_back(res);
     }

--- a/tests/src/ondevice_tests/pipeline/node/image_manip_test.cpp
+++ b/tests/src/ondevice_tests/pipeline/node/image_manip_test.cpp
@@ -573,6 +573,50 @@ TEST_CASE("ImageManip four point transform normalized coordinates") {
     testManipFourPointTransform(true);
 }
 
+TEST_CASE("ImageManip crop and four point transform with stretch") {
+    constexpr int inputWidth = 400;
+    constexpr int inputHeight = 300;
+    constexpr int outputWidth = 45;
+    constexpr int outputHeight = 36;
+
+    auto inputFrame = std::make_shared<dai::ImgFrame>();
+    inputFrame->setCvFrame(createFourPointTransformInputImage(inputWidth, inputHeight), dai::ImgFrame::Type::GRAY8);
+
+    dai::Pipeline p;
+    auto manip = p.create<dai::node::ImageManip>();
+    manip->inputConfig.setWaitForMessage(true);
+    manip->setMaxOutputFrameSize(inputWidth * inputHeight);
+
+    auto inputQueue = manip->inputImage.createInputQueue();
+    auto configQueue = manip->inputConfig.createInputQueue();
+    auto outputQueue = manip->out.createOutputQueue();
+
+    p.start();
+
+    auto cfg = std::make_shared<dai::ImageManipConfig>();
+    cfg->addCropRotatedRect(
+        dai::RotatedRect(dai::Point2f(0.45f, 0.04f, true), dai::Size2f(0.12f, 0.12f, true), 0.0f),
+        true);
+    cfg->addTransformFourPoints({dai::Point2f(0.44f, 0.83f),
+                                 dai::Point2f(0.15f, 0.36f),
+                                 dai::Point2f(0.54f, 0.17f),
+                                 dai::Point2f(0.82f, 0.42f)},
+                                {dai::Point2f(0.0f, 0.0f), dai::Point2f(1.0f, 0.0f), dai::Point2f(1.0f, 1.0f), dai::Point2f(0.0f, 1.0f)},
+                                true);
+    cfg->setOutputSize(outputWidth, outputHeight, dai::ImageManipConfig::ResizeMode::STRETCH);
+    cfg->setFrameType(dai::ImgFrame::Type::GRAY8);
+
+    configQueue->send(cfg);
+    inputQueue->send(inputFrame);
+
+    bool timedOut = false;
+    auto outFrame = outputQueue->get<dai::ImgFrame>(std::chrono::seconds(5), timedOut);
+    REQUIRE_FALSE(timedOut);
+    REQUIRE(outFrame != nullptr);
+    REQUIRE(outFrame->getWidth() == outputWidth);
+    REQUIRE(outFrame->getHeight() == outputHeight);
+}
+
 TEST_CASE("ImageManip GRAY8") {
     runManipTests(dai::ImgFrame::Type::GRAY8, false);
 }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed four-point image transformations so the fourth corner is handled correctly.
  * Improved accuracy for rotated-rectangle cropping and transformed image output.

* **Tests**
  * Added coverage for normalized rotated cropping, four-point transformations, and stretched output resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->