### PR TITLE
Scheduled weekly stability runs & develop wheel builds

### DIFF
--- a/.github/workflows/hil_testing_schedule_develop.yml
+++ b/.github/workflows/hil_testing_schedule_develop.yml
@@ -30,8 +30,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f protocol=tcpip -f timeout=168
-          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f protocol=usb -f timeout=168
+          WHEEL_RUN_ID=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow python-main.yml --branch develop --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+          if [[ -z "$WHEEL_RUN_ID" ]]; then
+            echo "No successful develop Python workflow found"
+            exit 1
+          fi
+          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f wheel_run_id="$WHEEL_RUN_ID" -f protocol=tcpip -f timeout=168
+          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f wheel_run_id="$WHEEL_RUN_ID" -f protocol=usb -f timeout=168
 
       - name: Trigger nightly develop HIL testing
         if: github.event.schedule == '0 1 * * *'

--- a/.github/workflows/hil_testing_schedule_develop.yml
+++ b/.github/workflows/hil_testing_schedule_develop.yml
@@ -3,8 +3,8 @@ name: DepthAI Core HIL Testing Develop Schedule
 on:
   schedule:
     - cron: '0 1 * * *' # Every day at 01:00 UTC
-    - cron: '0 21 * * 5' # Fridays at 21:00 UTC
     - cron: '0 3 * * 6' # Saturdays at 03:00 UTC
+    - cron: '0 3 * * 0' # Sundays at 03:00 UTC
 
 permissions:
   actions: write
@@ -19,24 +19,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run hil_testing_weekly.yml --repo "$GITHUB_REPOSITORY" --ref develop
 
-      - name: Trigger weekly Python CI/CD (wheels build)
-        if: github.event.schedule == '0 21 * * 5'
+      - name: Trigger weekly Python wheels and stability
+        if: github.event.schedule == '0 3 * * 0'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run python-main.yml --repo "$GITHUB_REPOSITORY" --ref develop
-
-      - name: Trigger weekly stability runs
-        if: github.event.schedule == '0 3 * * 6'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          WHEEL_RUN_ID=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow python-main.yml --branch develop --status success --limit 1 --json databaseId --jq '.[0].databaseId')
-          if [[ -z "$WHEEL_RUN_ID" ]]; then
-            echo "No successful develop Python workflow found"
-            exit 1
-          fi
-          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f wheel_run_id="$WHEEL_RUN_ID" -f protocol=tcpip -f timeout=168
-          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f wheel_run_id="$WHEEL_RUN_ID" -f protocol=usb -f timeout=168
+        run: gh workflow run weekly_stability.yml --repo "$GITHUB_REPOSITORY" --ref develop
 
       - name: Trigger nightly develop HIL testing
         if: github.event.schedule == '0 1 * * *'

--- a/.github/workflows/hil_testing_schedule_develop.yml
+++ b/.github/workflows/hil_testing_schedule_develop.yml
@@ -3,6 +3,7 @@ name: DepthAI Core HIL Testing Develop Schedule
 on:
   schedule:
     - cron: '0 1 * * *' # Every day at 01:00 UTC
+    - cron: '0 21 * * 5' # Fridays at 21:00 UTC
     - cron: '0 3 * * 6' # Saturdays at 03:00 UTC
 
 permissions:
@@ -17,6 +18,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run hil_testing_weekly.yml --repo "$GITHUB_REPOSITORY" --ref develop
+
+      - name: Trigger weekly Python CI/CD (wheels build)
+        if: github.event.schedule == '0 21 * * 5'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run python-main.yml --repo "$GITHUB_REPOSITORY" --ref develop
+
+      - name: Trigger weekly stability runs
+        if: github.event.schedule == '0 3 * * 6'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f protocol=tcpip -f timeout=168
+          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f protocol=usb -f timeout=168
 
       - name: Trigger nightly develop HIL testing
         if: github.event.schedule == '0 1 * * *'

--- a/.github/workflows/python-main.yml
+++ b/.github/workflows/python-main.yml
@@ -2,10 +2,16 @@ name: Depthai Python CI/CD
 
 # Controls when the action will run. Triggers the workflow on push
 concurrency:
-  group: depthai-python-${{ github.event.pull_request.number || github.ref }}
+  group: depthai-python-${{ github.event.pull_request.number || github.ref }}-${{ inputs.concurrency_suffix || 'default' }}
   cancel-in-progress: true
 
 on:
