### PR TITLE
enforced transform validation in stereo_depth_remap.cppand reduced lo…

### DIFF
--- a/examples/cpp/Camera/camera_multiple_outputs.cpp
+++ b/examples/cpp/Camera/camera_multiple_outputs.cpp
@@ -121,9 +121,10 @@ int main(int argc, char* argv[]) {
             auto videoIn = queues[i]->tryGet<dai::ImgFrame>();
             if(videoIn != nullptr) {
                 fpsCounters[i].tick();
-                std::cout << "frame " << videoIn->getWidth() << "x" << videoIn->getHeight() << " | " << videoIn->getSequenceNum()
-                          << ": exposure=" << videoIn->getExposureTime().count()
-                          << "us, timestamp: " << videoIn->getTimestampDevice().time_since_epoch().count() << std::endl;
+                if (!(videoIn->getSequenceNum() % 60))
+                    std::cout << "frame " << videoIn->getWidth() << "x" << videoIn->getHeight() << " | " << videoIn->getSequenceNum()
+                            << ": exposure=" << videoIn->getExposureTime().count()
+                            << "us, timestamp: " << videoIn->getTimestampDevice().time_since_epoch().count() << std::endl;
 
                 cv::Mat cvFrame = videoIn->getCvFrame();
 

--- a/examples/cpp/StereoDepth/stereo_depth_remap.cpp
+++ b/examples/cpp/StereoDepth/stereo_depth_remap.cpp
@@ -123,6 +123,7 @@ int main() {
         // Validate transformations
         if(!colorFrame->validateTransformations() || !stereoFrame->validateTransformations()) {
             std::cerr << "Invalid transformations!" << std::endl;
+            throw std::runtime_error("Invalid transformations!");
             continue;
         }
 

--- a/examples/python/Camera/camera_multiple_outputs.py
+++ b/examples/python/Camera/camera_multiple_outputs.py
@@ -79,9 +79,10 @@ with dai.Pipeline() as pipeline:
             if videoIn is not None:
                 FPSCounters[index].tick()
                 assert isinstance(videoIn, dai.ImgFrame)
-                print(
-                    f"frame {videoIn.getWidth()}x{videoIn.getHeight()} | {videoIn.getSequenceNum()}: exposure={videoIn.getExposureTime()}us, timestamp: {videoIn.getTimestampDevice()}"
-                )
+                if (videoIn.getSequenceNum() % 60) == 0:
+                    print(
+                        f"frame {videoIn.getWidth()}x{videoIn.getHeight()} | {videoIn.getSequenceNum()}: exposure={videoIn.getExposureTime()}us, timestamp: {videoIn.getTimestampDevice()}"
+                    )
                 # Get BGR frame from NV12 encoded video frame to show with opencv
                 # Visualizing the frame on slower hosts might have overhead
                 cvFrame = videoIn.getCvFrame()


### PR DESCRIPTION
## Purpose
stereo_depth_remap.cpp now throws if an imgFrame fails validateTransformations
camera_multiple_outputs.py now only logs every 60 frames instead of every frame

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: Probably


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid frame transformations now stop processing with a clear runtime error instead of continuing silently.
  * Reduced camera metadata log frequency to improve console readability and runtime performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->