### PR TITLE
Add 30second device search timeout

### DIFF
--- a/cmake/depthaiOptions.cmake
+++ b/cmake/depthaiOptions.cmake
@@ -128,3 +128,4 @@ set(DEPTHAI_BOOTLOADER_SHARED_LOCAL "" CACHE STRING "Path to local depthai-bootl
 option(DEPTHAI_INTERNAL_DEVICE_BUILD_RVC4 "This build is part of the rvc4 firmware build" OFF)
 option(DEPTHAI_GENERATE_HOUSING_COORDS "Generate housing coordinate system data from JSON files" ON)
 option(DEPTHAI_TESTS_ENABLE_REPLAY "Set DEPTHAI_REPLAY for all tests" OFF)
+set(DEPTHAI_TEST_DEVICE_SEARCH_TIMEOUT 30 CACHE STRING "Seconds test_wrapper waits for a device before giving up")

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -27,6 +27,8 @@ set(TOP_CPP_EXAMPLES_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 # Regexes for example test failure
 set(STRICT_EXAMPLE_TEST_FAIL_REGEX "\\[warning\\];\\[error\\];\\[critical\\]")
+# Emitted by test_wrapper when no device shows up; marks the test skipped rather than failed
+set(NO_DEVICE_SKIP_REGEX "No device found after .* skipping test")
 set(RELAXED_EXAMPLE_TEST_FAIL_REGEX "\\[error\\];\\[critical\\]")
 
 # Helper for adding new examples
@@ -75,6 +77,8 @@ function(dai_add_example example_name example_src enable_test use_pcl)
         add_dependencies(${example_name} test_wrapper)
         # Sets a regex catching any logged warnings, errors or critical (coming either from device or host)
         set_tests_properties(${example_name} PROPERTIES FAIL_REGULAR_EXPRESSION "${STRICT_EXAMPLE_TEST_FAIL_REGEX}")
+        # No device available -> skip rather than fail
+        set_tests_properties(${example_name} PROPERTIES SKIP_REGULAR_EXPRESSION "${NO_DEVICE_SKIP_REGEX}")
 
         # Add ubsan halt on error
         set_tests_properties(${example_name} PROPERTIES ENVIRONMENT "${test_env}")

--- a/examples/cpp/cmake/ExecuteTestTimeout.cmake
+++ b/examples/cpp/cmake/ExecuteTestTimeout.cmake
@@ -40,6 +40,8 @@ if(error_variable MATCHES "timeout" OR error_variable EQUAL 128 OR error_variabl
     # Okay
 elseif(NOT error_variable)
     # return code == 0, also okay
+elseif(error_variable EQUAL 125)
+    message(STATUS "No device available, ${PATH_TO_TEST_EXECUTABLE} skipped")
 elseif(error_variable EQUAL 133 OR error_variable MATCHES "Child killed")
     # sigkill, return fatal error but mark the issue
     message(FATAL_ERROR "${PATH_TO_TEST_EXECUTABLE} had to be forcefully killed after 5 additional seconds after SIGINT")

--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TARGET_NAME "depthai")
 
 # Regexes for example test failure
 set(STRICT_EXAMPLE_TEST_FAIL_REGEX "\\[warning\\];\\[error\\];\\[critical\\]")
+set(NO_DEVICE_SKIP_REGEX "No device found after .* skipping test")
 set(RELAXED_EXAMPLE_TEST_FAIL_REGEX "\\[error\\];\\[critical\\]")
 
 # Add a target to install_requirements (added to ALL)
@@ -92,6 +93,8 @@ function(add_python_example example_name python_script_path)
 
         # Sets a regex catching any logged warnings, errors or critical (coming either from device or host)
         set_tests_properties (${example_name} PROPERTIES FAIL_REGULAR_EXPRESSION ${STRICT_EXAMPLE_TEST_FAIL_REGEX})
+
+        set_tests_properties (${example_name} PROPERTIES SKIP_REGULAR_EXPRESSION "${NO_DEVICE_SKIP_REGEX}")
 
     endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -425,6 +425,7 @@ endfunction()
 add_executable(test_wrapper src/helpers/test_wrapper.cpp)
 target_include_directories(test_wrapper PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include/subprocess)
 target_link_libraries(test_wrapper PRIVATE depthai::core Threads::Threads spdlog::spdlog)
+target_compile_definitions(test_wrapper PRIVATE DEVICE_SEARCH_TIMEOUT_SECONDS=${DEPTHAI_TEST_DEVICE_SEARCH_TIMEOUT})
 
 add_executable(telemetry_test_child src/ondevice_tests/telemetry_test_child.cpp)
 add_default_flags(telemetry_test_child LEAN)

--- a/tests/src/helpers/test_wrapper.cpp
+++ b/tests/src/helpers/test_wrapper.cpp
@@ -10,6 +10,10 @@
 #include "depthai/depthai.hpp"
 #include "subprocess.hpp"
 
+#ifndef DEVICE_SEARCH_TIMEOUT_SECONDS
+    #define DEVICE_SEARCH_TIMEOUT_SECONDS 30
+#endif
+
 int main(int argc, char* argv[]) {
     if(argc < 3) {
         std::cerr << "Usage: " << argv[0] << " <timeout> <script> [args...]" << std::endl;
@@ -38,7 +42,13 @@ int main(int argc, char* argv[]) {
         auto devicesBefore = 0;
         std::string targetDeviceId;
 
+        constexpr auto DEVICE_SEARCH_TIMEOUT = std::chrono::seconds(DEVICE_SEARCH_TIMEOUT_SECONDS);
+        auto searchStart = std::chrono::steady_clock::now();
         while(devicesBefore < 1) {
+            if(std::chrono::steady_clock::now() - searchStart > DEVICE_SEARCH_TIMEOUT) {
+                std::cerr << "=== No device found after " << DEVICE_SEARCH_TIMEOUT.count() << " seconds, skipping test ===" << std::endl;
+                return 125;  // skip code
+            }
             devicesBefore = dai::Device::getAllAvailableDevices().size();
             std::cout << "Devices now: " << devicesBefore << std::endl;
             std::this_thread::sleep_for(std::chrono::seconds(5));
@@ -47,7 +57,9 @@ int main(int argc, char* argv[]) {
         // Mirror child auto-selection logic, then pin child to that same device id.
         bool foundTargetDevice = false;
         dai::DeviceInfo targetDeviceInfo;
-        std::tie(foundTargetDevice, targetDeviceInfo) = dai::Device::getAnyAvailableDevice();
+        if(devicesBefore >= 1) {
+            std::tie(foundTargetDevice, targetDeviceInfo) = dai::Device::getAnyAvailableDevice();
+        }
         if(foundTargetDevice) {
             targetDeviceId = targetDeviceInfo.getDeviceId();
         }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
If no device available (eg. device crashed), the example tests would use the overall 300 second timeout set by DFORCE_TIMEOUT_SECONDS in: 

`Test command: /usr/bin/cmake "-E" "env" "PATH=/bin:/workspace/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" "PYTHONPATH=/workspace/build/bindings/python:" "DEPTHAI_SEARCH_TIMEOUT=20000" "DEPTHAI_CONNECT_TIMEOUT=10000" "DEPTHAI_RECONNECT_TIMEOUT=0" "/usr/bin/cmake" "-DFORCE_TIMEOUT_SECONDS=300" "-P" "/workspace/examples/python/../cpp/cmake/ExecuteTestTimeout.cmake" "/workspace/build/tests/test_wrapper" "40" "/workspace/venv/bin/python" "-Werror" "/workspace/examples/python/Camera/camera_output.py"
`

and the `test_wrapper.cpp` would search for a device until the timeout. This PR adds a device search timeout cmake cache variable set to default 30 seconds. If no device is found, the wrapper returns code 125 which means skip.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: claude opus 5.0 high

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Test Improvements**
  * Tests now wait up to 30 seconds for a device to become available, with a configurable timeout.
  * Tests are skipped with a clear “No device available” message when no device is detected, rather than reported as failures.
  * Applies consistently to C++ and Python example tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->