### PR TITLE
Add calibrated panorama stitching

### DIFF
--- a/bindings/python/src/beta/node/StitchingBindings.cpp
+++ b/bindings/python/src/beta/node/StitchingBindings.cpp
@@ -64,6 +64,7 @@ void bind_beta_stitching(pybind11::module& m, void* pCallstack) {
 
     stitchingProperties.def_readwrite("mode", &StitchingProperties::mode)
         .def_readwrite("cameraModel", &StitchingProperties::cameraModel)
+        .def_readwrite("useInputCalibration", &StitchingProperties::useInputCalibration)
         .def_readwrite("continuous", &StitchingProperties::continuous)
         .def_readwrite("estimationFrames", &StitchingProperties::estimationFrames)
         .def_readwrite("maxPanoramaWidth", &StitchingProperties::maxPanoramaWidth)
@@ -116,6 +117,11 @@ void bind_beta_stitching(pybind11::module& m, void* pCallstack) {
         .def("getMinIncidenceAngle", &Stitching::getMinIncidenceAngle, DOC(dai, beta, node, Stitching, getMinIncidenceAngle))
         .def("setCameraModel", &Stitching::setCameraModel, py::arg("model"), DOC(dai, beta, node, Stitching, setCameraModel))
         .def("getCameraModel", &Stitching::getCameraModel, DOC(dai, beta, node, Stitching, getCameraModel))
+        .def("setUseInputCalibration",
+             &Stitching::setUseInputCalibration,
+             py::arg("useInputCalibration"),
+             DOC(dai, beta, node, Stitching, setUseInputCalibration))
+        .def("getUseInputCalibration", &Stitching::getUseInputCalibration, DOC(dai, beta, node, Stitching, getUseInputCalibration))
         .def("setContinuous", &Stitching::setContinuous, py::arg("continuous"), DOC(dai, beta, node, Stitching, setContinuous))
         .def("getContinuous", &Stitching::getContinuous, DOC(dai, beta, node, Stitching, getContinuous))
         .def("setEstimationFrames", &Stitching::setEstimationFrames, py::arg("frames"), DOC(dai, beta, node, Stitching, setEstimationFrames))

--- a/bindings/python/tests/beta_stitching_test.py
+++ b/bindings/python/tests/beta_stitching_test.py
@@ -11,3 +11,7 @@ def test_stitching_is_exposed_only_through_beta_api():
         assert isinstance(stitching, dai.beta.node.Stitching)
         assert stitching.getNumInputs() == 2
         assert stitching.getMode() == dai.beta.node.Stitching.Mode.PANORAMA
+        assert not stitching.getUseInputCalibration()
+
+        stitching.setUseInputCalibration(True)
+        assert stitching.getUseInputCalibration()

--- a/bindings/python/tests/beta_stitching_test.py
+++ b/bindings/python/tests/beta_stitching_test.py
@@ -1,7 +1,7 @@
 import depthai as dai
 
 
-def test_stitching_is_exposed_only_through_beta_api():
+def test_stitching_beta_api_and_input_calibration_configuration():
     assert not hasattr(dai.node, "Stitching")
     assert dai.beta.node.Stitching.Properties is dai.beta.StitchingProperties
 

--- a/include/depthai/beta/node/Stitching.hpp
+++ b/include/depthai/beta/node/Stitching.hpp
@@ -183,6 +183,23 @@ class Stitching : public DeviceNodeCRTP<BetaNode, Stitching, StitchingProperties
     CameraModel getCameraModel() const;
 
     /**
+     * Use the intrinsics and rotations carried by the input ImgTransformations to compose a panorama.
+     *
+     * All inputs must be expressed relative to exactly the same destination device ID and camera socket. Translation
+     * is ignored, so all camera centers are treated as coincident. When enabled, panorama composition starts from the
+     * first synchronized group without feature matching or bundle adjustment. With `SeamFinder::NONE`, warped inputs
+     * are copied in order and later inputs replace earlier ones in overlapping regions. Other seam finders enable seam
+     * estimation, exposure compensation, and multiband blending. The prepared composition is reused for subsequent
+     * groups. Only undistorted inputs are accepted. Only used in `Mode::PANORAMA`.
+     */
+    void setUseInputCalibration(bool useInputCalibration);
+
+    /**
+     * Return whether panorama composition uses the calibration carried by the input ImgTransformations.
+     */
+    bool getUseInputCalibration() const;
+
+    /**
      * Re-estimate the camera parameters on every frame. Only used in `Mode::PANORAMA`.
      *
      * When true, registration runs for every synced group, which is slow but tolerates cameras that
@@ -220,6 +237,10 @@ class Stitching : public DeviceNodeCRTP<BetaNode, Stitching, StitchingProperties
     void setPanoConfidenceThreshold(double threshold);
     double getPanoConfidenceThreshold() const;
 
+    /**
+     * Set the panorama seam finder. In calibrated panorama mode, `NONE` selects direct composition; other values also
+     * enable exposure compensation and multiband blending.
+     */
     void setSeamFinder(SeamFinder finder);
     SeamFinder getSeamFinder() const;
 

--- a/include/depthai/beta/node/Stitching.hpp
+++ b/include/depthai/beta/node/Stitching.hpp
@@ -186,11 +186,12 @@ class Stitching : public DeviceNodeCRTP<BetaNode, Stitching, StitchingProperties
      * Use the intrinsics and rotations carried by the input ImgTransformations to compose a panorama.
      *
      * All inputs must be expressed relative to exactly the same destination device ID and camera socket. Translation
-     * is ignored, so all camera centers are treated as coincident. When enabled, panorama composition starts from the
-     * first synchronized group without feature matching or bundle adjustment. With `SeamFinder::NONE`, warped inputs
-     * are copied in order and later inputs replace earlier ones in overlapping regions. Other seam finders enable seam
-     * estimation, exposure compensation, and multiband blending. The prepared composition is reused for subsequent
-     * groups. Only undistorted inputs are accepted. Only used in `Mode::PANORAMA`.
+     * is ignored, so all camera centers are treated as coincident. Cylindrical panoramas use the normalized mean input
+     * camera Y axis as the cylinder axis. When enabled, panorama composition starts from the first synchronized group
+     * without feature matching or bundle adjustment. With `SeamFinder::NONE`, warped inputs are copied in order and
+     * later inputs replace earlier ones in overlapping regions. Other seam finders enable seam estimation, exposure
+     * compensation, and multiband blending. The prepared composition is reused for subsequent groups. Only undistorted
+     * inputs are accepted. Only used in `Mode::PANORAMA`.
      */
     void setUseInputCalibration(bool useInputCalibration);
 

--- a/include/depthai/beta/properties/StitchingProperties.hpp
+++ b/include/depthai/beta/properties/StitchingProperties.hpp
@@ -78,6 +78,8 @@ struct StitchingProperties : PropertiesSerializable<Properties, StitchingPropert
     /// Maximum planar projection range, stored in centimeters.
     float maxRange = 1000.0f;
     float minIncidenceAngle = 5.0f;
+    /// Use the rotations and intrinsics carried by the input frames instead of visually registering a panorama.
+    bool useInputCalibration = false;
 
     ~StitchingProperties() override;
 };
@@ -99,7 +101,8 @@ DEPTHAI_SERIALIZE_EXT(StitchingProperties,
                       maxViewHeight,
                       maxRange,
                       minIncidenceAngle,
-                      numInputs);
+                      numInputs,
+                      useInputCalibration);
 
 }  // namespace beta
 }  // namespace dai

