### PR TITLE
Fix/python binding deadlock

### DIFF
--- a/bindings/python/src/pipeline/node/NodeBindings.cpp
+++ b/bindings/python/src/pipeline/node/NodeBindings.cpp
@@ -342,7 +342,7 @@ void NodeBindings::bind(pybind11::module& m, void* pCallstack) {
     py::class_<Node::DatatypeHierarchy> nodeDatatypeHierarchy(pyNode, "DatatypeHierarchy", DOC(dai, Node, DatatypeHierarchy));
 
     py::class_<InputQueue, std::shared_ptr<InputQueue>> pyInputQueue(m, "InputQueue", DOC(dai, InputQueue));
-    pyInputQueue.def("send", &InputQueue::send, py::arg("msg"), DOC(dai, InputQueue, send));
+    pyInputQueue.def("send", &InputQueue::send, py::arg("msg"), DOC(dai, InputQueue, send), py::call_guard<py::gil_scoped_release>());
     pyInputQueue.def("trySend", &InputQueue::trySend, py::arg("msg"), DOC(dai, InputQueue, trySend));
 
     // Node::Id bindings


### PR DESCRIPTION
## Purpose
When I tried to send many messages form host to device to a script node input queue using python bindings the script would get stuck and XLInkOutHost wouldn't send more than 1 message to the node. It would just hand on the mainLoop() call indefinitly.
I believe this is because the queue on the device would fill up so inputQueue.send (host side) would wait untill it frees up but at the same time hold a lock on the queue so it couldn't get emptied.

## Specification
I changed the python binding for inputQueue.send and added a lock release.

## Dependencies & Potential Impact
This changes how consurrency is handled so should be considered carefully.

## Testing & Validation
I tested it on my example and it started working after the change.

## AI Usage
Codex told me to add this change

Submitted code was reviewed by a human: NO

The author is taking the responsibility for the contribution: NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Python threading responsiveness by allowing other threads to run while input data is being sent through the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->