### PR TITLE
Bugfix/detection parser test stability

### DIFF
--- a/src/opencv/RecordReplay.cpp
+++ b/src/opencv/RecordReplay.cpp
@@ -256,8 +256,9 @@ void VideoPlayer::init(const std::string& filePath) {
         throw std::runtime_error("VideoPlayer file does not exist: " + filePath);
     }
     cvReader = std::make_unique<cv::VideoCapture>();
-    cvReader->open(filePath, cv::CAP_FFMPEG);
-    assert(cvReader->isOpened());
+    if(!cvReader->open(filePath, cv::CAP_FFMPEG) || !cvReader->isOpened()) {
+        throw std::runtime_error("Failed to open video with FFMPEG: " + filePath);
+    }
     initialized = true;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,6 +234,20 @@ if(DEPTHAI_FETCH_ARTIFACTS)
     )
 
     private_data(
+        URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/misc/parser_testing/images/detection_parser/yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_nn_data.bin"
+        SHA1 "298b0b69a22cc1fbd89ec95e9de5f2865a6c3f77"
+        FILE "yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_nn_data.bin"
+        LOCATION yolo_v8_instance_segmentation_large_coco_640x352_kitchen_segmentation_nn_data
+    )
+
+    private_data(
+        URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/misc/parser_testing/images/detection_parser/yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_nn_metadata.bin"
+        SHA1 "ebb04c34eaae80e5009c8fb2f4b78d09d64314d5"
+        FILE "yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_nn_metadata.bin"
+        LOCATION yolo_v8_instance_segmentation_large_coco_640x352_kitchen_segmentation_nn_metadata
+    )
+
+    private_data(
         URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/misc/parser_testing/ground_truth_files/detection_parser/yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_mask_v2.png"
         SHA1 "cf947acf1c210efba34c363fe6d8fd8d02293601"
         FILE "yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_mask_v2.png"
@@ -762,6 +776,8 @@ if(DEPTHAI_FETCH_ARTIFACTS)
         FIRE_VIDEO="${fire_video}"
         KITCHEN_IMAGE_PATH="${kitchen_image}"
         YOLO_V8_INSTANCE_SEGMENTATION_LARGE_COCO_640x352_KITCHEN_SEGMENTATION_GROUND_TRUTH="${yolo_v8_instance_segmentation_large_coco_640x352_kitchen_segmentation_gt_v2}"
+        YOLO_V8_INSTANCE_SEGMENTATION_LARGE_COCO_640x352_KITCHEN_SEGMENTATION_NN_DATA="${yolo_v8_instance_segmentation_large_coco_640x352_kitchen_segmentation_nn_data}"
+        YOLO_V8_INSTANCE_SEGMENTATION_LARGE_COCO_640x352_KITCHEN_SEGMENTATION_NN_METADATA="${yolo_v8_instance_segmentation_large_coco_640x352_kitchen_segmentation_nn_metadata}"
     )
     dai_set_test_labels(detection_parser_test ondevice rvc4 ci)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,14 +234,14 @@ if(DEPTHAI_FETCH_ARTIFACTS)
     )
 
     private_data(
-        URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/misc/parser_testing/images/detection_parser/yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_nn_data.bin"
+        URL "https://artifacts.luxonis.com/api/v1/repositories/luxonis-depthai-data-local/download/misc/parser_testing/images/detection_parser/yolov8-instance-segmentation-large_coco-640x352_701031f/nnData.bin"
         SHA1 "298b0b69a22cc1fbd89ec95e9de5f2865a6c3f77"
         FILE "yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_nn_data.bin"
         LOCATION yolo_v8_instance_segmentation_large_coco_640x352_kitchen_segmentation_nn_data
     )
 
     private_data(
-        URL "https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/misc/parser_testing/images/detection_parser/yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_nn_metadata.bin"
+        URL "https://artifacts.luxonis.com/api/v1/repositories/luxonis-depthai-data-local/download/misc/parser_testing/images/detection_parser/yolov8-instance-segmentation-large_coco-640x352_701031f/metadata.bin"
         SHA1 "ebb04c34eaae80e5009c8fb2f4b78d09d64314d5"
         FILE "yolov8-instance-segmentation-large_coco-640x352_701031f-segmentation_nn_metadata.bin"
         LOCATION yolo_v8_instance_segmentation_large_coco_640x352_kitchen_segmentation_nn_metadata

--- a/tests/src/ondevice_tests/pipeline/node/detection_parser_test.cpp
+++ b/tests/src/ondevice_tests/pipeline/node/detection_parser_test.cpp
@@ -566,15 +566,10 @@ TEST_CASE("DetectionParser YOLO26 smoke test") {
 #ifdef DEPTHAI_HAVE_OPENCV_SUPPORT
 TEST_CASE("DetectionParser segmentation mask test") {
     const std::string modelName = "yolov8-instance-segmentation-large:coco-640x352:701031f";
-
-    const std::filesystem::path kitchenImagePath{KITCHEN_IMAGE_PATH};
     const std::string segmentationGroundTruth = YOLO_V8_INSTANCE_SEGMENTATION_LARGE_COCO_640x352_KITCHEN_SEGMENTATION_GROUND_TRUTH;
 
     cv::Mat kitchenGtSegmentation = cv::imread(segmentationGroundTruth, cv::IMREAD_GRAYSCALE);
     REQUIRE_FALSE(kitchenGtSegmentation.empty());
-
-    cv::Mat kitchenImage = cv::imread(kitchenImagePath.string(), cv::IMREAD_COLOR);
-    REQUIRE_FALSE(kitchenImage.empty());
 
     dai::Pipeline p;
     auto device = p.getDefaultDevice();
@@ -586,28 +581,30 @@ TEST_CASE("DetectionParser segmentation mask test") {
     const auto inputSize = nnArchive.getInputSize();
     REQUIRE(inputSize.has_value());
 
-    const cv::Size networkSize{static_cast<int>(inputSize->first), static_cast<int>(inputSize->second)};
-    cv::resize(kitchenImage, kitchenImage, networkSize, 0.0, 0.0, cv::INTER_AREA);
+    auto detectionParser = p.create<dai::node::DetectionParser>();
+    detectionParser->setNNArchive(nnArchive);
 
-    auto nn = p.create<dai::node::NeuralNetwork>();
-    nn->setModelPath(archivePath);
-
-    auto detectionParser = p.create<dai::node::DetectionParser>()->build(nn->out, nnArchive);
-
-    auto nnInput = nn->input.createInputQueue();
+    auto inputQueue = detectionParser->input.createInputQueue();
     auto outputQueue = detectionParser->out.createOutputQueue();
-
-    auto inputFrame = std::make_shared<dai::ImgFrame>();
-    auto transformation = dai::ImgTransformation{inputSize->first, inputSize->second};
-    inputFrame->setCvFrame(kitchenImage, dai::ImgFrame::Type::BGR888i);
-    inputFrame->setTimestamp(std::chrono::steady_clock::now());
-    inputFrame->setSequenceNum(0);
-    inputFrame->transformation = transformation;
 
     p.start();
     REQUIRE(p.isRunning());
 
-    nnInput->send(inputFrame);
+    auto nnData = std::make_shared<dai::NNData>();
+    std::ifstream nnMetadataFile(YOLO_V8_INSTANCE_SEGMENTATION_LARGE_COCO_640x352_KITCHEN_SEGMENTATION_NN_METADATA, std::ios::binary);
+    const auto nnMetadata = std::vector<uint8_t>(
+        std::istreambuf_iterator<char>(nnMetadataFile),
+        std::istreambuf_iterator<char>());
+    REQUIRE(dai::utility::deserialize(nnMetadata, *nnData));
+    std::ifstream nnPayloadFile(YOLO_V8_INSTANCE_SEGMENTATION_LARGE_COCO_640x352_KITCHEN_SEGMENTATION_NN_DATA, std::ios::binary);
+    const auto nnDataPayload = std::vector<uint8_t>(
+        std::istreambuf_iterator<char>(nnPayloadFile),
+        std::istreambuf_iterator<char>());
+    REQUIRE(nnMetadata.size());
+    REQUIRE(nnDataPayload.size());
+    nnData->setData(nnDataPayload);
+
+    inputQueue->send(nnData);
 
     auto detections = outputQueue->get<dai::ImgDetections>();
     REQUIRE(detections != nullptr);


### PR DESCRIPTION
## Purpose
detection_parser_test.cpp would behave differently depending on enviroment image/video codecs.

## Specification
Forced the VideoPlayer (inside replay node) to throw when it can't open a video. Otherwise replay node would simply block forever.
Switched detection_parser_test/"DetectionParser segmentation mask test" to using neural network data instead of an image as test data.

## Dependencies & Potential Impact
Added 2 DEPTHAI_FETCH_ARTIFACTS to tests/CMakeLists which stops them from configuring successfully

## Deployment Plan
Need to upload fetch ertefacts before merging

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video playback startup errors by providing a clear message when a video cannot be opened.

* **Tests**
  * Updated segmentation validation to use representative neural-network data and metadata directly.
  * Improved test reliability by removing unnecessary image loading and preprocessing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->