### PR TITLE
check only yolo output count when checking number of strides

### DIFF
--- a/bindings/python/src/beta/node/ClassificationSequenceParserBindings.cpp
+++ b/bindings/python/src/beta/node/ClassificationSequenceParserBindings.cpp
@@ -25,7 +25,8 @@ void bind_beta_classificationsequenceparser(pybind11::module& m, void* pCallstac
         .def_readwrite("nClasses", &beta::ClassificationSequenceParserProperties::nClasses)
         .def_readwrite("isSoftmax", &beta::ClassificationSequenceParserProperties::isSoftmax);
 
-    classificationSequenceParser.def_readonly("inputConfig", &ClassificationSequenceParser::inputConfig, DOC(dai, beta, node, ClassificationSequenceParser, inputConfig))
+    classificationSequenceParser
+        .def_readonly("inputConfig", &ClassificationSequenceParser::inputConfig, DOC(dai, beta, node, ClassificationSequenceParser, inputConfig))
         .def_readonly("initialConfig", &ClassificationSequenceParser::initialConfig, DOC(dai, beta, node, ClassificationSequenceParser, initialConfig))
         .def_readonly("input", &ClassificationSequenceParser::input, DOC(dai, beta, node, ClassificationSequenceParser, input))
         .def_readonly("out", &ClassificationSequenceParser::out, DOC(dai, beta, node, ClassificationSequenceParser, out))

--- a/src/pipeline/node/DetectionParser.cpp
+++ b/src/pipeline/node/DetectionParser.cpp
@@ -149,7 +149,12 @@ void DetectionParser::configureYOLONetworkParser(DetectionParserOptions& parser,
         parser.strides = {1};
     }
     if(metadata.strides) {
-        const size_t numYoloOutputs = metadata.yoloOutputs ? metadata.yoloOutputs->size() : (head.outputs ? head.outputs->size() : 0);
+        size_t numYoloOutputs = 0;
+        if(metadata.yoloOutputs) numYoloOutputs = metadata.yoloOutputs->size();
+        else if(head.outputs.has_value()) {
+            for (const auto& name : *head.outputs)
+                if(name.find("_yolo") != std::string::npos) numYoloOutputs++;
+        }
         DAI_CHECK_V(!metadata.strides->empty(), "`strides` must not be empty.");
         DAI_CHECK_V(numYoloOutputs > 0, "YOLO outputs must be defined when `strides` is provided.");
         DAI_CHECK_V(metadata.strides->size() == numYoloOutputs,

--- a/src/pipeline/node/DetectionParser.cpp
+++ b/src/pipeline/node/DetectionParser.cpp
@@ -150,9 +150,10 @@ void DetectionParser::configureYOLONetworkParser(DetectionParserOptions& parser,
     }
     if(metadata.strides) {
         size_t numYoloOutputs = 0;
-        if(metadata.yoloOutputs) numYoloOutputs = metadata.yoloOutputs->size();
+        if(metadata.yoloOutputs)
+            numYoloOutputs = metadata.yoloOutputs->size();
         else if(head.outputs.has_value()) {
-            for (const auto& name : *head.outputs)
+            for(const auto& name : *head.outputs)
                 if(name.find("_yolo") != std::string::npos) numYoloOutputs++;
         }
         DAI_CHECK_V(!metadata.strides->empty(), "`strides` must not be empty.");


### PR DESCRIPTION
## Purpose
There was an incorrect check that would look for all outputs instead of just yolo outputs when checking amount of strides

## Specification
Made it only look at yolo outputs

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YOLO output detection by counting only outputs explicitly identified as YOLO results.
  * Corrected stride validation and configuration when archives contain unrelated outputs.
  * Fixed Python access to the classification sequence parser’s input configuration, preserving its documented read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->