### PR TITLE
Fix user bootloader support check

### DIFF
--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -703,8 +703,7 @@ bool DeviceBootloader::isUserBootloaderSupported() {
 }
 
 bool DeviceBootloader::isUserBootloader() {
-    // Check if bootloader version is adequate
-    if(getVersion() < Version(Request::IsUserBootloader::VERSION)) {
+    if(!isUserBootloaderSupported()) {
         return false;
     }
 


### PR DESCRIPTION
## Summary
- reuse `isUserBootloaderSupported()` before sending the user-bootloader query
- preserve the bootloader-version guard while also enforcing the NETWORK-only requirement
- avoid sending an unsupported request to USB bootloaders with a sufficiently new version

## Validation
- configured and built `depthai-core` successfully on macOS with optional OpenCV, dynamic calibration, events manager, and MP4 support disabled
- verified `src/device/DeviceBootloader.cpp` compiles and the final `libdepthai-core.a` links
- `clang-format --dry-run --Werror src/device/DeviceBootloader.cpp`
- `git diff --check`

Hardware validation was not run because an OAK device is not available locally.

Closes #1102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootloader capability checks to ensure requests are sent only when the bootloader type and version are supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->