+  workflow_call:
+    inputs:
+      concurrency_suffix:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/stability.workflow.yml
+++ b/.github/workflows/stability.workflow.yml
@@ -23,6 +23,18 @@ on:
         type: string
         default: "latest"
         description: "Version for depthai"
+      protocol:
+        required: false
+        type: choice
+        default: "tcpip"
+        options:
+          - tcpip
+          - usb
+        description: "Connect to the device over PoE (tcpip) or USB"
+      timeout:
+        required: false
+        type: string
+        description: "Stop the stability test after this many hours; unlimited when omitted"
 
 
 jobs:
@@ -50,11 +62,11 @@ jobs:
           if [[ -n "${{ github.event.inputs.reservation_name }}" ]]; then
             RESERVATION_OPTION="--reservation-name ${{ github.event.inputs.reservation_name }}"
           else
-            export RESERVATION_NAME="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID#rvc4-depthai-stability"
+            export RESERVATION_NAME="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID#rvc4-depthai-stability-${{ github.event.inputs.protocol }}"
             RESERVATION_OPTION="--reservation-name $RESERVATION_NAME"
           fi
           if [[ -n  "${{ github.event.inputs.luxonis_os }}" ]]; then
             UPDATE_LUXONIS_OS="--rvc4-os-version ${{ github.event.inputs.luxonis_os }}"
           fi
 
-          exec hil $HOLD_RESERVATION --models "oak4_pro or oak4_d" $TESTBED_OPTION $RESERVATION_OPTION $UPDATE_LUXONIS_OS --wait --sync-workspace --stability-test --stability-name depthai-stability --commands 'cd /tmp/depthai-core || exit' 'scripts/hil/run_hil_stability.sh ${{ github.event.inputs.depthai  }}'
+          exec hil $HOLD_RESERVATION --models "oak4_pro or oak4_d" $TESTBED_OPTION $RESERVATION_OPTION $UPDATE_LUXONIS_OS --wait --sync-workspace --stability-test --stability-name depthai-stability-${{ github.event.inputs.protocol }} --commands 'cd /tmp/depthai-core || exit' 'scripts/hil/run_hil_stability.sh ${{ github.event.inputs.depthai }} ${{ github.event.inputs.protocol }} ${{ github.event.inputs.timeout }}'

--- a/.github/workflows/stability.workflow.yml
+++ b/.github/workflows/stability.workflow.yml
@@ -35,7 +35,14 @@ on:
         required: false
         type: string
         description: "Stop the stability test after this many hours; unlimited when omitted"
+      wheel_run_id:
+        required: false
+        type: string
+        description: "Workflow run containing the Python wheel artifact"
 
+permissions:
+  actions: read
+  contents: read
 
 jobs:
   id:
@@ -53,8 +60,26 @@ jobs:
 
     - uses: actions/checkout@v3
 
+    - name: Download Python wheel
+      if: github.event.inputs.wheel_run_id != ''
+      uses: actions/download-artifact@v4
+      with:
+        name: audited-wheels-combined-linux-x86_64
+        path: stability-wheels
+        github-token: ${{ github.token }}
+        run-id: ${{ github.event.inputs.wheel_run_id }}
+
     - name: Test
+      env:
+        INPUT_DEPTHAI_VERSION: ${{ github.event.inputs.depthai }}
+        INPUT_PROTOCOL: ${{ github.event.inputs.protocol }}
+        INPUT_TIMEOUT: ${{ github.event.inputs.timeout }}
       run: |
+          if [[ -n "$INPUT_TIMEOUT" ]] && ! python3 -c 'import math, sys; value = float(sys.argv[1]); raise SystemExit(0 if math.isfinite(value) and value > 0 else 1)' "$INPUT_TIMEOUT" 2>/dev/null; then
+            echo "::error::timeout must be a positive finite number"
+            exit 1
+          fi
+
           source scripts/hil/prepare_hil_framework.sh ${{ secrets.HIL_PAT_TOKEN }}
           if [[ -n "${{ github.event.inputs.testbed }}" ]]; then
             TESTBED_OPTION="--testbed ${{ github.event.inputs.testbed }}"
@@ -69,4 +94,5 @@ jobs:
             UPDATE_LUXONIS_OS="--rvc4-os-version ${{ github.event.inputs.luxonis_os }}"
           fi
 
