### PR TITLE
Handle distorted images in PointCloud Node

### DIFF
--- a/include/depthai/common/CameraModel.hpp
+++ b/include/depthai/common/CameraModel.hpp
@@ -1,11 +1,26 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace dai {
 /**
  * Which CameraModel to initialize the calibration with.
  */
 enum class CameraModel : int8_t { Perspective = 0, Fisheye = 1, Equirectangular = 2, RadialDivision = 3 };
+
+inline std::string toString(CameraModel model) {
+    switch(model) {
+        case CameraModel::Perspective:
+            return "Perspective";
+        case CameraModel::Fisheye:
+            return "Fisheye";
+        case CameraModel::RadialDivision:
+            return "RadialDivision";
+        case CameraModel::Equirectangular:
+            return "Equirectangular";
+    }
+    return "Unknown";
+}
 
 }  // namespace dai

--- a/include/depthai/common/CameraModel.hpp
+++ b/include/depthai/common/CameraModel.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
+#include <string_view>
 
 namespace dai {
 /**
@@ -9,17 +9,14 @@ namespace dai {
  */
 enum class CameraModel : int8_t { Perspective = 0, Fisheye = 1, Equirectangular = 2, RadialDivision = 3 };
 
-inline std::string toString(CameraModel model) {
+[[nodiscard]] constexpr std::string_view toString(CameraModel model) {
     switch(model) {
-        case CameraModel::Perspective:
-            return "Perspective";
-        case CameraModel::Fisheye:
-            return "Fisheye";
-        case CameraModel::RadialDivision:
-            return "RadialDivision";
-        case CameraModel::Equirectangular:
-            return "Equirectangular";
+        case CameraModel::Perspective:    return "Perspective";
+        case CameraModel::Fisheye:         return "Fisheye";
+        case CameraModel::Equirectangular: return "Equirectangular";
+        case CameraModel::RadialDivision:  return "RadialDivision";
     }
+
     return "Unknown";
 }
 

--- a/include/depthai/common/CameraModel.hpp
+++ b/include/depthai/common/CameraModel.hpp
@@ -11,10 +11,14 @@ enum class CameraModel : int8_t { Perspective = 0, Fisheye = 1, Equirectangular 
 
 [[nodiscard]] constexpr std::string_view toString(CameraModel model) {
     switch(model) {
-        case CameraModel::Perspective:    return "Perspective";
-        case CameraModel::Fisheye:         return "Fisheye";
-        case CameraModel::Equirectangular: return "Equirectangular";
-        case CameraModel::RadialDivision:  return "RadialDivision";
+        case CameraModel::Perspective:
+            return "Perspective";
+        case CameraModel::Fisheye:
+            return "Fisheye";
+        case CameraModel::Equirectangular:
+            return "Equirectangular";
+        case CameraModel::RadialDivision:
+            return "RadialDivision";
     }
 
     return "Unknown";

--- a/include/depthai/pipeline/datatype/PointCloudData.hpp
+++ b/include/depthai/pipeline/datatype/PointCloudData.hpp
@@ -223,7 +223,11 @@ class PointCloudData : public Buffer, public ProtoSerializable, public Transform
     PointCloudData& setInstanceNum(unsigned int instanceNum);
 
     /**
-     * Retrieves image transformation data
+     * Retrieves image transformation data.
+     *
+     * For PointCloud output, the distortion model and coefficients describe the source image used
+     * to generate the cloud. The 3D points themselves are already compensated for that distortion,
+     * so the distortion fields are informational.
      */
     const ImgTransformation& getTransformation() const;
 

--- a/include/depthai/pipeline/node/PointCloud.hpp
+++ b/include/depthai/pipeline/node/PointCloud.hpp
@@ -9,6 +9,7 @@
 #include "depthai/common/DepthUnit.hpp"
 #include "depthai/common/HousingCoordinateSystem.hpp"
 #include "depthai/common/ImgTransformations.hpp"
+#include "depthai/common/Point2f.hpp"
 #include "depthai/common/Point3f.hpp"
 #include "depthai/common/Point3fRGBA.hpp"
 #include "depthai/pipeline/Subnode.hpp"
@@ -61,6 +62,7 @@ class PointCloud : public DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudPrope
         void useCPUMT(uint32_t numThreads);
         void useGPU(uint32_t device);
         void setIntrinsics(float fx, float fy, float cx, float cy, unsigned int width, unsigned int height);
+        void setDistortion(CameraModel model, std::vector<float> coefficients);
         void setExtrinsics(const std::vector<std::vector<float>>& transformMatrix);
         void clearExtrinsics();
 
@@ -68,6 +70,7 @@ class PointCloud : public DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudPrope
 
        private:
         void initializeGPU(uint32_t device);
+        void cacheUndistortedRays();
         template <typename PointT>
         void transformPointsCPU(std::vector<PointT>& points);
         void calcPointsChunkDense(const uint8_t* depthData, std::vector<Point3f>& points, unsigned int startRow, unsigned int endRow);
@@ -101,6 +104,10 @@ class PointCloud : public DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudPrope
         float lengthUnitMultiplier = DEFAULT_LENGTH_UNIT_MULTIPLIER;
 
         float fx = 0.0f, fy = 0.0f, cx = 0.0f, cy = 0.0f;
+        CameraModel distortionModel = CameraModel::Perspective;
+        std::vector<float> distortionCoefficients;
+        std::vector<Point2f> undistortedRays;
+        bool hasDistortion = false;
         unsigned int width = 0u, height = 0u;
         size_t size = 0;
         bool intrinsicsSet = false;

--- a/include/depthai/pipeline/node/PointCloud.hpp
+++ b/include/depthai/pipeline/node/PointCloud.hpp
@@ -108,6 +108,7 @@ class PointCloud : public DeviceNodeCRTP<DeviceNode, PointCloud, PointCloudPrope
         std::vector<float> distortionCoefficients;
         std::vector<Point2f> undistortedRays;
         bool hasDistortion = false;
+        bool gpuDistortionFallbackWarned = false;
         unsigned int width = 0u, height = 0u;
         size_t size = 0;
         bool intrinsicsSet = false;

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <cstring>
 #include <future>
+#include <stdexcept>
+#include <string>
 #include <thread>
 
 #ifdef DEPTHAI_ENABLE_KOMPUTE
@@ -33,6 +35,24 @@
 namespace dai {
 namespace node {
 
+namespace {
+
+const char* distortionModelName(CameraModel model) {
+    switch(model) {
+        case CameraModel::Perspective:
+            return "Perspective";
+        case CameraModel::Fisheye:
+            return "Fisheye";
+        case CameraModel::RadialDivision:
+            return "RadialDivision";
+        case CameraModel::Equirectangular:
+            return "Equirectangular";
+    }
+    return "Unknown";
+}
+
+}  // namespace
+
 // ── Impl: apply / get methods ──
 
 void PointCloud::Impl::setLogger(const std::shared_ptr<::spdlog::logger>& log) {
@@ -55,7 +75,10 @@ void PointCloud::Impl::computePointCloudDense(const uint8_t* depthData, std::vec
             break;
         case ComputeMethod::GPU:
             if(hasDistortion) {
-                if(logger) logger->warn("GPU compute does not support depth undistortion yet, falling back to CPU");
+                if(!gpuDistortionFallbackWarned) {
+                    if(logger) logger->warn("GPU compute does not support depth undistortion yet, falling back to CPU");
+                    gpuDistortionFallbackWarned = true;
+                }
                 computePointCloudDenseCPU(depthData, points);
             } else {
                 computePointCloudDenseGPU(depthData, points);
@@ -377,6 +400,7 @@ void PointCloud::Impl::useCPUMT(uint32_t numThreads) {
 }
 
 void PointCloud::Impl::useGPU(uint32_t device) {
+    gpuDistortionFallbackWarned = false;
     initializeGPU(device);
 }
 
@@ -406,9 +430,16 @@ void PointCloud::Impl::setIntrinsics(float fx, float fy, float cx, float cy, uns
 }
 
 void PointCloud::Impl::setDistortion(CameraModel model, std::vector<float> coefficients) {
+    const bool nextHasDistortion = hasNonZeroDistortion(coefficients);
+    if(nextHasDistortion && model != CameraModel::Perspective && model != CameraModel::Fisheye) {
+        throw std::invalid_argument(std::string("PointCloud does not support distortion model: ") + distortionModelName(model));
+    }
+
+    const bool distortionStateChanged = hasDistortion != nextHasDistortion;
     distortionModel = model;
     distortionCoefficients = std::move(coefficients);
-    hasDistortion = hasNonZeroDistortion(distortionCoefficients);
+    hasDistortion = nextHasDistortion;
+    if(distortionStateChanged) gpuDistortionFallbackWarned = false;
     cacheUndistortedRays();
 }
 

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -856,6 +856,9 @@ void PointCloud::run() {
         auto pc = std::make_shared<PointCloudData>();
         pc->setBufferMetadataFrom(depthFrame);
         pc->setInstanceNum(depthFrame->getInstanceNum());
+        // Preserve the source ImgTransformation as metadata. The distortion model and
+        // coefficients describe the image used to generate the cloud; the 3D points have already
+        // been distortion-compensated.
         auto outputTransformation = depthFrame->getTransformation();
         if(targetExtrinsics_) {
             outputTransformation.setExtrinsics(*targetExtrinsics_);

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -23,6 +23,7 @@
 #include "device/CalibrationHandler.hpp"
 #include "pipeline/Pipeline.hpp"
 #include "pipeline/ThreadedNodeImpl.hpp"
+#include "pipeline/utilities/Alignment/AlignmentUtilities.hpp"
 
 #ifdef DEPTHAI_ENABLE_KOMPUTE
     #include "depthai/shaders/depth2pointcloud.hpp"
@@ -53,7 +54,12 @@ void PointCloud::Impl::computePointCloudDense(const uint8_t* depthData, std::vec
             computePointCloudDenseCPUMT(depthData, points);
             break;
         case ComputeMethod::GPU:
-            computePointCloudDenseGPU(depthData, points);
+            if(hasDistortion) {
+                if(logger) logger->warn("GPU compute does not support depth undistortion yet, falling back to CPU");
+                computePointCloudDenseCPU(depthData, points);
+            } else {
+                computePointCloudDenseGPU(depthData, points);
+            }
             break;
     }
 }
@@ -147,8 +153,9 @@ void PointCloud::Impl::calcPointsChunkDense(const uint8_t* depthData, std::vecto
             float yCoord = 0.0f;
 
             if(z > 0.0f) {
-                xCoord = (col - cx) * z / fx;
-                yCoord = (row - cy) * z / fy;
+                const auto& ray = undistortedRays[i];
+                xCoord = ray.x * z;
+                yCoord = ray.y * z;
             }
 
             points[i] = Point3f{xCoord, yCoord, z};
@@ -199,8 +206,9 @@ void PointCloud::Impl::calcPointsChunkDenseColored(
             float yCoord = 0.0f;
 
             if(z > 0.0f) {
-                xCoord = (col - cx) * z / fx;
-                yCoord = (row - cy) * z / fy;
+                const auto& ray = undistortedRays[i];
+                xCoord = ray.x * z;
+                yCoord = ray.y * z;
             }
 
             uint8_t r = colorData[i * 3 + 0];
@@ -387,6 +395,7 @@ void PointCloud::Impl::setIntrinsics(float fx, float fy, float cx, float cy, uns
     this->height = height;
     size = this->width * this->height;
     intrinsicsSet = true;
+    cacheUndistortedRays();
 #ifdef DEPTHAI_ENABLE_KOMPUTE
     if(resolutionChanged) {
         tensorsInitialized = false;
@@ -394,6 +403,27 @@ void PointCloud::Impl::setIntrinsics(float fx, float fy, float cx, float cy, uns
         tensors.clear();
     }
 #endif
+}
+
+void PointCloud::Impl::setDistortion(CameraModel model, std::vector<float> coefficients) {
+    distortionModel = model;
+    distortionCoefficients = std::move(coefficients);
+    hasDistortion = hasNonZeroDistortion(distortionCoefficients);
+    cacheUndistortedRays();
+}
+
+void PointCloud::Impl::cacheUndistortedRays() {
+    undistortedRays.clear();
+    if(!intrinsicsSet) return;
+
+    undistortedRays.resize(size);
+    for(unsigned int row = 0; row < height; ++row) {
+        for(unsigned int col = 0; col < width; ++col) {
+            const size_t i = static_cast<size_t>(row) * width + col;
+            const auto ray = undistortPoint({(col - cx) / fx, (row - cy) / fy, 1.0f}, distortionModel, distortionCoefficients);
+            undistortedRays[i] = {ray[0] / ray[2], ray[1] / ray[2]};
+        }
+    }
 }
 
 void PointCloud::Impl::clearExtrinsics() {
@@ -618,6 +648,7 @@ void PointCloud::initialize(const ImgFrame& depthFrame, const PointCloudConfig& 
 
     // Set camera intrinsics from the depth frame
     setIntrinsicsFromFrame(depthFrame);
+    pimplPointCloud->setDistortion(depthFrame.transformation.getDistortionModel(), depthFrame.transformation.getDistortionCoefficients());
 
     // Compute and apply coordinate transformation (frame extrinsics + target transform)
     setCoordinateTransformation(depthFrame, config);

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -35,24 +35,6 @@
 namespace dai {
 namespace node {
 
-namespace {
-
-const char* distortionModelName(CameraModel model) {
-    switch(model) {
-        case CameraModel::Perspective:
-            return "Perspective";
-        case CameraModel::Fisheye:
-            return "Fisheye";
-        case CameraModel::RadialDivision:
-            return "RadialDivision";
-        case CameraModel::Equirectangular:
-            return "Equirectangular";
-    }
-    return "Unknown";
-}
-
-}  // namespace
-
 // ── Impl: apply / get methods ──
 
 void PointCloud::Impl::setLogger(const std::shared_ptr<::spdlog::logger>& log) {
@@ -432,7 +414,7 @@ void PointCloud::Impl::setIntrinsics(float fx, float fy, float cx, float cy, uns
 void PointCloud::Impl::setDistortion(CameraModel model, std::vector<float> coefficients) {
     const bool nextHasDistortion = hasNonZeroDistortion(coefficients);
     if(nextHasDistortion && model != CameraModel::Perspective && model != CameraModel::Fisheye) {
-        throw std::invalid_argument(std::string("PointCloud does not support distortion model: ") + distortionModelName(model));
+        throw std::invalid_argument(std::string("PointCloud does not support distortion model: ") + toString(model));
     }
 
     const bool distortionStateChanged = hasDistortion != nextHasDistortion;

--- a/src/pipeline/node/PointCloud.cpp
+++ b/src/pipeline/node/PointCloud.cpp
@@ -414,7 +414,7 @@ void PointCloud::Impl::setIntrinsics(float fx, float fy, float cx, float cy, uns
 void PointCloud::Impl::setDistortion(CameraModel model, std::vector<float> coefficients) {
     const bool nextHasDistortion = hasNonZeroDistortion(coefficients);
     if(nextHasDistortion && model != CameraModel::Perspective && model != CameraModel::Fisheye) {
-        throw std::invalid_argument(std::string("PointCloud does not support distortion model: ") + toString(model));
+        throw std::invalid_argument(std::string("PointCloud does not support distortion model: ") + std::string(toString(model)));
     }
 
     const bool distortionStateChanged = hasDistortion != nextHasDistortion;

--- a/src/pipeline/utilities/Alignment/AlignmentUtilities.cpp
+++ b/src/pipeline/utilities/Alignment/AlignmentUtilities.cpp
@@ -315,6 +315,6 @@ inline float coeffAt(const std::vector<float>& coeffs, size_t idx) {
     return idx < coeffs.size() ? coeffs[idx] : 0.0f;
 }
 
-inline bool hasNonZeroDistortion(const std::vector<float>& coeffs) {
+bool hasNonZeroDistortion(const std::vector<float>& coeffs) {
     return std::any_of(coeffs.begin(), coeffs.end(), [](float value) { return std::abs(value) > 0.0f; });
 }

--- a/tests/src/ondevice_tests/pointcloud_test.cpp
+++ b/tests/src/ondevice_tests/pointcloud_test.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <catch2/catch_all.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cstring>
@@ -63,6 +64,73 @@ TEST_CASE("sparse pointcloud") {
         REQUIRE(pcl->getMinY() <= pcl->getMaxY());
         REQUIRE(pcl->getMinZ() <= pcl->getMaxZ());
     }
+}
+
+TEST_CASE("PointCloud compensates perspective distortion in depth rays") {
+    dai::Pipeline pipeline;
+    if(pipeline.getDefaultDevice()->getPlatform() == dai::Platform::RVC2) {
+        WARN("Skipping distorted pointcloud test: PointCloud node is not supported on RVC2.");
+        return;
+    }
+
+    auto pointcloud = pipeline.create<dai::node::PointCloud>();
+    pointcloud->initialConfig->setOrganized(true);
+    pointcloud->initialConfig->setLengthUnit(dai::LengthUnit::MILLIMETER);
+
+    auto depthInQ = pointcloud->inputDepth.createInputQueue();
+    auto outQ = pointcloud->outputPointCloud.createOutputQueue(4, false);
+
+    constexpr unsigned W = 5, H = 3;
+    constexpr float FX = 100.f, FY = 100.f, CX = 2.f, CY = 1.f;
+    constexpr unsigned CX_PIXEL = 2, CY_PIXEL = 1;
+    constexpr float DEPTH_MM = 1000.f;
+    constexpr float K1 = 100.f;
+    constexpr float EXPECTED_UNDISTORTED_X_MM = 19.282993f;
+
+    const std::array<std::array<float, 3>, 3> intrinsics = {{{FX, 0.f, CX}, {0.f, FY, CY}, {0.f, 0.f, 1.f}}};
+    dai::Extrinsics extrinsics({{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}, {0, 0, 0}, dai::CameraBoardSocket::CAM_B);
+    dai::ImgTransformation transformation(W, H, intrinsics, dai::CameraModel::Perspective, {K1}, extrinsics);
+
+    auto depthFrame = std::make_shared<dai::ImgFrame>();
+    depthFrame->setWidth(W);
+    depthFrame->setHeight(H);
+    depthFrame->setType(dai::ImgFrame::Type::RAW16);
+    std::vector<uint16_t> depthData(W * H, static_cast<uint16_t>(DEPTH_MM));
+    std::vector<uint8_t> depthBytes(depthData.size() * sizeof(uint16_t));
+    std::memcpy(depthBytes.data(), depthData.data(), depthBytes.size());
+    depthFrame->setData(std::move(depthBytes));
+    depthFrame->setTransformation(transformation);
+
+    pipeline.start();
+    depthInQ->send(depthFrame);
+
+    auto pointCloudData = outQ->get<dai::PointCloudData>();
+    REQUIRE(pointCloudData != nullptr);
+    REQUIRE(pointCloudData->isOrganized());
+
+    const auto points = pointCloudData->getPoints();
+    REQUIRE(points.size() == W * H);
+
+    // The centre pixel has no radial distortion and lies on the optical axis.
+    const auto& centre = points[CY_PIXEL * W + CX_PIXEL];
+    REQUIRE(centre.x == Catch::Approx(0.f));
+    REQUIRE(centre.y == Catch::Approx(0.f));
+    REQUIRE(centre.z == Catch::Approx(DEPTH_MM));
+
+    // At (u=4,v=1), xd=(u-cx)/fx=0.02. With k1=100, the undistorted
+    // normalized ray is 0.019282993, giving x=19.282993 mm at z=1000 mm.
+    const auto& right = points[1 * W + 4];
+    REQUIRE(right.x == Catch::Approx(EXPECTED_UNDISTORTED_X_MM).epsilon(0.0001f));
+    REQUIRE(right.y == Catch::Approx(0.f));
+    REQUIRE(right.z == Catch::Approx(DEPTH_MM));
+
+    // Radial distortion is symmetric around the principal point.
+    const auto& left = points[1 * W + 0];
+    REQUIRE(left.x == Catch::Approx(-EXPECTED_UNDISTORTED_X_MM).epsilon(0.0001f));
+    REQUIRE(left.y == Catch::Approx(0.f));
+    REQUIRE(left.z == Catch::Approx(DEPTH_MM));
+
+    pipeline.stop();
 }
 
 // ============================================================================

--- a/tests/src/onhost_tests/point_cloud_test.cpp
+++ b/tests/src/onhost_tests/point_cloud_test.cpp
@@ -199,6 +199,42 @@ TEST_CASE("Distorted depth is undistorted before deprojection", "[PointCloud][Im
     REQUIRE(points[2].x < 5.f);
 }
 
+TEST_CASE("Fisheye depth is undistorted before deprojection", "[PointCloud][Impl]") {
+    dai::node::PointCloud::Impl impl;
+    constexpr unsigned W = 3, H = 1;
+    impl.setIntrinsics(100.f, 100.f, 1.f, 0.f, W, H);
+    impl.setDistortion(dai::CameraModel::Fisheye, {0.5f, 0.0f, 0.0f, 0.0f});
+
+    const auto points = computeDense(impl, makeConstantDepth(W, H, 1000));
+
+    REQUIRE(points[2].x < 10.f);
+    REQUIRE(points[2].y == Catch::Approx(0.f));
+    REQUIRE(points[2].z == Catch::Approx(1000.f));
+}
+
+TEST_CASE("Zero distortion preserves the original deprojection", "[PointCloud][Impl]") {
+    dai::node::PointCloud::Impl impl;
+    constexpr unsigned W = 3, H = 1;
+    impl.setIntrinsics(100.f, 100.f, 1.f, 0.f, W, H);
+    impl.setDistortion(dai::CameraModel::Perspective, {0.0f, 0.0f, 0.0f, 0.0f});
+
+    const auto points = computeDense(impl, makeConstantDepth(W, H, 1000));
+
+    REQUIRE(points[2].x == Catch::Approx(10.f));
+    REQUIRE(points[2].y == Catch::Approx(0.f));
+    REQUIRE(points[2].z == Catch::Approx(1000.f));
+}
+
+TEST_CASE("Unsupported distortion models are rejected by PointCloud", "[PointCloud][Impl]") {
+    dai::node::PointCloud::Impl impl;
+    impl.setIntrinsics(100.f, 100.f, 1.f, 0.f, 3, 1);
+
+    REQUIRE_THROWS_WITH(impl.setDistortion(dai::CameraModel::RadialDivision, {0.1f}),
+                        "PointCloud does not support distortion model: RadialDivision");
+    REQUIRE_THROWS_WITH(impl.setDistortion(dai::CameraModel::Equirectangular, {0.1f}),
+                        "PointCloud does not support distortion model: Equirectangular");
+}
+
 // ============================================================================
 // Depth with holes → filterValidPoints keeps only z > 0
 // ============================================================================
@@ -1077,6 +1113,24 @@ std::vector<dai::Point3fRGBA> computeDenseColored(dai::node::PointCloud::Impl& i
 }
 
 }  // namespace
+
+TEST_CASE("Colored deprojection uses undistorted rays", "[PointCloud][Impl][Colored]") {
+    dai::node::PointCloud::Impl impl;
+    constexpr unsigned W = 3, H = 1;
+    impl.setIntrinsics(100.f, 100.f, 1.f, 0.f, W, H);
+    impl.setDistortion(dai::CameraModel::Perspective, {10.f});
+
+    const auto depth = makeConstantDepth(W, H, 1000);
+    const auto color = makeConstantColor(W, H, 1, 2, 3);
+    const auto points = computeDenseColored(impl, depth, color);
+
+    REQUIRE(points[2].x < 10.f);
+    REQUIRE(points[2].y == Catch::Approx(0.f));
+    REQUIRE(points[2].z == Catch::Approx(1000.f));
+    REQUIRE(points[2].r == 1);
+    REQUIRE(points[2].g == 2);
+    REQUIRE(points[2].b == 3);
+}
 
 // ============================================================================
 // Colored dense compute: constant depth + constant color

--- a/tests/src/onhost_tests/point_cloud_test.cpp
+++ b/tests/src/onhost_tests/point_cloud_test.cpp
@@ -179,6 +179,26 @@ TEST_CASE("Zero depth pixels produce zero-valued points", "[PointCloud][Impl]") 
     }
 }
 
+TEST_CASE("Distorted depth is undistorted before deprojection", "[PointCloud][Impl]") {
+    dai::node::PointCloud::Impl impl;
+    constexpr unsigned W = 3, H = 1;
+    impl.setIntrinsics(100.f, 100.f, 1.f, 0.f, W, H);
+    impl.setDistortion(dai::CameraModel::Perspective, {10.f});
+
+    auto points = computeDense(impl, makeConstantDepth(W, H, 1000));
+
+    // The right pixel's distorted normalized x is 0.01. Positive radial
+    // distortion maps it to a smaller undistorted ray before deprojection.
+    REQUIRE(points[2].x < 10.f);
+    REQUIRE(points[2].y == Catch::Approx(0.f));
+    REQUIRE(points[2].z == Catch::Approx(1000.f));
+
+    // Updating intrinsics must rebuild the cached rays.
+    impl.setIntrinsics(200.f, 100.f, 1.f, 0.f, W, H);
+    points = computeDense(impl, makeConstantDepth(W, H, 1000));
+    REQUIRE(points[2].x < 5.f);
+}
+
 // ============================================================================
 // Depth with holes → filterValidPoints keeps only z > 0
 // ============================================================================

--- a/tests/src/onhost_tests/point_cloud_test.cpp
+++ b/tests/src/onhost_tests/point_cloud_test.cpp
@@ -238,10 +238,8 @@ TEST_CASE("Unsupported distortion models are rejected by PointCloud", "[PointClo
     dai::node::PointCloud::Impl impl;
     impl.setIntrinsics(100.f, 100.f, 1.f, 0.f, 3, 1);
 
-    REQUIRE_THROWS_WITH(impl.setDistortion(dai::CameraModel::RadialDivision, {0.1f}),
-                        "PointCloud does not support distortion model: RadialDivision");
-    REQUIRE_THROWS_WITH(impl.setDistortion(dai::CameraModel::Equirectangular, {0.1f}),
-                        "PointCloud does not support distortion model: Equirectangular");
+    REQUIRE_THROWS_WITH(impl.setDistortion(dai::CameraModel::RadialDivision, {0.1f}), "PointCloud does not support distortion model: RadialDivision");
+    REQUIRE_THROWS_WITH(impl.setDistortion(dai::CameraModel::Equirectangular, {0.1f}), "PointCloud does not support distortion model: Equirectangular");
 }
 
 // ============================================================================

--- a/tests/src/onhost_tests/point_cloud_test.cpp
+++ b/tests/src/onhost_tests/point_cloud_test.cpp
@@ -181,22 +181,31 @@ TEST_CASE("Zero depth pixels produce zero-valued points", "[PointCloud][Impl]") 
 
 TEST_CASE("Distorted depth is undistorted before deprojection", "[PointCloud][Impl]") {
     dai::node::PointCloud::Impl impl;
-    constexpr unsigned W = 3, H = 1;
-    impl.setIntrinsics(100.f, 100.f, 1.f, 0.f, W, H);
-    impl.setDistortion(dai::CameraModel::Perspective, {10.f});
+    constexpr unsigned W = 5, H = 3;
+    constexpr float DEPTH_MM = 1000.f;
+    constexpr float EXPECTED_UNDISTORTED_X_MM = 19.282993f;
+    impl.setIntrinsics(100.f, 100.f, 2.f, 1.f, W, H);
+    impl.setDistortion(dai::CameraModel::Perspective, {100.f});
 
-    auto points = computeDense(impl, makeConstantDepth(W, H, 1000));
+    const auto points = computeDense(impl, makeConstantDepth(W, H, static_cast<uint16_t>(DEPTH_MM)));
 
-    // The right pixel's distorted normalized x is 0.01. Positive radial
-    // distortion maps it to a smaller undistorted ray before deprojection.
-    REQUIRE(points[2].x < 10.f);
-    REQUIRE(points[2].y == Catch::Approx(0.f));
-    REQUIRE(points[2].z == Catch::Approx(1000.f));
+    // At (u=4,v=1), xd=(u-cx)/fx=0.02. With k1=100, the undistorted
+    // normalized ray is 0.019282993, giving x=19.282993 mm at z=1000 mm.
+    const auto& right = points[1 * W + 4];
+    REQUIRE(right.x == Catch::Approx(EXPECTED_UNDISTORTED_X_MM).epsilon(0.0001f));
+    REQUIRE(right.y == Catch::Approx(0.f));
+    REQUIRE(right.z == Catch::Approx(DEPTH_MM));
+
+    // Radial distortion is symmetric around the principal point.
+    const auto& left = points[1 * W + 0];
+    REQUIRE(left.x == Catch::Approx(-EXPECTED_UNDISTORTED_X_MM).epsilon(0.0001f));
+    REQUIRE(left.y == Catch::Approx(0.f));
+    REQUIRE(left.z == Catch::Approx(DEPTH_MM));
 
     // Updating intrinsics must rebuild the cached rays.
     impl.setIntrinsics(200.f, 100.f, 1.f, 0.f, W, H);
-    points = computeDense(impl, makeConstantDepth(W, H, 1000));
-    REQUIRE(points[2].x < 5.f);
+    const auto updatedPoints = computeDense(impl, makeConstantDepth(W, H, static_cast<uint16_t>(DEPTH_MM)));
+    REQUIRE(updatedPoints[1 * W + 4].x < EXPECTED_UNDISTORTED_X_MM);
 }
 
 TEST_CASE("Fisheye depth is undistorted before deprojection", "[PointCloud][Impl]") {


### PR DESCRIPTION
## What changed

- Compensate PointCloud depth rays for Perspective and Fisheye distortion.
- Cache undistorted rays for CPU deprojection.
- Fall back from GPU to CPU when distortion compensation is required.
- Reject unsupported distortion models with a clear error.
- Document that output distortion metadata describes the source image and is informational because points are already compensated.
- Add synthetic host and public-node regression tests for corrected optical rays.

## Validation

- `point_cloud_test`: 71 tests, 20,290 assertions passed.
- Public-node distortion test builds successfully and is intended for hardware/HIL execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Point-cloud generation now compensates for supported perspective and fisheye camera distortion.
  - Colored and depth-only point clouds preserve accurate geometry and color alignment.
  - Added a helper for displaying camera model names.

- **Bug Fixes**
  - Distorted inputs now use a safe CPU fallback when GPU processing does not support distortion.

- **Documentation**
  - Clarified that distortion metadata describes the source image, while generated 3D points are already corrected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->