### PR TITLE
Deprecate depthai application packages (RVC2 standalone)

### DIFF
--- a/bindings/python/src/DeviceBootloaderBindings.cpp
+++ b/bindings/python/src/DeviceBootloaderBindings.cpp
@@ -1,7 +1,15 @@
 #include "DeviceBootloaderBindings.hpp"
 
+#include <utility>
+
 // depthai
 #include "depthai/device/DeviceBootloader.hpp"
+#include "depthai/utility/CompilerWarnings.hpp"
+
+namespace {
+constexpr const char* RVC2_STANDALONE_DEPRECATION_MESSAGE =
+    "RVC2 standalone applications (.dap) are deprecated and unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.";
+}  // namespace
 
 void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
     using namespace dai;
@@ -107,19 +115,38 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
 
         .def_static("getFirstAvailableDevice", &DeviceBootloader::getFirstAvailableDevice, DOC(dai, DeviceBootloader, getFirstAvailableDevice))
         .def_static("getAllAvailableDevices", &DeviceBootloader::getAllAvailableDevices, DOC(dai, DeviceBootloader, getAllAvailableDevices))
-        .def_static("saveDepthaiApplicationPackage",
-                    py::overload_cast<const std::filesystem::path&, const Pipeline&, const std::filesystem::path&, bool, const std::string&, bool>(
-                        &DeviceBootloader::saveDepthaiApplicationPackage),
-                    py::arg("path"),
-                    py::arg("pipeline"),
-                    py::arg("pathToCmd") = std::filesystem::path(),
-                    py::arg("compress") = false,
-                    py::arg("applicationName") = "",
-                    py::arg("checkChecksum") = false,
-                    DOC(dai, DeviceBootloader, saveDepthaiApplicationPackage))
         .def_static(
             "saveDepthaiApplicationPackage",
-            py::overload_cast<const std::filesystem::path&, const Pipeline&, bool, const std::string&, bool>(&DeviceBootloader::saveDepthaiApplicationPackage),
+            [](const std::filesystem::path& path,
+               const Pipeline& pipeline,
+               const std::filesystem::path& pathToCmd,
+               bool compress,
+               const std::string& applicationName,
+               bool checkChecksum) {
+                if(PyErr_WarnEx(PyExc_DeprecationWarning, RVC2_STANDALONE_DEPRECATION_MESSAGE, 1) < 0) {
+                    throw pybind11::error_already_set();
+                }
+                DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
+                DeviceBootloader::saveDepthaiApplicationPackage(path, pipeline, pathToCmd, compress, applicationName, checkChecksum);
+                DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
+            },
+            py::arg("path"),
+            py::arg("pipeline"),
+            py::arg("pathToCmd") = std::filesystem::path(),
+            py::arg("compress") = false,
+            py::arg("applicationName") = "",
+            py::arg("checkChecksum") = false,
+            DOC(dai, DeviceBootloader, saveDepthaiApplicationPackage))
+        .def_static(
+            "saveDepthaiApplicationPackage",
+            [](const std::filesystem::path& path, const Pipeline& pipeline, bool compress, const std::string& applicationName, bool checkChecksum) {
+                if(PyErr_WarnEx(PyExc_DeprecationWarning, RVC2_STANDALONE_DEPRECATION_MESSAGE, 1) < 0) {
+                    throw pybind11::error_already_set();
+                }
+                DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
+                DeviceBootloader::saveDepthaiApplicationPackage(path, pipeline, compress, applicationName, checkChecksum);
+                DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
+            },
             py::arg("path"),
             py::arg("pipeline"),
             py::arg("compress"),
@@ -128,20 +155,35 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
             DOC(dai, DeviceBootloader, saveDepthaiApplicationPackage, 2))
         .def_static(
             "createDepthaiApplicationPackage",
-            py::overload_cast<const Pipeline&, const std::filesystem::path&, bool, std::string, bool>(&DeviceBootloader::createDepthaiApplicationPackage),
+            [](const Pipeline& pipeline, const std::filesystem::path& pathToCmd, bool compress, std::string applicationName, bool checkChecksum) {
+                if(PyErr_WarnEx(PyExc_DeprecationWarning, RVC2_STANDALONE_DEPRECATION_MESSAGE, 1) < 0) {
+                    throw pybind11::error_already_set();
+                }
+                DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
+                return DeviceBootloader::createDepthaiApplicationPackage(pipeline, pathToCmd, compress, std::move(applicationName), checkChecksum);
+                DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
+            },
             py::arg("pipeline"),
             py::arg("pathToCmd") = std::filesystem::path(),
             py::arg("compress") = false,
             py::arg("applicationName") = "",
             py::arg("checkChecksum") = false,
             DOC(dai, DeviceBootloader, createDepthaiApplicationPackage))