-          exec hil $HOLD_RESERVATION --models "oak4_pro or oak4_d" $TESTBED_OPTION $RESERVATION_OPTION $UPDATE_LUXONIS_OS --wait --sync-workspace --stability-test --stability-name depthai-stability-${{ github.event.inputs.protocol }} --commands 'cd /tmp/depthai-core || exit' 'scripts/hil/run_hil_stability.sh ${{ github.event.inputs.depthai }} ${{ github.event.inputs.protocol }} ${{ github.event.inputs.timeout }}'
+          printf -v STABILITY_COMMAND 'scripts/hil/run_hil_stability.sh %q %q %q %q' "$INPUT_DEPTHAI_VERSION" "$INPUT_PROTOCOL" "$INPUT_TIMEOUT" stability-wheels
+          exec hil $HOLD_RESERVATION --models "oak4_pro or oak4_d" $TESTBED_OPTION $RESERVATION_OPTION $UPDATE_LUXONIS_OS --wait --sync-workspace --stability-test --stability-name depthai-stability-${{ github.event.inputs.protocol }} --commands 'cd /tmp/depthai-core || exit' "$STABILITY_COMMAND"

--- a/.github/workflows/stability.workflow.yml
+++ b/.github/workflows/stability.workflow.yml
@@ -87,7 +87,7 @@ jobs:
           if [[ -n "${{ github.event.inputs.reservation_name }}" ]]; then
             RESERVATION_OPTION="--reservation-name ${{ github.event.inputs.reservation_name }}"
           else
-            export RESERVATION_NAME="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID#rvc4-depthai-stability-${{ github.event.inputs.protocol }}"
+            export RESERVATION_NAME="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID#rvc4-depthai-stability-$INPUT_PROTOCOL"
             RESERVATION_OPTION="--reservation-name $RESERVATION_NAME"
           fi
           if [[ -n  "${{ github.event.inputs.luxonis_os }}" ]]; then
@@ -95,4 +95,4 @@ jobs:
           fi
 
           printf -v STABILITY_COMMAND 'scripts/hil/run_hil_stability.sh %q %q %q %q' "$INPUT_DEPTHAI_VERSION" "$INPUT_PROTOCOL" "$INPUT_TIMEOUT" stability-wheels
-          exec hil $HOLD_RESERVATION --models "oak4_pro or oak4_d" $TESTBED_OPTION $RESERVATION_OPTION $UPDATE_LUXONIS_OS --wait --sync-workspace --stability-test --stability-name depthai-stability-${{ github.event.inputs.protocol }} --commands 'cd /tmp/depthai-core || exit' "$STABILITY_COMMAND"
+          exec hil $HOLD_RESERVATION --models "oak4_pro or oak4_d" $TESTBED_OPTION $RESERVATION_OPTION $UPDATE_LUXONIS_OS --wait --sync-workspace --stability-test --stability-name "depthai-stability-$INPUT_PROTOCOL" --commands 'cd /tmp/depthai-core || exit' "$STABILITY_COMMAND"

--- a/.github/workflows/weekly_stability.yml
+++ b/.github/workflows/weekly_stability.yml
@@ -1,0 +1,27 @@
+name: Weekly Python Wheels and Stability
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  build_wheels:
+    uses: ./.github/workflows/python-main.yml
+    with:
+      concurrency_suffix: weekly-stability
+    secrets: inherit
+
+  dispatch_stability:
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger weekly stability runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WHEEL_RUN_ID: ${{ github.run_id }}
+        run: |
+          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f wheel_run_id="$WHEEL_RUN_ID" -f protocol=tcpip -f timeout=168
+          gh workflow run stability.workflow.yml --repo "$GITHUB_REPOSITORY" --ref develop -f wheel_run_id="$WHEEL_RUN_ID" -f protocol=usb -f timeout=168

--- a/scripts/hil/run_hil_stability.sh
+++ b/scripts/hil/run_hil_stability.sh
@@ -5,8 +5,15 @@ DEPTHAI_VERSION="$1"
 
 RELEASE_URL="https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/"
 SNAPSHOT_URL="https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/"
+WHEEL_DIR="$4"
 
