### PR TITLE
Validate camera intrinsics consistently

### DIFF
--- a/include/depthai/utility/matrixOps.hpp
+++ b/include/depthai/utility/matrixOps.hpp
@@ -47,6 +47,7 @@ std::vector<float> matrix3x3ToVector(const std::array<std::array<float, 3>, 3>& 
 std::vector<float> rotationMatrixToVector(const std::vector<std::vector<float>>& R);
 std::vector<std::vector<float>> matrix3x3ToVectorMatrix(const std::array<std::array<float, 3>, 3>& R);
 std::array<std::array<float, 3>, 3> vectorMatrixToMatrix3x3(const std::vector<std::vector<float>>& R);
+bool isValidIntrinsicsMatrix(const std::vector<std::vector<float>>& intrinsics);
 void validateRotationMatrix3x3(const std::vector<std::vector<float>>& rotationMatrix);
 std::vector<std::vector<float>> extractRotationMatrix(const std::vector<std::vector<float>>& transform);
 std::vector<float> extractTranslationVector(const std::vector<std::vector<float>>& transform);

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -32,19 +32,8 @@ namespace {
 constexpr size_t kImuCalibrationRowCount = 3;
 constexpr size_t kImuCalibrationColumnCount = 4;
 
-bool isValidIntrinsicsMatrix(const std::vector<std::vector<float>>& intrinsics) {
-    if(intrinsics.size() != 3 || intrinsics[0].size() != 3 || intrinsics[1].size() != 3 || intrinsics[2].size() != 3) {
-        return false;
-    }
-
-    for(const auto& row : intrinsics) {
-        if(!std::all_of(row.begin(), row.end(), [](float value) { return std::isfinite(value); })) {
-            return false;
-        }
-    }
-
-    return intrinsics[0][0] > 0.0f && intrinsics[1][1] > 0.0f && intrinsics[1][0] == 0.0f && intrinsics[2][0] == 0.0f && intrinsics[2][1] == 0.0f
-           && intrinsics[2][2] == 1.0f;
+bool isValidCalibrationDimension(float dimension) {
+    return std::isfinite(dimension) && dimension > 0.0f && dimension <= std::numeric_limits<uint16_t>::max() && std::trunc(dimension) == dimension;
 }
 
 std::optional<std::array<float, 3>> lookupHousingEntry(const std::string& productName, HousingCoordinateSystem housingCs) {
@@ -1053,7 +1042,7 @@ void CalibrationHandler::setProductName(const std::string& productName) {
 
 void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& intrinsics, int width, int height) {
     if(!isValidIntrinsicsMatrix(intrinsics)) {
-        throw std::runtime_error("Invalid Intrinsic Matrix entered!!");
+        throw std::runtime_error("Invalid Intrinsic Matrix entered: " + nlohmann::json(intrinsics).dump());
     }
     if(width <= 0 || height <= 0 || width > std::numeric_limits<uint16_t>::max() || height > std::numeric_limits<uint16_t>::max()) {
         throw std::runtime_error("Invalid calibration resolution entered!!");
@@ -1074,6 +1063,9 @@ void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, const s
 }
 
 void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& intrinsics, Size2f frameSize) {
+    if(!isValidCalibrationDimension(frameSize.width) || !isValidCalibrationDimension(frameSize.height)) {
+        throw std::runtime_error("Invalid calibration resolution entered!!");
+    }
     setCameraIntrinsics(cameraId, intrinsics, static_cast<int>(frameSize.width), static_cast<int>(frameSize.height));
     return;
 }

--- a/src/device/CalibrationHandler.cpp
+++ b/src/device/CalibrationHandler.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -30,6 +31,21 @@ namespace {
 
 constexpr size_t kImuCalibrationRowCount = 3;
 constexpr size_t kImuCalibrationColumnCount = 4;
+
+bool isValidIntrinsicsMatrix(const std::vector<std::vector<float>>& intrinsics) {
+    if(intrinsics.size() != 3 || intrinsics[0].size() != 3 || intrinsics[1].size() != 3 || intrinsics[2].size() != 3) {
+        return false;
+    }
+
+    for(const auto& row : intrinsics) {
+        if(!std::all_of(row.begin(), row.end(), [](float value) { return std::isfinite(value); })) {
+            return false;
+        }
+    }
+
+    return intrinsics[0][0] > 0.0f && intrinsics[1][1] > 0.0f && intrinsics[1][0] == 0.0f && intrinsics[2][0] == 0.0f && intrinsics[2][1] == 0.0f
+           && intrinsics[2][2] == 1.0f;
+}
 
 std::optional<std::array<float, 3>> lookupHousingEntry(const std::string& productName, HousingCoordinateSystem housingCs) {
     if(productName.empty()) return std::nullopt;
@@ -333,9 +349,8 @@ bool CalibrationHandler::hasCameraCalibration(CameraBoardSocket cameraId) const 
 }
 
 void CalibrationHandler::validateIntrinsicsMatrix(CameraBoardSocket cameraId) const {
-    const auto& storedIntrinsics = eepromData.cameraData.at(cameraId).intrinsicMatrix;
-    if(storedIntrinsics.size() < 3 || storedIntrinsics[0].size() < 3 || storedIntrinsics[1].size() < 3 || storedIntrinsics[2].size() < 3
-       || storedIntrinsics[0][0] == 0) {
+    const auto& cameraData = eepromData.cameraData.at(cameraId);
+    if(cameraData.width == 0 || cameraData.height == 0 || !isValidIntrinsicsMatrix(cameraData.intrinsicMatrix)) {
         throw std::runtime_error("There is no Intrinsic matrix available for the requested cameraID");
     }
 }
@@ -1037,12 +1052,11 @@ void CalibrationHandler::setProductName(const std::string& productName) {
 }
 
 void CalibrationHandler::setCameraIntrinsics(CameraBoardSocket cameraId, const std::vector<std::vector<float>>& intrinsics, int width, int height) {
-    if(intrinsics.size() != 3 || intrinsics[0].size() != 3) {
-        throw std::runtime_error("Intrinsic Matrix size should always be 3x3 ");
-    }
-
-    if(intrinsics[1][0] != 0 || intrinsics[2][0] != 0 || intrinsics[2][1] != 0) {
+    if(!isValidIntrinsicsMatrix(intrinsics)) {
         throw std::runtime_error("Invalid Intrinsic Matrix entered!!");
+    }
+    if(width <= 0 || height <= 0 || width > std::numeric_limits<uint16_t>::max() || height > std::numeric_limits<uint16_t>::max()) {
+        throw std::runtime_error("Invalid calibration resolution entered!!");
     }
 
     if(eepromData.cameraData.find(cameraId) == eepromData.cameraData.end()) {

--- a/src/utility/matrixOps.cpp
+++ b/src/utility/matrixOps.cpp
@@ -135,6 +135,21 @@ std::vector<std::vector<float>> matMul(const std::vector<std::vector<float>>& A,
     return res;
 }
 
+bool isValidIntrinsicsMatrix(const std::vector<std::vector<float>>& intrinsics) {
+    if(intrinsics.size() != 3 || intrinsics[0].size() != 3 || intrinsics[1].size() != 3 || intrinsics[2].size() != 3) {
+        return false;
+    }
+
+    for(const auto& row : intrinsics) {
+        if(!std::all_of(row.begin(), row.end(), [](float value) { return std::isfinite(value); })) {
+            return false;
+        }
+    }
+
+    return intrinsics[0][0] > 0.0f && intrinsics[1][1] > 0.0f && intrinsics[1][0] == 0.0f && intrinsics[2][0] == 0.0f && intrinsics[2][1] == 0.0f
+           && intrinsics[2][2] == 1.0f;
+}
+
 void validateRotationMatrix3x3(const std::vector<std::vector<float>>& rotationMatrix) {
     if(rotationMatrix.size() != 3) {
         throw std::runtime_error("Rotation Matrix size should always be 3x3 ");

--- a/tests/src/onhost_tests/calibration_handler_test.cpp
+++ b/tests/src/onhost_tests/calibration_handler_test.cpp
@@ -491,6 +491,31 @@ TEST_CASE("Camera intrinsics require a valid calibration resolution", "[getCamer
                         Catch::Matchers::ContainsSubstring("Invalid calibration resolution"));
 }
 
+TEST_CASE("Size2f camera intrinsics require valid calibration dimensions", "[setCameraIntrinsics]") {
+    auto handler = loadValidHandler();
+    const std::vector<std::vector<float>> intrinsics = {{1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}};
+
+    const std::vector<std::pair<const char*, float>> invalidDimensions = {
+        {"fractional", 1920.5f},
+        {"NaN", std::numeric_limits<float>::quiet_NaN()},
+        {"infinite", std::numeric_limits<float>::infinity()},
+        {"zero", 0.0f},
+        {"negative", -1.0f},
+        {"outside uint16_t range", static_cast<float>(std::numeric_limits<uint16_t>::max()) + 1.0f},
+    };
+
+    for(const auto& [category, dimension] : invalidDimensions) {
+        DYNAMIC_SECTION(category << " width") {
+            REQUIRE_THROWS_WITH(handler.setCameraIntrinsics(CameraBoardSocket::CAM_A, intrinsics, Size2f(dimension, 1080.0f)),
+                                Catch::Matchers::ContainsSubstring("Invalid calibration resolution"));
+        }
+        DYNAMIC_SECTION(category << " height") {
+            REQUIRE_THROWS_WITH(handler.setCameraIntrinsics(CameraBoardSocket::CAM_A, intrinsics, Size2f(1920.0f, dimension)),
+                                Catch::Matchers::ContainsSubstring("Invalid calibration resolution"));
+        }
+    }
+}
+
 TEST_CASE("Setting camera intrinsics uses the same validation contract", "[setCameraIntrinsics]") {
     auto handler = loadValidHandler();
     const std::vector<std::vector<float>> validIntrinsics = {{1000.0f, 2.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}};
@@ -499,7 +524,8 @@ TEST_CASE("Setting camera intrinsics uses the same validation contract", "[setCa
     REQUIRE(std::get<0>(handler.getDefaultIntrinsics(CameraBoardSocket::CAM_A)) == validIntrinsics);
 
     REQUIRE_THROWS_WITH(handler.setCameraIntrinsics(CameraBoardSocket::CAM_A, {{1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f}, {0.0f, 0.0f, 1.0f}}, 1920, 1080),
-                        Catch::Matchers::ContainsSubstring("Invalid Intrinsic Matrix"));
+                        Catch::Matchers::ContainsSubstring("Invalid Intrinsic Matrix")
+                            && Catch::Matchers::ContainsSubstring("[[1000.0,0.0,960.0],[0.0,1000.0],[0.0,0.0,1.0]]"));
     REQUIRE_THROWS_WITH(
         handler.setCameraIntrinsics(CameraBoardSocket::CAM_A, {{-1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}}, 1920, 1080),
         Catch::Matchers::ContainsSubstring("Invalid Intrinsic Matrix"));

--- a/tests/src/onhost_tests/calibration_handler_test.cpp
+++ b/tests/src/onhost_tests/calibration_handler_test.cpp
@@ -1,8 +1,10 @@
 #include <catch2/catch_all.hpp>
 #include <cmath>
 #include <depthai/device/CalibrationHandler.hpp>
+#include <limits>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 using namespace dai;
@@ -418,6 +420,89 @@ TEST_CASE("Missing camera intrinsics reports calibration guidance", "[getCameraI
 
     REQUIRE_THROWS_WITH(handler.getCameraIntrinsics(CameraBoardSocket::CAM_A, 640, 480),
                         Catch::Matchers::ContainsSubstring("Camera data available for the requested cameraID"));
+}
+
+TEST_CASE("Camera intrinsics must follow the calibration matrix contract", "[getCameraIntrinsics]") {
+    const auto requireInvalidIntrinsics = [](std::vector<std::vector<float>> intrinsics) {
+        auto data = loadValidHandler().getEepromData();
+        data.cameraData.at(CameraBoardSocket::CAM_A).intrinsicMatrix = std::move(intrinsics);
+        const CalibrationHandler handler(data);
+
+        REQUIRE_THROWS_WITH(handler.getDefaultIntrinsics(CameraBoardSocket::CAM_A), Catch::Matchers::ContainsSubstring("no Intrinsic matrix available"));
+    };
+
+    SECTION("oversized matrix") {
+        requireInvalidIntrinsics({{1000.0f, 0.0f, 960.0f, 0.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}});
+    }
+
+    SECTION("ragged matrix") {
+        requireInvalidIntrinsics({{1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f}, {0.0f, 0.0f, 1.0f}});
+    }
+
+    SECTION("singular matrix") {
+        requireInvalidIntrinsics({{1000.0f, 0.0f, 960.0f}, {0.0f, 0.0f, 540.0f}, {0.0f, 0.0f, 1.0f}});
+    }
+
+    SECTION("negative focal length") {
+        requireInvalidIntrinsics({{-1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}});
+    }
+
+    SECTION("nonzero element below horizontal focal length") {
+        requireInvalidIntrinsics({{1000.0f, 0.0f, 960.0f}, {1.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}});
+    }
+
+    SECTION("nonzero first element in homogeneous row") {
+        requireInvalidIntrinsics({{1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {1.0f, 0.0f, 1.0f}});
+    }
+
+    SECTION("nonzero second element in homogeneous row") {
+        requireInvalidIntrinsics({{1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 1.0f, 1.0f}});
+    }
+
+    SECTION("noncanonical homogeneous scale") {
+        requireInvalidIntrinsics({{1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 2.0f}});
+    }
+
+    SECTION("non-finite matrix") {
+        requireInvalidIntrinsics({{1000.0f, 0.0f, 960.0f}, {0.0f, std::numeric_limits<float>::infinity(), 540.0f}, {0.0f, 0.0f, 1.0f}});
+    }
+}
+
+TEST_CASE("Invertible camera intrinsics with skew remain valid", "[getCameraIntrinsics]") {
+    auto data = loadValidHandler().getEepromData();
+    const std::vector<std::vector<float>> intrinsics = {{1000.0f, 2.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}};
+    data.cameraData.at(CameraBoardSocket::CAM_A).intrinsicMatrix = intrinsics;
+
+    const CalibrationHandler handler(data);
+    REQUIRE(std::get<0>(handler.getDefaultIntrinsics(CameraBoardSocket::CAM_A)) == intrinsics);
+}
+
+TEST_CASE("Camera intrinsics require a valid calibration resolution", "[getCameraIntrinsics][setCameraIntrinsics]") {
+    auto data = loadValidHandler().getEepromData();
+    data.cameraData.at(CameraBoardSocket::CAM_A).width = 0;
+    const CalibrationHandler handler(data);
+    REQUIRE_THROWS_WITH(handler.getDefaultIntrinsics(CameraBoardSocket::CAM_A), Catch::Matchers::ContainsSubstring("no Intrinsic matrix available"));
+
+    auto mutableHandler = loadValidHandler();
+    const std::vector<std::vector<float>> intrinsics = {{1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}};
+    REQUIRE_THROWS_WITH(mutableHandler.setCameraIntrinsics(CameraBoardSocket::CAM_A, intrinsics, 0, 1080),
+                        Catch::Matchers::ContainsSubstring("Invalid calibration resolution"));
+    REQUIRE_THROWS_WITH(mutableHandler.setCameraIntrinsics(CameraBoardSocket::CAM_A, intrinsics, 1920, 100000),
+                        Catch::Matchers::ContainsSubstring("Invalid calibration resolution"));
+}
+
+TEST_CASE("Setting camera intrinsics uses the same validation contract", "[setCameraIntrinsics]") {
+    auto handler = loadValidHandler();
+    const std::vector<std::vector<float>> validIntrinsics = {{1000.0f, 2.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}};
+
+    handler.setCameraIntrinsics(CameraBoardSocket::CAM_A, validIntrinsics, 1920, 1080);
+    REQUIRE(std::get<0>(handler.getDefaultIntrinsics(CameraBoardSocket::CAM_A)) == validIntrinsics);
+
+    REQUIRE_THROWS_WITH(handler.setCameraIntrinsics(CameraBoardSocket::CAM_A, {{1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f}, {0.0f, 0.0f, 1.0f}}, 1920, 1080),
+                        Catch::Matchers::ContainsSubstring("Invalid Intrinsic Matrix"));
+    REQUIRE_THROWS_WITH(
+        handler.setCameraIntrinsics(CameraBoardSocket::CAM_A, {{-1000.0f, 0.0f, 960.0f}, {0.0f, 1000.0f, 540.0f}, {0.0f, 0.0f, 1.0f}}, 1920, 1080),
+        Catch::Matchers::ContainsSubstring("Invalid Intrinsic Matrix"));
 }
 
 TEST_CASE("Invalid camera ID throws", "[getCameraIntrinsics]") {


### PR DESCRIPTION
## Summary

Expand camera intrinsics validation so health checks reject calibration data that Camera nodes and downstream consumers cannot safely use.

Validation now requires:

- An exact, non-ragged 3×3 matrix
- Finite values
- Positive `fx` and `fy`
- Zero lower-triangular elements
- A homogeneous scale of `1`
- Valid, nonzero calibration dimensions representable by `CameraInfo`

The same validation is now applied when reading and setting intrinsics, preventing inconsistent calibration data from entering through the setter.

Principal points outside the image and an optional skew term remain supported to avoid rejecting unusual but valid calibrations.

## Testing

- Added unit coverage for malformed, non-finite, noncanonical, and valid unusual matrices
- `calibration_handler_test`: 68 test cases and 1,541 assertions passed
- Full on-host suite: 34/34 tests passed
- Verified checked-in calibration JSON files and the holistic recording’s `camera_info.json` against the new rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of camera calibration data, including intrinsic matrices and frame dimensions.
  * Invalid, malformed, singular, non-finite, negative, or structurally incorrect calibration values are now rejected.
  * Valid skewed intrinsic matrices continue to be accepted.
* **Tests**
  * Added coverage for calibration validation across default and manually configured camera settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->