### PR TITLE
Added LUXONIS_TELEMETRY_CORRELATION_ID env variable support

### DIFF
--- a/src/utility/Telemetry.cpp
+++ b/src/utility/Telemetry.cpp
@@ -610,6 +610,7 @@ void TelemetrySharedState::init() {
                   {"host_os_version", getTelemetryHostOSVersion()},
                   {"is_oak_app", !readEnv("OAKAGENT_PRIVATE_HTTP_PWD").empty()},
                   {"uses_python", telemetryUsesPython.load()},
+                  {"correlation_id", readEnv("LUXONIS_TELEMETRY_CORRELATION_ID")},
               });
     }
 }

--- a/tests/src/ondevice_tests/telemetry_multi_device_test.cpp
+++ b/tests/src/ondevice_tests/telemetry_multi_device_test.cpp
@@ -307,6 +307,9 @@ void validateRequests(const std::vector<ReceivedRequest>& requests) {
     REQUIRE_FALSE(depthaiLoadProperties.value("host_os_version", std::string{}).empty());
     REQUIRE(depthaiLoadProperties.value("is_oak_app", false));
     REQUIRE_FALSE(depthaiLoadProperties.value("uses_python", true));
+    // correlation_id is always attached to depthai_load, empty when LUXONIS_TELEMETRY_CORRELATION_ID is not set
+    REQUIRE(depthaiLoadProperties.contains("correlation_id"));
+    REQUIRE(depthaiLoadProperties["correlation_id"].is_string());
 
     const auto deviceConstructorRequests = getEventRequests(requests, "depthai_device_constructor");
     CAPTURE(deviceConstructorRequests.size());

--- a/tests/src/ondevice_tests/telemetry_test.cpp
+++ b/tests/src/ondevice_tests/telemetry_test.cpp
@@ -25,6 +25,7 @@ namespace {
 constexpr int kPort = 8955;
 constexpr char kTelemetryUrl[] = "http://localhost:8955";
 constexpr char kTelemetryApiKey[] = "phc_depthai_telemetry_test";
+constexpr char kTelemetryCorrelationId[] = "depthai-telemetry-test-correlation-id";
 constexpr auto kRequestTimeout = std::chrono::seconds(20);
 
 using Json = nlohmann::json;
@@ -151,6 +152,7 @@ subprocess::env_map_t makeChildEnv(const std::filesystem::path& tempHome) {
         {makeEnvString("DEPTHAI_TELEMETRY_URL"), makeEnvString(kTelemetryUrl)},
         {makeEnvString("DEPTHAI_TELEMETRY_API_KEY"), makeEnvString(kTelemetryApiKey)},
         {makeEnvString("OAKAGENT_PRIVATE_HTTP_PWD"), makeEnvString("telemetry-test")},
+        {makeEnvString("LUXONIS_TELEMETRY_CORRELATION_ID"), makeEnvString(kTelemetryCorrelationId)},
         {makeEnvString("HOME"), makeEnvString(tempHome.string())},
     };
 }
@@ -390,6 +392,9 @@ void validateRequests(const std::vector<ReceivedRequest>& requests) {
     REQUIRE_FALSE(depthaiLoadProperties.value("host_os_version", std::string{}).empty());
     REQUIRE(depthaiLoadProperties.value("is_oak_app", false));
     REQUIRE_FALSE(depthaiLoadProperties.value("uses_python", true));
+    REQUIRE(depthaiLoadProperties.contains("correlation_id"));
+    REQUIRE(depthaiLoadProperties["correlation_id"].is_string());
+    REQUIRE(depthaiLoadProperties["correlation_id"].get<std::string>() == kTelemetryCorrelationId);
     const auto deviceConstructorProperties = deviceConstructor.body["properties"];
     REQUIRE_FALSE(deviceConstructorProperties.value("$session_id", std::string{}).empty());
     REQUIRE(deviceConstructorProperties.find("session_id") == deviceConstructorProperties.end());


### PR DESCRIPTION
## Purpose
cross product telemetry

## Testing & Validation
wasn't yet end2end tested

## AI Usage
Assisted-by: claude code fable 5 max

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a correlation ID to `depthai_load` telemetry events when provided by the runtime environment.
  * Telemetry events now consistently include a correlation ID field, which may be empty when no ID is configured.

* **Tests**
  * Added validation for correlation ID propagation across single- and multi-device telemetry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->