-        .def_static("createDepthaiApplicationPackage",
-                    py::overload_cast<const Pipeline&, bool, const std::string&, bool>(&DeviceBootloader::createDepthaiApplicationPackage),
-                    py::arg("pipeline"),
-                    py::arg("compress"),
-                    py::arg("applicationName") = "",
-                    py::arg("checkChecksum") = false,
-                    DOC(dai, DeviceBootloader, createDepthaiApplicationPackage, 2))
+        .def_static(
+            "createDepthaiApplicationPackage",
+            [](const Pipeline& pipeline, bool compress, const std::string& applicationName, bool checkChecksum) {
+                if(PyErr_WarnEx(PyExc_DeprecationWarning, RVC2_STANDALONE_DEPRECATION_MESSAGE, 1) < 0) {
+                    throw pybind11::error_already_set();
+                }
+                DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
+                return DeviceBootloader::createDepthaiApplicationPackage(pipeline, compress, applicationName, checkChecksum);
+                DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
+            },
+            py::arg("pipeline"),
+            py::arg("compress"),
+            py::arg("applicationName") = "",
+            py::arg("checkChecksum") = false,
+            DOC(dai, DeviceBootloader, createDepthaiApplicationPackage, 2))
         .def_static("getEmbeddedBootloaderVersion", &DeviceBootloader::getEmbeddedBootloaderVersion, DOC(dai, DeviceBootloader, getEmbeddedBootloaderVersion))
         .def_static("getEmbeddedBootloaderBinary", &DeviceBootloader::getEmbeddedBootloaderBinary, DOC(dai, DeviceBootloader, getEmbeddedBootloaderBinary))
 
@@ -168,8 +210,13 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
                std::string applicationName,
                DeviceBootloader::Memory memory,
                bool checkChecksum) {
+                if(PyErr_WarnEx(PyExc_DeprecationWarning, RVC2_STANDALONE_DEPRECATION_MESSAGE, 1) < 0) {
+                    throw pybind11::error_already_set();
+                }
                 py::gil_scoped_release release;
+                DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
                 return db.flash(progressCallback, pipeline, compress, applicationName, memory, checkChecksum);
+                DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
             },
             py::arg("progressCallback"),
             py::arg("pipeline"),
@@ -186,8 +233,13 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
                std::string applicationName,
                DeviceBootloader::Memory memory,
                bool checkChecksum) {
+                if(PyErr_WarnEx(PyExc_DeprecationWarning, RVC2_STANDALONE_DEPRECATION_MESSAGE, 1) < 0) {
+                    throw pybind11::error_already_set();
+                }
                 py::gil_scoped_release release;
+                DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
                 return db.flash(pipeline, compress, applicationName, memory, checkChecksum);
+                DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
             },
             py::arg("pipeline"),
             py::arg("compress") = false,