--- a/src/beta/node/Stitching.cpp
+++ b/src/beta/node/Stitching.cpp
@@ -176,6 +176,17 @@ Stitching::CameraModel Stitching::getCameraModel() const {
     return properties.cameraModel;
 }
 
+void Stitching::setUseInputCalibration(bool useInputCalibration) {
+    std::lock_guard<std::mutex> lock(hostPropertiesMutex);
+    properties.useInputCalibration = useInputCalibration;
+    invalidateHostState();
+}
+
+bool Stitching::getUseInputCalibration() const {
+    std::lock_guard<std::mutex> lock(hostPropertiesMutex);
+    return properties.useInputCalibration;
+}
+
 void Stitching::setContinuous(bool continuous) {
     std::lock_guard<std::mutex> lock(hostPropertiesMutex);
     properties.continuous = continuous;

--- a/src/beta/utilities/Stitching/FixedPanoramaCompositor.cpp
+++ b/src/beta/utilities/Stitching/FixedPanoramaCompositor.cpp
@@ -73,20 +73,23 @@ void FixedPanoramaCompositor::prepare(const std::vector<cv::Mat>& images, const 
         cv::Mat mapX;
         cv::Mat mapY;
         source.roi = warper->buildMaps(source.composeInputSize, intrinsics, camera.R, mapX, mapY);
-        cv::convertMaps(mapX, mapY, source.map1, source.map2, CV_16SC2);
+        source.roi.width = mapX.cols;
+        source.roi.height = mapX.rows;
 
         const cv::Mat inputMask(source.composeInputSize, CV_8U, cv::Scalar::all(255));
-        cv::remap(inputMask, source.mask, source.map1, source.map2, cv::INTER_NEAREST, cv::BORDER_CONSTANT);
-        source.seamMask = source.mask.clone();
+        cv::remap(inputMask, source.mask, mapX, mapY, cv::INTER_NEAREST, cv::BORDER_CONSTANT);
+        cv::convertMaps(mapX, mapY, source.map1, source.map2, CV_16SC2);
 
         canvas = sources.empty() ? source.roi : canvas | source.roi;
         sources.push_back(std::move(source));
     }
     DAI_CHECK_V(canvas.width > 0 && canvas.height > 0, "The registered panorama has an empty canvas");
 
-    const auto warped = warp(images);
-    prepareCompositing(warped);
-    blender = stitching::createBlender(canvas.size());
+    if(config.composition == Composition::BLENDED) {
+        const auto warped = warp(images);
+        prepareCompositing(warped);
+        blender = stitching::createBlender(canvas.size());
+    }
     prepared = true;
 }
 
