### PR TITLE
report device in use more accurately

### DIFF
--- a/src/device/HealthCheck.cpp
+++ b/src/device/HealthCheck.cpp
@@ -616,7 +616,7 @@ HealthCheckMetrics DeviceHealthCheck::run(const DeviceInfo& devInfo, const Healt
         device = std::make_shared<Device>(devInfo);
     } catch(const std::exception& ex) {
         const std::string errorMessage = ex.what();
-        metrics.deviceInUse = errorMessage.find("X_LINK_DEVICE_ALREADY_IN_USE") != std::string::npos || devInfo.state == X_LINK_GATE_BOOTED;
+        metrics.deviceInUse = errorMessage.find("X_LINK_DEVICE_ALREADY_IN_USE") != std::string::npos || errorMessage.find("Device is already used") != std::string::npos || devInfo.state == X_LINK_GATE_BOOTED;
         metrics.missingUdevRules = errorMessage.find("X_LINK_INSUFFICIENT_PERMISSIONS") != std::string::npos;
         metrics.issues.emplace_back(HealthCheckIssueType::Error, HealthCheckIssueStage::Connection, errorMessage);
         setRequestedChecksFailed(metrics, config);

--- a/src/device/HealthCheck.cpp
+++ b/src/device/HealthCheck.cpp
@@ -616,7 +616,9 @@ HealthCheckMetrics DeviceHealthCheck::run(const DeviceInfo& devInfo, const Healt
         device = std::make_shared<Device>(devInfo);
     } catch(const std::exception& ex) {
         const std::string errorMessage = ex.what();
-        metrics.deviceInUse = errorMessage.find("X_LINK_DEVICE_ALREADY_IN_USE") != std::string::npos || errorMessage.find("Device is already used") != std::string::npos || devInfo.state == X_LINK_GATE_BOOTED;
+        // devInfo can have stale/unresolved values in some cases and does not necessarily contain the correct state values - parse error message
+        metrics.deviceInUse =
+            errorMessage.find("X_LINK_DEVICE_ALREADY_IN_USE") != std::string::npos || errorMessage.find("Device is already used") != std::string::npos;
         metrics.missingUdevRules = errorMessage.find("X_LINK_INSUFFICIENT_PERMISSIONS") != std::string::npos;
         metrics.issues.emplace_back(HealthCheckIssueType::Error, HealthCheckIssueStage::Connection, errorMessage);
         setRequestedChecksFailed(metrics, config);


### PR DESCRIPTION
## Purpose
deviceInUse was not being set to true for certain errors in device constructor if deviceInfo was out of date (had incorrect state)

## Specification
Matched more error messages

## AI Usage
None

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device connection error handling by correctly identifying when a device is already in use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->