-if [ -z "$DEPTHAI_VERSION" ] || [ "$DEPTHAI_VERSION" == "latest" ]; then
+if [ -d "$WHEEL_DIR" ]; then
+    echo "Installing depthai from $WHEEL_DIR"
+    rm -rf venv
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install --no-cache-dir "$WHEEL_DIR"/*.whl
+elif [ -z "$DEPTHAI_VERSION" ] || [ "$DEPTHAI_VERSION" == "latest" ]; then
     echo "Using latest depthai"
     source /home/hil/.hil/bin/activate
 else

--- a/scripts/hil/run_hil_stability.sh
+++ b/scripts/hil/run_hil_stability.sh
@@ -18,6 +18,12 @@ else
 fi
 
 export DEPTHAI_PLATFORM=rvc4
+export DEPTHAI_PROTOCOL="${2:-tcpip}"
 export DISPLAY=:99
 
-python tests/stability/stability_test_depthai.py
+TIMEOUT_ARGS=()
+if [[ -n "$3" ]]; then
+    TIMEOUT_ARGS=(--timeout "$3")
+fi
+
+python tests/stability/stability_test_depthai.py "${TIMEOUT_ARGS[@]}"

--- a/tests/stability/stability_test_depthai.py
+++ b/tests/stability/stability_test_depthai.py
@@ -183,4 +183,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--timeout", type=float, help="Stop the stability-test loop after this many hours")
     args = parser.parse_args()
+    if args.timeout is not None and (not math.isfinite(args.timeout) or args.timeout <= 0):
+        parser.error("--timeout must be a positive finite number")
     stability_test(30, args.timeout)

--- a/tests/stability/stability_test_depthai.py
+++ b/tests/stability/stability_test_depthai.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 import depthai as dai
+import argparse
 import time
 from typing import List, Dict
 import datetime
-import sys
 import math
 
 MEMORY_LEAK_DETECTION_THRESHOLD = 1.05
@@ -20,7 +20,7 @@ def calculate_latency_jitter(latencies: List[float]) -> float:
     return math.sqrt(variance)
 
 
-def stability_test(fps):
+def stability_test(fps, timeoutHours=None):
     # Creates the pipeline and a default device implicitly
     with dai.Pipeline() as p:
         # Define sources and outputs
@@ -142,7 +142,8 @@ def stability_test(fps):
         time.sleep(10)
         initialProcessMemoryUsage = p.getDefaultDevice().getProcessMemoryUsage()
         print(f"Initial depthai-device process memory usage is: {initialProcessMemoryUsage} kB")
-        while True:
+        loopStart = time.monotonic()
+        while timeoutHours is None or time.monotonic() - loopStart < timeoutHours * 60 * 60:
             for name, queue in benchmarkReportQueues.items():
                 report = queue.get(timeout=datetime.timedelta(minutes=1)) # 1 minute timeout
                 if report is None:
@@ -173,10 +174,13 @@ def stability_test(fps):
 
             # Detect memory leaks
             processMemoryUsage = p.getDefaultDevice().getProcessMemoryUsage()
-            #if processMemoryUsage > MEMORY_LEAK_DETECTION_THRESHOLD * initialProcessMemoryUsage:
-            #    raise RuntimeError("Memory used by depthai-device process increased above the given threshold - potential memory leak detected")
+            if processMemoryUsage > MEMORY_LEAK_DETECTION_THRESHOLD * initialProcessMemoryUsage:
+                raise RuntimeError("Memory used by depthai-device process increased above the given threshold - potential memory leak detected")
             print(f"Memory used by depthai-device process: {processMemoryUsage} kB. Current time: {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())}")
             print(f"Running for {datetime.timedelta(seconds=time.time() - tStart)}", flush=True)
 
 if __name__ == "__main__":
-    stability_test(30)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--timeout", type=float, help="Stop the stability-test loop after this many hours")
+    args = parser.parse_args()
+    stability_test(30, args.timeout)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
This PR adds weekly schedules stability runs, which last for a week. It also adds weekly python wheels building for develop branch.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Codex

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stability tests can now run over TCP/IP or USB connections.
  * Stability test runs support an optional duration limit.
  * Stability testing can use specified Python wheel builds.
  * Automated weekly runs now build wheels and launch protocol-specific stability tests.
  * Stability workflows can be triggered with custom concurrency suffixes.

* **Bug Fixes**
  * Memory leak detection is now active during stability testing and reports failures when thresholds are exceeded.
  * Invalid or non-positive test timeout values are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->