@@ -154,6 +157,15 @@ void FixedPanoramaCompositor::prepareCompositing(const std::vector<cv::Mat>& war
 cv::Mat FixedPanoramaCompositor::compose(const std::vector<cv::Mat>& images) {
     DAI_CHECK_V(prepared, "The fixed panorama compositor was not prepared yet");
     const auto warped = warp(images);
+
+    if(config.composition == Composition::DIRECT) {
+        cv::Mat result = cv::Mat::zeros(canvas.size(), warped.front().type());
+        for(size_t i = 0; i < sources.size(); ++i) {
+            const cv::Point destination = sources[i].roi.tl() - canvas.tl();
+            warped[i].copyTo(result(cv::Rect(destination, warped[i].size())), sources[i].mask);
+        }
+        return result;
+    }
 
     blender->prepare(canvas);
     for(size_t i = 0; i < sources.size(); ++i) {

--- a/src/beta/utilities/Stitching/FixedPanoramaCompositor.hpp
+++ b/src/beta/utilities/Stitching/FixedPanoramaCompositor.hpp
@@ -17,16 +17,19 @@ using node::Stitching;
 /**
  * Composes a panorama whose registered camera geometry does not change.
  *
- * Projection maps, image regions, validity and seam masks, and exposure parameters are prepared from the first image
- * group and reused. Later groups only resize (when requested), remap, compensate and blend.
+ * Projection maps and image regions are prepared once and reused. The compositor can either perform the full seam,
+ * exposure, and blending pipeline or directly copy warped inputs into the panorama.
  */
 class FixedPanoramaCompositor {
    public:
+    enum class Composition { BLENDED, DIRECT };
+
     struct Config {
         Stitching::CameraModel cameraModel = Stitching::CameraModel::SPHERICAL;
         Stitching::SeamFinder seamFinder = Stitching::SeamFinder::GRAPHCUT_COLOR;
         double compositingResolution = -1.0;
         double seamEstimationResolution = 0.1;
+        Composition composition = Composition::BLENDED;
     };
 
     void setConfig(const Config& config);

--- a/src/beta/utilities/Stitching/Stitching.cpp
+++ b/src/beta/utilities/Stitching/Stitching.cpp
@@ -18,6 +18,7 @@
     #include "beta/utilities/Stitching/StitchingCompositing.hpp"
     #include "depthai/pipeline/datatype/ImgFrame.hpp"
     #include "depthai/pipeline/datatype/MessageGroup.hpp"
+    #include "depthai/utility/matrixOps.hpp"
     #include "pipeline/ThreadedNodeImpl.hpp"
     #include "utility/ErrorMacros.hpp"
 
@@ -43,6 +44,13 @@ std::string statusToString(cv::Stitcher::Status status) {
             return "camera parameters adjustment failed";
     }
     return "unknown error";
+}
+
+bool isUndistorted(const ImgTransformation& transformation) {
+    const auto coefficients = transformation.getDistortionCoefficients();
+    return std::all_of(coefficients.begin(), coefficients.end(), [](float coefficient) {
+        return std::isfinite(coefficient) && std::abs(coefficient) <= matrix::MATRIX_EQ_EPSILON;
+    });
 }
 
 /** Decorates OpenCV's matcher and scores a candidate by confidence weighted by geometrically consistent inliers. */
@@ -115,6 +123,7 @@ class Stitching::Impl {
     uint32_t candidatesEvaluated = 0;
     bool transformFixed = false;
     FixedPanoramaCompositor fixedPanorama;
+    std::vector<ImgTransformation> fixedPanoramaTransformations;
     PlanarStitcher planar;
 
     void invalidate() {
@@ -124,6 +133,7 @@ class Stitching::Impl {
         candidatesEvaluated = 0;
         transformFixed = false;
         fixedPanorama.reset();
+        fixedPanoramaTransformations.clear();
         planar.reset();
     }
 
@@ -178,18 +188,106 @@ class Stitching::Impl {
         stitcher->setBlender(stitching::createBlender(panoSizeHint));
     }
 
-    void prepareFixedPanorama(const std::vector<cv::Mat>& images, const StitchingProperties& properties) {
+    void validateInputCalibrationOrigins(const std::vector<ImgTransformation>& transformations) const {
+        DAI_CHECK_V(!transformations.empty(), "Calibrated panorama stitching needs at least one input transformation");
+        DAI_CHECK_V(transformations.front().isValid(), "Calibrated panorama input 0 carries no valid image transformation");
+
+        const auto firstExtrinsics = transformations.front().getExtrinsics();
+        DAI_CHECK_V(!firstExtrinsics.toDeviceId.empty(), "Calibrated panorama stitching needs a destination device ID, but input 0 has none");
+        DAI_CHECK_V(firstExtrinsics.toCameraSocket != CameraBoardSocket::AUTO,
+                    "Calibrated panorama stitching needs a concrete destination camera socket, but input 0 uses AUTO");
+
+        for(size_t i = 0; i < transformations.size(); ++i) {
+            const auto& transformation = transformations[i];
+            DAI_CHECK_V(transformation.isValid(), "Calibrated panorama input {} carries no valid image transformation", i);
+
+            const auto extrinsics = transformation.getExtrinsics();
+            DAI_CHECK_V(extrinsics.toDeviceId == firstExtrinsics.toDeviceId && extrinsics.toCameraSocket == firstExtrinsics.toCameraSocket,
+                        "Calibrated panorama inputs must share one destination coordinate system, but input 0 uses {}/{} and input {} uses {}/{}",
+                        firstExtrinsics.toDeviceId,
+                        toString(firstExtrinsics.toCameraSocket),
+                        i,
+                        extrinsics.toDeviceId,
+                        toString(extrinsics.toCameraSocket));
+        }
+    }
+
+    std::vector<cv::detail::CameraParams> camerasFromInputCalibration(const std::vector<ImgTransformation>& transformations) const {
+        validateInputCalibrationOrigins(transformations);
+
+        std::vector<cv::detail::CameraParams> cameras;
+        cameras.reserve(transformations.size());
+        for(size_t i = 0; i < transformations.size(); ++i) {
+            const auto& transformation = transformations[i];
+            DAI_CHECK_V(isUndistorted(transformation), "Calibrated panorama input {} is distorted; request an undistorted camera output", i);
+            const auto extrinsics = transformation.getExtrinsics();
+            matrix::validateRotationMatrix3x3(extrinsics.rotationMatrix);
+
+            const auto intrinsics = transformation.getIntrinsicMatrix();
+            const float fx = intrinsics[0][0];
+            const float fy = intrinsics[1][1];
+            const float ppx = intrinsics[0][2];
+            const float ppy = intrinsics[1][2];
+            DAI_CHECK_V(std::isfinite(fx) && std::isfinite(fy) && std::isfinite(ppx) && std::isfinite(ppy) && fx > 0.0f && fy > 0.0f,
+                        "Calibrated panorama input {} carries invalid intrinsics",
+                        i);
+
+            cv::detail::CameraParams camera;
+            camera.focal = fx;
+            camera.aspect = fy / fx;
+            camera.ppx = ppx;
+            camera.ppy = ppy;
+            camera.R = cv::Mat(3, 3, CV_32F);
+            for(int row = 0; row < 3; ++row) {
+                for(int column = 0; column < 3; ++column) camera.R.at<float>(row, column) = extrinsics.rotationMatrix[row][column];
+            }
+            camera.t = cv::Mat::zeros(3, 1, CV_64F);
+            cameras.push_back(std::move(camera));
+        }
+        return cameras;
+    }
+
+    void validatePreparedInputCalibration(const std::vector<ImgTransformation>& transformations) const {
+        validateInputCalibrationOrigins(transformations);
+        DAI_CHECK_V(transformations.size() == fixedPanoramaTransformations.size(),
+                    "Calibrated panorama was prepared for {} inputs, but the current group has {}",
+                    fixedPanoramaTransformations.size(),
+                    transformations.size());
+        for(size_t i = 0; i < transformations.size(); ++i) {
+            const auto currentExtrinsics = transformations[i].getExtrinsics();
+            const auto preparedExtrinsics = fixedPanoramaTransformations[i].getExtrinsics();
+            DAI_CHECK_V(isUndistorted(transformations[i])
+                            && matrix::mateq(transformations[i].getIntrinsicMatrix(), fixedPanoramaTransformations[i].getIntrinsicMatrix())
+                            && matrix::mateq(currentExtrinsics.rotationMatrix, preparedExtrinsics.rotationMatrix)
+                            && transformations[i].getSize() == fixedPanoramaTransformations[i].getSize(),
+                        "Calibrated panorama input {} became distorted or changed its intrinsics, rotation, or size after preparation",
+                        i);
+        }
+    }
+
+    void prepareFixedPanorama(const std::vector<cv::Mat>& images,
+                              const std::vector<cv::detail::CameraParams>& cameras,
+                              double registrationScale,
+                              FixedPanoramaCompositor::Composition composition,
+                              const StitchingProperties& properties) {
         FixedPanoramaCompositor::Config config;
         config.cameraModel = properties.cameraModel;
         config.seamFinder = properties.seamFinder;
         config.compositingResolution = stitching::COMPOSITING_RESOLUTION;
         config.seamEstimationResolution = stitching::SEAM_ESTIMATION_RESOLUTION;
+        config.composition = composition;
         fixedPanorama.setConfig(config);
-        fixedPanorama.prepare(images, stitcher->cameras(), stitcher->workScale());
+        fixedPanorama.prepare(images, cameras, registrationScale);
     }
 
-    cv::Size panoramaSize(const std::vector<cv::Mat>& images) const {
-        const auto cameras = stitcher->cameras();
+    void prepareEstimatedPanorama(const std::vector<cv::Mat>& images, const StitchingProperties& properties) {
+        prepareFixedPanorama(images, stitcher->cameras(), stitcher->workScale(), FixedPanoramaCompositor::Composition::BLENDED, properties);
+    }
+
+    cv::Size panoramaSize(const std::vector<cv::Mat>& images,
+                          const std::vector<cv::detail::CameraParams>& cameras,
+                          double registrationScale,
+                          const StitchingProperties& properties) const {
         DAI_CHECK_V(cameras.size() == images.size(), "Stitching camera and image counts differ");
 
         std::vector<double> focals;
@@ -203,8 +301,8 @@ class Stitching::Impl {
         if(stitching::COMPOSITING_RESOLUTION > 0.0) {
             composeScale = std::min(1.0, std::sqrt(stitching::COMPOSITING_RESOLUTION * 1e6 / static_cast<double>(images.front().size().area())));
         }
-        const double composeWorkAspect = composeScale / stitcher->workScale();
-        auto warper = stitcher->warper()->create(static_cast<float>(warpedImageScale * composeWorkAspect));
+        const double composeWorkAspect = composeScale / registrationScale;
+        auto warper = stitching::createWarper(properties.cameraModel)->create(static_cast<float>(warpedImageScale * composeWorkAspect));
 
         cv::Rect canvas;
         for(size_t i = 0; i < images.size(); ++i) {
@@ -221,12 +319,20 @@ class Stitching::Impl {
         return canvas.size();
     }
 
-    bool panoramaFits(const std::vector<cv::Mat>& images, cv::Size& size, const StitchingProperties& properties) const {
+    bool panoramaFits(const std::vector<cv::Mat>& images,
+                      const std::vector<cv::detail::CameraParams>& cameras,
+                      double registrationScale,
+                      cv::Size& size,
+                      const StitchingProperties& properties) const {
         if(properties.maxPanoramaWidth == std::numeric_limits<uint32_t>::max() && properties.maxPanoramaHeight == std::numeric_limits<uint32_t>::max())
             return true;
-        size = panoramaSize(images);
+        size = panoramaSize(images, cameras, registrationScale, properties);
         return size.width > 0 && size.height > 0 && static_cast<uint32_t>(size.width) <= properties.maxPanoramaWidth
                && static_cast<uint32_t>(size.height) <= properties.maxPanoramaHeight;
+    }
+
+    bool estimatedPanoramaFits(const std::vector<cv::Mat>& images, cv::Size& size, const StitchingProperties& properties) const {
+        return panoramaFits(images, stitcher->cameras(), stitcher->workScale(), size, properties);
     }
 };
 
@@ -259,7 +365,9 @@ void Stitching::run() {
             impl->invalidate();
         }
         if(!modeLogged && logger && currentProperties.mode == Mode::PANORAMA) {
-            if(currentProperties.continuous) {
+            if(currentProperties.useInputCalibration) {
+                logger->info("Panorama stitching using input calibration and coincident camera centers");
+            } else if(currentProperties.continuous) {
                 logger->info("Panorama stitching running in continuous estimation mode");
             } else {
                 logger->info("Panorama stitching running in best-of-{} mode; waiting for {} valid candidates before emitting panoramas",
@@ -327,6 +435,55 @@ void Stitching::run() {
             continue;
         }
 
+        if(currentProperties.useInputCalibration) {
+            cv::Mat pano;
+            try {
+                if(!impl->fixedPanorama.isPrepared()) {
+                    const auto cameras = impl->camerasFromInputCalibration(transformations);
+                    cv::Size panoramaSize;
+                    if(!impl->panoramaFits(images, cameras, 1.0, panoramaSize, currentProperties)) {
+                        if(logger) {
+                            logger->debug("Stitching rejected a {}x{} calibrated panorama exceeding the configured {}x{} maximum",
+                                          panoramaSize.width,
+                                          panoramaSize.height,
+                                          currentProperties.maxPanoramaWidth,
+                                          currentProperties.maxPanoramaHeight);
+                        }
+                        continue;
+                    }
+                    const auto composition = currentProperties.seamFinder == SeamFinder::NONE ? FixedPanoramaCompositor::Composition::DIRECT
+                                                                                              : FixedPanoramaCompositor::Composition::BLENDED;
+                    impl->prepareFixedPanorama(images, cameras, 1.0, composition, currentProperties);
+                    impl->fixedPanoramaTransformations = transformations;
+                    if(logger) {
+                        const auto size = impl->fixedPanorama.getCanvasSize();
+                        const auto* compositionName = composition == FixedPanoramaCompositor::Composition::DIRECT ? "direct" : "blended";
+                        logger->info(
+                            "Calibrated panorama composition fixed at {}x{}; reusing warp maps with {} composition", size.width, size.height, compositionName);
+                    }
+                } else {
+                    impl->validatePreparedInputCalibration(transformations);
+                }
+                pano = impl->fixedPanorama.compose(images);
+            } catch(const cv::Exception& e) {
+                if(logger) logger->warn("Calibrated panorama stitching failed: {}", e.what());
+                impl->fixedPanorama.reset();
+                impl->fixedPanoramaTransformations.clear();
+                continue;
+            } catch(const std::exception& e) {
+                if(logger) logger->warn("Calibrated panorama stitching rejected the current input group: {}", e.what());
+                impl->fixedPanorama.reset();
+                impl->fixedPanoramaTransformations.clear();
+                continue;
+            }
+
+            auto stitched = std::make_shared<ImgFrame>();
+            stitched->setCvFrame(pano, ImgFrame::Type::BGR888i);
+            stitched->setBufferMetadataFrom(first);
+            out.send(stitched);
+            continue;
+        }
+
         if(!impl->stitcher) {
             impl->createPanoramaStitcher(cv::Size(images.front().cols * static_cast<int>(images.size()), images.front().rows), currentProperties);
         }
@@ -335,7 +492,7 @@ void Stitching::run() {
         cv::Stitcher::Status status = cv::Stitcher::OK;
         const auto composePanorama = [&](const std::vector<cv::Mat>& contributing) -> std::optional<cv::Stitcher::Status> {
             cv::Size panoramaSize;
-            if(!impl->panoramaFits(contributing, panoramaSize, currentProperties)) {
+            if(!impl->estimatedPanoramaFits(contributing, panoramaSize, currentProperties)) {
                 if(logger) {
                     logger->debug("Stitching rejected a {}x{} panorama exceeding the configured {}x{} maximum",
                                   panoramaSize.width,
@@ -383,7 +540,7 @@ void Stitching::run() {
                     }
 
                     cv::Size candidateSize;
-                    if(!impl->panoramaFits(images, candidateSize, currentProperties)) {
+                    if(!impl->estimatedPanoramaFits(images, candidateSize, currentProperties)) {
                         if(logger) {
                             logger->debug("Stitching rejected a {}x{} panorama exceeding the configured {}x{} maximum",
                                           candidateSize.width,
@@ -403,7 +560,7 @@ void Stitching::run() {
 
                     status = impl->stitcher->setTransform(images, impl->bestCandidate->cameras);
                     if(status == cv::Stitcher::OK) {
-                        impl->prepareFixedPanorama(images, currentProperties);
+                        impl->prepareEstimatedPanorama(images, currentProperties);
                         pano = impl->fixedPanorama.compose(images);
                         impl->transformFixed = true;
                         if(logger) {

--- a/src/beta/utilities/Stitching/Stitching.cpp
+++ b/src/beta/utilities/Stitching/Stitching.cpp
@@ -53,6 +53,43 @@ bool isUndistorted(const ImgTransformation& transformation) {
     });
 }
 
+void alignCamerasToMeanYAxis(std::vector<cv::detail::CameraParams>& cameras) {
+    constexpr double AXIS_EPSILON = 1e-6;
+    DAI_CHECK_V(!cameras.empty(), "Calibrated panorama needs at least one camera to determine its mean Y axis");
+
+    cv::Vec3d meanYAxis(0.0, 0.0, 0.0);
+    for(const auto& camera : cameras) {
+        cv::Mat rotation;
+        camera.R.convertTo(rotation, CV_64F);
+        meanYAxis += cv::Vec3d(rotation.at<double>(0, 1), rotation.at<double>(1, 1), rotation.at<double>(2, 1));
+    }
+    meanYAxis /= static_cast<double>(cameras.size());
+
+    const double meanNorm = cv::norm(meanYAxis);
+    DAI_CHECK_V(meanNorm > AXIS_EPSILON, "Calibrated panorama camera Y axes have no well-defined mean direction");
+    meanYAxis /= meanNorm;
+
+    const cv::Vec3d panoramaYAxis(0.0, 1.0, 0.0);
+    const cv::Vec3d cross = meanYAxis.cross(panoramaYAxis);
+    const double sineSquared = cross.dot(cross);
+    const double cosine = meanYAxis.dot(panoramaYAxis);
+
+    cv::Mat alignment = cv::Mat::eye(3, 3, CV_64F);
+    if(sineSquared > AXIS_EPSILON * AXIS_EPSILON) {
+        const cv::Mat crossMatrix = (cv::Mat_<double>(3, 3) << 0.0, -cross[2], cross[1], cross[2], 0.0, -cross[0], -cross[1], cross[0], 0.0);
+        alignment += crossMatrix + crossMatrix * crossMatrix * ((1.0 - cosine) / sineSquared);
+    } else if(cosine < 0.0) {
+        alignment = (cv::Mat_<double>(3, 3) << 1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0);
+    }
+
+    for(auto& camera : cameras) {
+        cv::Mat rotation;
+        camera.R.convertTo(rotation, CV_64F);
+        const cv::Mat aligned = alignment * rotation;
+        aligned.convertTo(camera.R, CV_32F);
+    }
+}
+
 /** Decorates OpenCV's matcher and scores a candidate by confidence weighted by geometrically consistent inliers. */
 class ScoringFeaturesMatcher : public cv::detail::FeaturesMatcher {
    public:
@@ -439,7 +476,10 @@ void Stitching::run() {
             cv::Mat pano;
             try {
                 if(!impl->fixedPanorama.isPrepared()) {
-                    const auto cameras = impl->camerasFromInputCalibration(transformations);
+                    auto cameras = impl->camerasFromInputCalibration(transformations);
+                    if(currentProperties.cameraModel == CameraModel::CYLINDRICAL) {
+                        alignCamerasToMeanYAxis(cameras);
+                    }
                     cv::Size panoramaSize;
                     if(!impl->panoramaFits(images, cameras, 1.0, panoramaSize, currentProperties)) {
                         if(logger) {

--- a/tests/src/onhost_tests/pipeline/node/stitching_device_node_test.cpp
+++ b/tests/src/onhost_tests/pipeline/node/stitching_device_node_test.cpp
@@ -5,12 +5,14 @@
 TEST_CASE("Stitching accepts deserialized properties", "[Stitching]") {
     auto properties = std::make_unique<dai::beta::StitchingProperties>();
     properties->mode = dai::beta::StitchingProperties::Mode::PLANAR_PROJECTION;
+    properties->useInputCalibration = true;
     properties->maxViewWidth = 1280;
     properties->numInputs = 2;
 
     auto stitching = std::make_shared<dai::beta::node::Stitching>(std::move(properties));
 
     REQUIRE(stitching->properties.mode == dai::beta::StitchingProperties::Mode::PLANAR_PROJECTION);
+    REQUIRE(stitching->getUseInputCalibration());
     REQUIRE(stitching->properties.maxViewWidth == 1280);
     REQUIRE(stitching->getNumInputs() == 2);
     REQUIRE(stitching->inputs.has("input0"));
@@ -32,6 +34,7 @@ TEST_CASE("Stitching serializes as a device node", "[Stitching]") {
     auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(2);
     stitching->setRunOnHost(false);
     stitching->setMode(dai::beta::node::Stitching::Mode::PLANAR_PROJECTION);
+    stitching->setUseInputCalibration(true);
     stitching->setPlane({1.0f, 2.0f, 3.0f}, {0.0f, 1.0f, 0.0f}, dai::LengthUnit::METER);
     stitching->setMaxViewSize(1280, 720);
     stitching->setMaxRange(4.0f, dai::LengthUnit::METER);
@@ -43,6 +46,7 @@ TEST_CASE("Stitching serializes as a device node", "[Stitching]") {
     dai::beta::StitchingProperties properties;
     REQUIRE(dai::utility::deserialize(serialized, properties));
     REQUIRE(properties.mode == dai::beta::node::Stitching::Mode::PLANAR_PROJECTION);
+    REQUIRE(properties.useInputCalibration);
     REQUIRE(properties.numInputs == 2);
     REQUIRE(properties.plane.has_value());
     REQUIRE(properties.plane->point.x == 1.0f);

--- a/tests/src/onhost_tests/pipeline/node/stitching_node_test.cpp
+++ b/tests/src/onhost_tests/pipeline/node/stitching_node_test.cpp
@@ -41,6 +41,29 @@ std::shared_ptr<dai::ImgFrame> toFrame(const cv::Mat& image, int64_t sequenceNum
     return frame;
 }
 
+dai::ImgTransformation calibratedTransformation(double yawDegrees,
+                                                const std::string& originDeviceId = "reference-device",
+                                                std::vector<float> distortionCoefficients = {}) {
+    const double yaw = yawDegrees * CV_PI / 180.0;
+    const std::vector<std::vector<float>> rotation = {
+        {static_cast<float>(std::cos(yaw)), 0.0f, static_cast<float>(std::sin(yaw))},
+        {0.0f, 1.0f, 0.0f},
+        {static_cast<float>(-std::sin(yaw)), 0.0f, static_cast<float>(std::cos(yaw))},
+    };
+    // Deliberately different centers: calibrated panorama mode must ignore translation.
+    dai::Extrinsics extrinsics(rotation, {static_cast<float>(yawDegrees), 50.0f, -25.0f}, dai::CameraBoardSocket::CAM_A);
+    extrinsics.toDeviceId = originDeviceId;
+    const std::array<std::array<float, 3>, 3> intrinsics = {
+        {{static_cast<float>(FOCAL), 0.0f, VIEW_WIDTH / 2.0f}, {0.0f, static_cast<float>(FOCAL), VIEW_HEIGHT / 2.0f}, {0.0f, 0.0f, 1.0f}}};
+    return {VIEW_WIDTH, VIEW_HEIGHT, intrinsics, dai::CameraModel::Perspective, std::move(distortionCoefficients), extrinsics};
+}
+
+std::shared_ptr<dai::ImgFrame> toCalibratedFrame(const cv::Mat& image, double yawDegrees, int64_t sequenceNum) {
+    auto frame = toFrame(image, sequenceNum);
+    frame->getTransformation() = calibratedTransformation(yawDegrees);
+    return frame;
+}
+
 }  // namespace
 
 TEST_CASE("Stitching rejects fewer than two inputs", "[Stitching]") {
@@ -55,6 +78,250 @@ TEST_CASE("Stitching stitches panoramas by default", "[Stitching]") {
     auto stitching = pipeline.create<dai::beta::node::Stitching>();
 
     REQUIRE(stitching->getMode() == dai::beta::node::Stitching::Mode::PANORAMA);
+}
+
+TEST_CASE("Stitching uses input calibration to compose a cylindrical panorama", "[Stitching]") {
+    const std::vector<double> yaws = {-15.0, 0.0, 15.0};
+    const std::vector<cv::Mat> featurelessViews = {
+        cv::Mat(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(40, 60, 80)),
+        cv::Mat(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(80, 60, 40)),
+        cv::Mat(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(60, 80, 40)),
+    };
+
+    dai::Pipeline pipeline(false);
+    auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(featurelessViews.size());
+    stitching->setUseInputCalibration(true);
+    stitching->setCameraModel(dai::beta::node::Stitching::CameraModel::CYLINDRICAL);
+    stitching->setSeamFinder(dai::beta::node::Stitching::SeamFinder::NONE);
+    stitching->setSyncThreshold(std::chrono::seconds(1));
+    REQUIRE(stitching->getUseInputCalibration());
+
+    std::vector<std::shared_ptr<dai::InputQueue>> inputQueues;
+    for(size_t i = 0; i < featurelessViews.size(); ++i) {
+        inputQueues.push_back(stitching->inputs["input" + std::to_string(i)].createInputQueue());
+    }
+    auto output = stitching->out.createOutputQueue();
+
+    pipeline.start();
+    for(size_t i = 0; i < featurelessViews.size(); ++i) {
+        inputQueues[i]->send(toCalibratedFrame(featurelessViews[i], yaws[i], 11));
+    }
+
+    bool timedOut = false;
+    auto panorama = output->get<dai::ImgFrame>(std::chrono::seconds(2), timedOut);
+    pipeline.stop();
+
+    REQUIRE_FALSE(timedOut);
+    REQUIRE(panorama != nullptr);
+    REQUIRE(panorama->getSequenceNum() == 11);
+    REQUIRE(panorama->getWidth() > static_cast<unsigned int>(VIEW_WIDTH));
+    REQUIRE(panorama->getWidth() < static_cast<unsigned int>(2 * VIEW_WIDTH));
+    REQUIRE(panorama->getHeight() >= static_cast<unsigned int>(VIEW_HEIGHT * 0.95));
+    REQUIRE(panorama->getHeight() <= static_cast<unsigned int>(VIEW_HEIGHT));
+}
+
+TEST_CASE("Calibrated panorama directly copies overlapping inputs", "[Stitching]") {
+    const cv::Vec3b firstColor(20, 40, 60);
+    const cv::Vec3b secondColor(180, 200, 220);
+    const cv::Mat firstImage(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, firstColor);
+    const cv::Mat secondImage(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, secondColor);
+
+    dai::Pipeline pipeline(false);
+    auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(2);
+    stitching->setUseInputCalibration(true);
+    stitching->setCameraModel(dai::beta::node::Stitching::CameraModel::CYLINDRICAL);
+    stitching->setSeamFinder(dai::beta::node::Stitching::SeamFinder::NONE);
+    stitching->setSyncThreshold(std::chrono::seconds(1));
+
+    auto firstInput = stitching->inputs["input0"].createInputQueue();
+    auto secondInput = stitching->inputs["input1"].createInputQueue();
+    auto output = stitching->out.createOutputQueue();
+
+    pipeline.start();
+    firstInput->send(toCalibratedFrame(firstImage, 0.0, 12));
+    secondInput->send(toCalibratedFrame(secondImage, 0.0, 12));
+
+    bool timedOut = false;
+    auto panorama = output->get<dai::ImgFrame>(std::chrono::seconds(2), timedOut);
+    pipeline.stop();
+
+    REQUIRE_FALSE(timedOut);
+    REQUIRE(panorama != nullptr);
+    const auto result = panorama->getCvFrame();
+    REQUIRE(result.at<cv::Vec3b>(result.rows / 2, result.cols / 2) == secondColor);
+}
+
+TEST_CASE("Calibrated panorama blends overlapping inputs when seam finding is enabled", "[Stitching]") {
+    const cv::Vec3b firstColor(20, 40, 60);
+    const cv::Vec3b secondColor(180, 200, 220);
+    const cv::Mat firstImage(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, firstColor);
+    const cv::Mat secondImage(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, secondColor);
+
+    dai::Pipeline pipeline(false);
+    auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(2);
+    stitching->setUseInputCalibration(true);
+    stitching->setCameraModel(dai::beta::node::Stitching::CameraModel::CYLINDRICAL);
+    stitching->setSeamFinder(dai::beta::node::Stitching::SeamFinder::GRAPHCUT_COLOR);
+    stitching->setSyncThreshold(std::chrono::seconds(1));
+
+    auto firstInput = stitching->inputs["input0"].createInputQueue();
+    auto secondInput = stitching->inputs["input1"].createInputQueue();
+    auto output = stitching->out.createOutputQueue();
+
+    pipeline.start();
+    firstInput->send(toCalibratedFrame(firstImage, 0.0, 14));
+    secondInput->send(toCalibratedFrame(secondImage, 0.0, 14));
+
+    bool timedOut = false;
+    auto panorama = output->get<dai::ImgFrame>(std::chrono::seconds(2), timedOut);
+    pipeline.stop();
+
+    REQUIRE_FALSE(timedOut);
+    REQUIRE(panorama != nullptr);
+    const auto result = panorama->getCvFrame();
+    const auto center = result.at<cv::Vec3b>(result.rows / 2, result.cols / 2);
+    REQUIRE(center != firstColor);
+    REQUIRE(center != secondColor);
+}
+
+TEST_CASE("Calibrated cylindrical panorama masks inputs crossing the wrap boundary", "[Stitching]") {
+    const cv::Vec3b referenceColor(20, 80, 140);
+    const cv::Vec3b wrappedColor(180, 100, 40);
+    const cv::Mat referenceImage(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, referenceColor);
+    const cv::Mat wrappedImage(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, wrappedColor);
+
+    dai::Pipeline pipeline(false);
+    auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(2);
+    stitching->setUseInputCalibration(true);
+    stitching->setCameraModel(dai::beta::node::Stitching::CameraModel::CYLINDRICAL);
+    stitching->setSeamFinder(dai::beta::node::Stitching::SeamFinder::NONE);
+    stitching->setSyncThreshold(std::chrono::seconds(1));
+
+    auto referenceInput = stitching->inputs["input0"].createInputQueue();
+    auto wrappedInput = stitching->inputs["input1"].createInputQueue();
+    auto output = stitching->out.createOutputQueue();
+
+    pipeline.start();
+    referenceInput->send(toCalibratedFrame(referenceImage, 0.0, 13));
+    wrappedInput->send(toCalibratedFrame(wrappedImage, 170.0, 13));
+
+    bool timedOut = false;
+    auto panorama = output->get<dai::ImgFrame>(std::chrono::seconds(2), timedOut);
+    pipeline.stop();
+
+    REQUIRE_FALSE(timedOut);
+    REQUIRE(panorama != nullptr);
+    const auto result = panorama->getCvFrame();
+    REQUIRE(result.at<cv::Vec3b>(result.rows / 2, result.cols / 2) == referenceColor);
+}
+
+TEST_CASE("Calibrated panorama rejects camera geometry changes after preparation", "[Stitching]") {
+    const cv::Mat image(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(40, 60, 80));
+
+    dai::Pipeline pipeline(false);
+    auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(2);
+    stitching->setUseInputCalibration(true);
+    stitching->setSyncThreshold(std::chrono::seconds(1));
+
+    auto firstInput = stitching->inputs["input0"].createInputQueue();
+    auto secondInput = stitching->inputs["input1"].createInputQueue();
+    auto output = stitching->out.createOutputQueue();
+
+    pipeline.start();
+    firstInput->send(toCalibratedFrame(image, -10.0, 20));
+    secondInput->send(toCalibratedFrame(image, 10.0, 20));
+
+    bool timedOut = false;
+    auto panorama = output->get<dai::ImgFrame>(std::chrono::seconds(2), timedOut);
+    REQUIRE_FALSE(timedOut);
+    REQUIRE(panorama != nullptr);
+
+    firstInput->send(toCalibratedFrame(image, -10.0, 21));
+    secondInput->send(toCalibratedFrame(image, 15.0, 21));
+    panorama = output->get<dai::ImgFrame>(std::chrono::milliseconds(200), timedOut);
+    pipeline.stop();
+
+    REQUIRE(timedOut);
+    REQUIRE(panorama == nullptr);
+}
+
+TEST_CASE("Calibrated panorama rejects distorted inputs", "[Stitching]") {
+    const cv::Mat image(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(40, 60, 80));
+
+    dai::Pipeline pipeline(false);
+    auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(2);
+    stitching->setUseInputCalibration(true);
+    stitching->setSyncThreshold(std::chrono::seconds(1));
+
+    auto firstInput = stitching->inputs["input0"].createInputQueue();
+    auto secondInput = stitching->inputs["input1"].createInputQueue();
+    auto output = stitching->out.createOutputQueue();
+
+    auto distorted = toCalibratedFrame(image, 10.0, 30);
+    distorted->getTransformation() = calibratedTransformation(10.0, "reference-device", {0.1f, 0.0f, 0.0f, 0.0f});
+
+    pipeline.start();
+    firstInput->send(toCalibratedFrame(image, -10.0, 30));
+    secondInput->send(distorted);
+
+    bool timedOut = false;
+    auto panorama = output->get<dai::ImgFrame>(std::chrono::milliseconds(200), timedOut);
+    pipeline.stop();
+
+    REQUIRE(timedOut);
+    REQUIRE(panorama == nullptr);
+}
+
+TEST_CASE("Calibrated panorama rejects inputs with different destination origins", "[Stitching]") {
+    const cv::Mat image(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(40, 60, 80));
+
+    dai::Pipeline pipeline(false);
+    auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(2);
+    stitching->setUseInputCalibration(true);
+    stitching->setSeamFinder(dai::beta::node::Stitching::SeamFinder::NONE);
+    stitching->setSyncThreshold(std::chrono::seconds(1));
+
+    auto firstInput = stitching->inputs["input0"].createInputQueue();
+    auto secondInput = stitching->inputs["input1"].createInputQueue();
+    auto output = stitching->out.createOutputQueue();
+
+    pipeline.start();
+    firstInput->send(toCalibratedFrame(image, -10.0, 0));
+    auto mismatched = toCalibratedFrame(image, 10.0, 0);
+    auto mismatchedTransformation = calibratedTransformation(10.0);
+    auto mismatchedExtrinsics = mismatchedTransformation.getExtrinsics();
+    SECTION("device ID") {
+        mismatchedExtrinsics.toDeviceId = "different-device";
+    }
+    SECTION("camera socket") {
+        mismatchedExtrinsics.toCameraSocket = dai::CameraBoardSocket::CAM_B;
+    }
+    mismatchedTransformation.setExtrinsics(mismatchedExtrinsics);
+    mismatched->getTransformation() = mismatchedTransformation;
+    secondInput->send(mismatched);
+
+    bool timedOut = false;
+    auto panorama = output->get<dai::ImgFrame>(std::chrono::milliseconds(200), timedOut);
+    REQUIRE(timedOut);
+    REQUIRE(panorama == nullptr);
+
+    firstInput->send(toCalibratedFrame(image, -10.0, 1));
+    secondInput->send(toCalibratedFrame(image, 10.0, 1));
+    panorama = output->get<dai::ImgFrame>(std::chrono::seconds(2), timedOut);
+    REQUIRE_FALSE(timedOut);
+    REQUIRE(panorama != nullptr);
+    REQUIRE(panorama->getSequenceNum() == 1);
+
+    firstInput->send(toCalibratedFrame(image, -10.0, 2));
+    auto changedOrigin = toCalibratedFrame(image, 10.0, 2);
+    auto changedTransformation = calibratedTransformation(10.0, "changed-after-preparation");
+    changedOrigin->getTransformation() = changedTransformation;
+    secondInput->send(changedOrigin);
+    panorama = output->get<dai::ImgFrame>(std::chrono::milliseconds(200), timedOut);
+    pipeline.stop();
+
+    REQUIRE(timedOut);
+    REQUIRE(panorama == nullptr);
 }
 
 TEST_CASE("Stitching combines three rotated views into a wider panorama", "[Stitching]") {

--- a/tests/src/onhost_tests/pipeline/node/stitching_node_test.cpp
+++ b/tests/src/onhost_tests/pipeline/node/stitching_node_test.cpp
@@ -43,12 +43,18 @@ std::shared_ptr<dai::ImgFrame> toFrame(const cv::Mat& image, int64_t sequenceNum
 
 dai::ImgTransformation calibratedTransformation(double yawDegrees,
                                                 const std::string& originDeviceId = "reference-device",
-                                                std::vector<float> distortionCoefficients = {}) {
+                                                std::vector<float> distortionCoefficients = {},
+                                                double rigPitchDegrees = 0.0) {
     const double yaw = yawDegrees * CV_PI / 180.0;
+    const double pitch = rigPitchDegrees * CV_PI / 180.0;
+    const double cosYaw = std::cos(yaw);
+    const double sinYaw = std::sin(yaw);
+    const double cosPitch = std::cos(pitch);
+    const double sinPitch = std::sin(pitch);
     const std::vector<std::vector<float>> rotation = {
-        {static_cast<float>(std::cos(yaw)), 0.0f, static_cast<float>(std::sin(yaw))},
-        {0.0f, 1.0f, 0.0f},
-        {static_cast<float>(-std::sin(yaw)), 0.0f, static_cast<float>(std::cos(yaw))},
+        {static_cast<float>(cosYaw), 0.0f, static_cast<float>(sinYaw)},
+        {static_cast<float>(sinPitch * sinYaw), static_cast<float>(cosPitch), static_cast<float>(-sinPitch * cosYaw)},
+        {static_cast<float>(-cosPitch * sinYaw), static_cast<float>(sinPitch), static_cast<float>(cosPitch * cosYaw)},
     };
     // Deliberately different centers: calibrated panorama mode must ignore translation.
     dai::Extrinsics extrinsics(rotation, {static_cast<float>(yawDegrees), 50.0f, -25.0f}, dai::CameraBoardSocket::CAM_A);
@@ -58,10 +64,41 @@ dai::ImgTransformation calibratedTransformation(double yawDegrees,
     return {VIEW_WIDTH, VIEW_HEIGHT, intrinsics, dai::CameraModel::Perspective, std::move(distortionCoefficients), extrinsics};
 }
 
-std::shared_ptr<dai::ImgFrame> toCalibratedFrame(const cv::Mat& image, double yawDegrees, int64_t sequenceNum) {
+std::shared_ptr<dai::ImgFrame> toCalibratedFrame(const cv::Mat& image, double yawDegrees, int64_t sequenceNum, double rigPitchDegrees = 0.0) {
     auto frame = toFrame(image, sequenceNum);
-    frame->getTransformation() = calibratedTransformation(yawDegrees);
+    frame->getTransformation() = calibratedTransformation(yawDegrees, "reference-device", {}, rigPitchDegrees);
     return frame;
+}
+
+cv::Mat composeCalibratedCylindricalPanorama(const std::vector<cv::Mat>& images, const std::vector<double>& yaws, const std::vector<double>& pitches) {
+    REQUIRE(images.size() == yaws.size());
+    REQUIRE(images.size() == pitches.size());
+
+    dai::Pipeline pipeline(false);
+    auto stitching = pipeline.create<dai::beta::node::Stitching>()->build(images.size());
+    stitching->setUseInputCalibration(true);
+    stitching->setCameraModel(dai::beta::node::Stitching::CameraModel::CYLINDRICAL);
+    stitching->setSeamFinder(dai::beta::node::Stitching::SeamFinder::NONE);
+    stitching->setSyncThreshold(std::chrono::seconds(1));
+
+    std::vector<std::shared_ptr<dai::InputQueue>> inputs;
+    inputs.reserve(images.size());
+    for(size_t i = 0; i < images.size(); ++i) {
+        inputs.push_back(stitching->inputs["input" + std::to_string(i)].createInputQueue());
+    }
+    auto output = stitching->out.createOutputQueue();
+
+    pipeline.start();
+    for(size_t i = 0; i < images.size(); ++i) {
+        inputs[i]->send(toCalibratedFrame(images[i], yaws[i], 1, pitches[i]));
+    }
+    bool timedOut = false;
+    auto panorama = output->get<dai::ImgFrame>(std::chrono::seconds(2), timedOut);
+    pipeline.stop();
+
+    REQUIRE_FALSE(timedOut);
+    REQUIRE(panorama != nullptr);
+    return panorama->getCvFrame();
 }
 
 }  // namespace
@@ -118,6 +155,29 @@ TEST_CASE("Stitching uses input calibration to compose a cylindrical panorama", 
     REQUIRE(panorama->getWidth() < static_cast<unsigned int>(2 * VIEW_WIDTH));
     REQUIRE(panorama->getHeight() >= static_cast<unsigned int>(VIEW_HEIGHT * 0.95));
     REQUIRE(panorama->getHeight() <= static_cast<unsigned int>(VIEW_HEIGHT));
+}
+
+TEST_CASE("Calibrated cylindrical panorama uses the mean camera Y axis", "[Stitching]") {
+    const std::vector<double> yaws = {-30.0, -15.0, 0.0, 15.0, 30.0};
+    const std::vector<double> levelRigPitches = {-10.0, -5.0, 0.0, 5.0, 10.0};
+    const std::vector<double> pitchedRigPitches = {10.0, 15.0, 20.0, 25.0, 30.0};
+    const std::vector<cv::Mat> views = {
+        cv::Mat(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(20, 40, 60)),
+        cv::Mat(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(50, 70, 90)),
+        cv::Mat(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(80, 100, 120)),
+        cv::Mat(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(110, 130, 150)),
+        cv::Mat(VIEW_HEIGHT, VIEW_WIDTH, CV_8UC3, cv::Scalar(140, 160, 180)),
+    };
+
+    const auto levelRig = composeCalibratedCylindricalPanorama(views, yaws, levelRigPitches);
+    const auto pitchedRig = composeCalibratedCylindricalPanorama(views, yaws, pitchedRigPitches);
+
+    // These symmetric pitch offsets have mean Y aligned with panorama Y. This expected canvas
+    // distinguishes mean-axis alignment from aligning the cylinder to any individual camera.
+    REQUIRE(levelRig.size() == cv::Size(1288, 716));
+    REQUIRE(pitchedRig.size() == levelRig.size());
+    const double meanAbsoluteDifference = cv::norm(pitchedRig, levelRig, cv::NORM_L1) / static_cast<double>(pitchedRig.total() * pitchedRig.channels());
+    REQUIRE(meanAbsoluteDifference < 1e-3);
 }
 
 TEST_CASE("Calibrated panorama directly copies overlapping inputs", "[Stitching]") {

--- a/tests/src/onhost_tests/pipeline/node/stitching_node_test.cpp
+++ b/tests/src/onhost_tests/pipeline/node/stitching_node_test.cpp
@@ -172,9 +172,11 @@ TEST_CASE("Calibrated cylindrical panorama uses the mean camera Y axis", "[Stitc
     const auto levelRig = composeCalibratedCylindricalPanorama(views, yaws, levelRigPitches);
     const auto pitchedRig = composeCalibratedCylindricalPanorama(views, yaws, pitchedRigPitches);
 
-    // These symmetric pitch offsets have mean Y aligned with panorama Y. This expected canvas
-    // distinguishes mean-axis alignment from aligning the cylinder to any individual camera.
-    REQUIRE(levelRig.size() == cv::Size(1288, 716));
+    // These symmetric pitch offsets have mean Y aligned with panorama Y. OpenCV determines the
+    // cylindrical canvas from a variable ROI, so only require non-empty, bounded geometry here.
+    REQUIRE_FALSE(levelRig.empty());
+    REQUIRE(levelRig.cols <= static_cast<int>(views.size()) * VIEW_WIDTH);
+    REQUIRE(levelRig.rows <= static_cast<int>(views.size()) * VIEW_HEIGHT);
     REQUIRE(pitchedRig.size() == levelRig.size());
     const double meanAbsoluteDifference = cv::norm(pitchedRig, levelRig, cv::NORM_L1) / static_cast<double>(pitchedRig.total() * pitchedRig.channels());
     REQUIRE(meanAbsoluteDifference < 1e-3);


### PR DESCRIPTION
Adds a new calibrated panorama stitching mode through setUseInputCalibration(true).

When enabled, stitching:
- Uses camera intrinsics and rotations from each input frame.
- Skips feature matching.
- Treats camera centers as coincident and ignores translation.
- Reuses the prepared panorama geometry for subsequent frames.
- Aligns cylindrical panoramas around the mean Y-axis of all cameras instead of the first camera.
- Supports the existing seam finding, exposure compensation, and blending options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to create panoramas using calibration data from input frames.
  - Added support for direct composition or full seam, exposure, and blending processing.
  - Improved cylindrical panorama alignment and reuse of calibration information.
- **Bug Fixes**
  - Improved handling of warped image dimensions and masks during panorama composition.
  - Added validation to reject incompatible camera geometry, distortion, frame sizes, and synchronization.
- **Tests**
  - Expanded coverage for calibration-based stitching, serialization, blending, overlap handling, and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->