### PR TITLE
Fix/stereo default config

### DIFF
--- a/include/depthai/pipeline/node/StereoDepth.hpp
+++ b/include/depthai/pipeline/node/StereoDepth.hpp
@@ -17,6 +17,7 @@ class StereoDepth : public DeviceNodeCRTP<DeviceNode, StereoDepth, StereoDepthPr
    public:
     constexpr static const char* NAME = "StereoDepth";
     StereoDepth() = default;
+    StereoDepth(const std::shared_ptr<Device>& device);
 
     /**
      * Preset modes for stereo depth.

--- a/src/pipeline/node/StereoDepth.cpp
+++ b/src/pipeline/node/StereoDepth.cpp
@@ -41,6 +41,10 @@ StereoDepth::StereoDepth(std::unique_ptr<Properties> props)
     : DeviceNodeCRTP<DeviceNode, StereoDepth, StereoDepthProperties>(std::move(props)),
       initialConfig(std::make_shared<decltype(properties.initialConfig)>(properties.initialConfig)) {}
 
+StereoDepth::StereoDepth(const std::shared_ptr<Device>& device) : DeviceNodeCRTP<DeviceNode, StereoDepth, StereoDepthProperties>(device) {
+    setDefaultProfilePreset(PresetMode::DEFAULT);
+}
+
 StereoDepth::Properties& StereoDepth::getProperties() {
     properties.initialConfig = *initialConfig;
     return properties;
@@ -206,6 +210,9 @@ void StereoDepth::setDefaultProfilePreset(PresetMode mode) {
 }
 
 void StereoDepth::setRvc2ProfilePreset(PresetMode mode) {
+    *initialConfig = StereoDepthConfig{};
+    setPostProcessingHardwareResources(Properties::AUTO, Properties::AUTO);
+
     switch(mode) {
         case PresetMode::ACCURACY:
         case PresetMode::FAST_ACCURACY: {
@@ -404,6 +411,8 @@ void StereoDepth::setRvc2ProfilePreset(PresetMode mode) {
 }
 
 void StereoDepth::setRvc4ProfilePreset(PresetMode mode) {
+    *initialConfig = StereoDepthConfig{};
+
     switch(mode) {
         case PresetMode::DENSITY:
         case PresetMode::FAST_DENSITY:

--- a/tests/src/ondevice_tests/stereo_depth_node_test.cpp
+++ b/tests/src/ondevice_tests/stereo_depth_node_test.cpp
@@ -1,7 +1,25 @@
 #include <catch2/catch_all.hpp>
 
+#include <tuple>
+
 #include "depthai/depthai.hpp"
 #include "depthai/utility/CompilerWarnings.hpp"
+
+auto stereoProfileSignature(const std::shared_ptr<dai::node::StereoDepth>& stereo) {
+    const auto& config = *stereo->initialConfig;
+    return std::make_tuple(config.getConfidenceThreshold(),
+                           config.getLeftRightCheck(),
+                           config.getLeftRightCheckThreshold(),
+                           config.getExtendedDisparity(),
+                           config.getMedianFilter(),
+                           config.algorithmControl.enableSwLeftRightCheck,
+                           config.censusTransform.noiseThresholdScale,
+                           config.confidenceMetrics.flatnessConfidenceWeight,
+                           config.costAggregation.p1Config.defaultValue,
+                           config.costAggregation.p2Config.defaultValue,
+                           config.postProcessing.decimationFilter.decimationFactor,
+                           config.postProcessing.holeFilling.enable);
+}
 
 void testStereoDepthPreset(dai::node::StereoDepth::PresetMode preset, dai::ProcessorType backend = dai::ProcessorType::CPU) {
     dai::Pipeline p;
@@ -37,6 +55,24 @@ TEST_CASE("Test StereoDepth node DENSITY preset") {
 
 TEST_CASE("Test StereoDepth node DEFAULT preset") {
     testStereoDepthPreset(dai::node::StereoDepth::PresetMode::DEFAULT);
+}
+
+TEST_CASE("StereoDepth applies DEFAULT before manual links") {
+    dai::Pipeline pipeline;
+    auto left = pipeline.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_B);
+    auto right = pipeline.create<dai::node::Camera>()->build(dai::CameraBoardSocket::CAM_C);
+    auto leftOutput = left->requestFullResolutionOutput();
+    auto rightOutput = right->requestFullResolutionOutput();
+
+    auto manual = pipeline.create<dai::node::StereoDepth>();
+    leftOutput->link(manual->left);
+    rightOutput->link(manual->right);
+    auto built = pipeline.create<dai::node::StereoDepth>()->build(*leftOutput, *rightOutput);
+    auto accuracy = pipeline.create<dai::node::StereoDepth>();
+    accuracy->setDefaultProfilePreset(dai::node::StereoDepth::PresetMode::ACCURACY);
+
+    REQUIRE(stereoProfileSignature(manual) == stereoProfileSignature(built));
+    REQUIRE(stereoProfileSignature(manual) != stereoProfileSignature(accuracy));
 }
 
 TEST_CASE("Test StereoDepth node FACE preset") {


### PR DESCRIPTION
## Purpose
On RVC4, in StereoDepth, the DEFAULT mode was not set if build() had not been called.

## Tests
New test added validating the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating Stereo Depth nodes with an associated device.
  * Stereo Depth nodes now apply the default profile preset when initialized.

* **Bug Fixes**
  * Preset changes now reliably reset depth configuration before applying new settings.
  * Improved handling of post-processing hardware resources for RVC2 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->