@@ -229,8 +281,13 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
         .def(
             "flashDepthaiApplicationPackage",
             [](DeviceBootloader& db, std::function<void(float)> progressCallback, std::vector<uint8_t> package, DeviceBootloader::Memory memory) {
+                if(PyErr_WarnEx(PyExc_DeprecationWarning, RVC2_STANDALONE_DEPRECATION_MESSAGE, 1) < 0) {
+                    throw pybind11::error_already_set();
+                }
                 py::gil_scoped_release release;
+                DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
                 return db.flashDepthaiApplicationPackage(progressCallback, package);
+                DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
             },
             py::arg("progressCallback"),
             py::arg("package"),
@@ -239,8 +296,13 @@ void DeviceBootloaderBindings::bind(pybind11::module& m, void* pCallstack) {
         .def(
             "flashDepthaiApplicationPackage",
             [](DeviceBootloader& db, std::vector<uint8_t> package, DeviceBootloader::Memory memory) {
+                if(PyErr_WarnEx(PyExc_DeprecationWarning, RVC2_STANDALONE_DEPRECATION_MESSAGE, 1) < 0) {
+                    throw pybind11::error_already_set();
+                }
                 py::gil_scoped_release release;
+                DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
                 return db.flashDepthaiApplicationPackage(package);
+                DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
             },
             py::arg("package"),
             py::arg("memory") = DeviceBootloader::Memory::AUTO,

--- a/include/depthai/device/DeviceBootloader.hpp
+++ b/include/depthai/device/DeviceBootloader.hpp
@@ -128,7 +128,9 @@ class DeviceBootloader {
      * @param compress Optional boolean which specifies if contents should be compressed
      * @param applicationName Optional name the application that is flashed
      * @returns Depthai application package
+     * @deprecated RVC2 standalone applications are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.
      */
+    [[deprecated("RVC2 standalone applications (.dap) are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead")]]
     static std::vector<uint8_t> createDepthaiApplicationPackage(
         const Pipeline& pipeline, const fs::path& pathToCmd = {}, bool compress = false, std::string applicationName = "", bool checkChecksum = false);
 
@@ -138,7 +140,9 @@ class DeviceBootloader {
      * @param compress Specifies if contents should be compressed
      * @param applicationName Name the application that is flashed
      * @returns Depthai application package
+     * @deprecated RVC2 standalone applications are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.
      */
+    [[deprecated("RVC2 standalone applications (.dap) are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead")]]
     static std::vector<uint8_t> createDepthaiApplicationPackage(const Pipeline& pipeline,
                                                                 bool compress,
                                                                 const std::string& applicationName = "",
@@ -151,7 +155,9 @@ class DeviceBootloader {
      * @param pathToCmd Optional path to custom device firmware
      * @param compress Optional boolean which specifies if contents should be compressed
      * @param applicationName Optional name the application that is flashed
+     * @deprecated RVC2 standalone applications are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.
      */
+    [[deprecated("RVC2 standalone applications (.dap) are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead")]]
     static void saveDepthaiApplicationPackage(const fs::path& path,
                                               const Pipeline& pipeline,
                                               const fs::path& pathToCmd = {},
@@ -165,7 +171,9 @@ class DeviceBootloader {
      * @param pipeline Pipeline from which to create the application package
      * @param compress Specifies if contents should be compressed
      * @param applicationName Optional name the application that is flashed
+     * @deprecated RVC2 standalone applications are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.
      */
+    [[deprecated("RVC2 standalone applications (.dap) are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead")]]
     static void saveDepthaiApplicationPackage(
         const fs::path& path, const Pipeline& pipeline, bool compress, const std::string& applicationName = "", bool checkChecksum = false);
 
@@ -232,7 +240,9 @@ class DeviceBootloader {
      * @param pipeline Pipeline to flash to the board
      * @param compress Compresses application to reduce needed memory size
      * @param applicationName Name the application that is flashed
+     * @deprecated RVC2 standalone applications are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.
      */
+    [[deprecated("RVC2 standalone applications (.dap) are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead")]]
     std::tuple<bool, std::string> flash(const std::function<void(float)>& progressCallback,
                                         const Pipeline& pipeline,
                                         bool compress = false,
@@ -245,7 +255,9 @@ class DeviceBootloader {
      * @param pipeline Pipeline to flash to the board
      * @param compress Compresses application to reduce needed memory size
      * @param applicationName Optional name the application that is flashed
+     * @deprecated RVC2 standalone applications are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.
      */
+    [[deprecated("RVC2 standalone applications (.dap) are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead")]]
     std::tuple<bool, std::string> flash(
         const Pipeline& pipeline, bool compress = false, const std::string& applicationName = "", Memory memory = Memory::AUTO, bool checkChecksum = false);
 
@@ -259,7 +271,9 @@ class DeviceBootloader {
      * Flashes a specific depthai application package that was generated using createDepthaiApplicationPackage or saveDepthaiApplicationPackage
      * @param progressCallback Callback that sends back a value between 0..1 which signifies current flashing progress
      * @param package Depthai application package to flash to the board
+     * @deprecated RVC2 standalone applications are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.
      */
+    [[deprecated("RVC2 standalone applications (.dap) are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead")]]
     std::tuple<bool, std::string> flashDepthaiApplicationPackage(const std::function<void(float)>& progressCallback,
                                                                  const std::vector<uint8_t>& package,
                                                                  Memory memory = Memory::AUTO);
@@ -267,7 +281,9 @@ class DeviceBootloader {
     /**
      * Flashes a specific depthai application package that was generated using createDepthaiApplicationPackage or saveDepthaiApplicationPackage
      * @param package Depthai application package to flash to the board
+     * @deprecated RVC2 standalone applications are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead.
      */
+    [[deprecated("RVC2 standalone applications (.dap) are unsupported in DepthAI v3. Use RVC2 in peripheral mode or OAK Apps on RVC4 instead")]]
     std::tuple<bool, std::string> flashDepthaiApplicationPackage(const std::vector<uint8_t>& package, Memory memory = Memory::AUTO);
 
     /**

--- a/src/device/DeviceBootloader.cpp
+++ b/src/device/DeviceBootloader.cpp
@@ -9,6 +9,7 @@
 #include "depthai-bootloader-shared/Structure.hpp"
 #include "depthai-bootloader-shared/XLinkConstants.hpp"
 #include "depthai/pipeline/Assets.hpp"
+#include "depthai/utility/CompilerWarnings.hpp"
 #include "depthai/utility/Serialization.hpp"
 #include "depthai/xlink/XLinkConstants.hpp"
 
@@ -230,19 +231,25 @@ std::vector<uint8_t> DeviceBootloader::createDepthaiApplicationPackage(const Pip
                                                                        bool compress,
                                                                        const std::string& applicationName,
                                                                        bool checkChecksum) {
+    DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
     return createDepthaiApplicationPackage(pipeline, "", compress, applicationName, checkChecksum);
+    DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
 }
 
 void DeviceBootloader::saveDepthaiApplicationPackage(
     const fs::path& path, const Pipeline& pipeline, const fs::path& pathToCmd, bool compress, const std::string& applicationName, bool checkChecksum) {
+    DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
     auto dap = createDepthaiApplicationPackage(pipeline, pathToCmd, compress, applicationName, checkChecksum);
+    DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
     std::ofstream outfile(path, std::ios::binary);
     outfile.write(reinterpret_cast<const char*>(dap.data()), dap.size());
 }
 
 void DeviceBootloader::saveDepthaiApplicationPackage(
     const fs::path& path, const Pipeline& pipeline, bool compress, const std::string& applicationName, bool checkChecksum) {
+    DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
     auto dap = createDepthaiApplicationPackage(pipeline, compress, applicationName, checkChecksum);
+    DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
     std::ofstream outfile(path, std::ios::binary);
     outfile.write(reinterpret_cast<const char*>(dap.data()), dap.size());
 }
@@ -633,12 +640,16 @@ std::tuple<bool, std::string> DeviceBootloader::flash(const std::function<void(f
                                                       const std::string& applicationName,
                                                       Memory memory,
                                                       bool checkCheksum) {
+    DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
     return flashDepthaiApplicationPackage(progressCb, createDepthaiApplicationPackage(pipeline, compress, applicationName, checkCheksum), memory);
+    DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
 }
 
 std::tuple<bool, std::string> DeviceBootloader::flash(
     const Pipeline& pipeline, bool compress, const std::string& applicationName, Memory memory, bool checkCheksum) {
+    DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
     return flashDepthaiApplicationPackage(createDepthaiApplicationPackage(pipeline, compress, applicationName, checkCheksum), memory);
+    DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
 }
 
 DeviceBootloader::ApplicationInfo DeviceBootloader::readApplicationInfo(Memory mem) {
@@ -822,7 +833,9 @@ std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(c
 }
 
 std::tuple<bool, std::string> DeviceBootloader::flashDepthaiApplicationPackage(const std::vector<uint8_t>& package, Memory memory) {
+    DEPTHAI_BEGIN_SUPPRESS_DEPRECATION_WARNING
     return flashDepthaiApplicationPackage(nullptr, package, memory);
+    DEPTHAI_END_SUPPRESS_DEPRECATION_WARNING
 }
 
 std::tuple<bool, std::string> DeviceBootloader::flashClear(Memory memory) {

--- a/utilities/device_manager.py
+++ b/utilities/device_manager.py
@@ -468,6 +468,10 @@ deviceConfigLayout = [
 appLayout = [
     [sg.Text("Application settings", size=(20, 1), font=('Arial', 30, 'bold'), text_color="black")],
     [sg.HSeparator()],
+    [sg.Text(
+        "RVC2 standalone applications (.dap) are deprecated and unsupported in DepthAI v3.\nUse RVC2 in peripheral mode or OAK Apps on RVC4 instead.",
+        text_color="red",
+    )],
     [
         sg.Button("About device", size=(15, 1), font=('Arial', 10, 'bold'), disabled=False, key="_unique_aboutBtn"),
         sg.Button("Config", size=(15, 1), font=('Arial', 10, 'bold'), disabled=False, key="_unique_configBtn"),


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Added deprecation flags and warnings for depthai application packages - daps. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME: Codex

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecations**
  - RVC2 standalone applications (`.dap`) are deprecated and unsupported in DepthAI v3.
  - Use RVC2 peripheral mode or OAK Apps on RVC4 instead.
  - Python APIs for creating, saving, and flashing standalone applications now display deprecation warnings.

- **User Experience**
  - The Device Manager Application tab now displays a prominent warning about unsupported RVC2 standalone applications.

- **Testing**
  - BOM coverage now includes OAK4 Lite USB and PoE device models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->