### PR TITLE
Readme link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DepthAI Library
 
 [![Forum](https://img.shields.io/badge/Forum-discuss-orange)](https://discuss.luxonis.com/)
-[![Docs](https://img.shields.io/badge/Docs-DepthAI_API-yellow)](https://stg.docs.luxonis.com/software/v3/)
+[![Docs](https://img.shields.io/badge/Docs-DepthAI_API-yellow)](https://docs.luxonis.com/software-v3/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 DepthAI library for interfacing with Luxonis DepthAI hardware. It's written in C++ and offers Python bindings out of the box.
@@ -189,7 +189,7 @@ cmake --build build
 
 To integrate into a different build system than CMake, the preferred way is to compile as a dynamic library and set the correct build options.
 1. First build as dynamic library: [Building Dynamic library](#dynamic-library)
-2. Then install: [Installing](#installing)
+2. Then install: [Installing](#installation-and-integration)
 
 In your non-CMake project (new Visual Studio project, ...)
 1. Set needed library directories:

--- a/V2V3PortinGuide.md
+++ b/V2V3PortinGuide.md
@@ -114,7 +114,7 @@ monoOut = mono.requestOutput((1280, 720), type=dai.ImgFrame.Type.GRAY8)
 ## Porting the old `ImageManip` to the new API
 
 The new API tracks every transformation in sequence and separates *how* the final image is resized.
-See the [official documentation](https://docs.luxonis.com/software/v3/depthai-components/nodes/image_manip/) for full details.
+See the [official documentation](https://docs.luxonis.com/software-v3/depthai/depthai-components/nodes/image_manip/) for full details.
 
 ### v2 example
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # DepthAI Examples
 
-For more information about the examples, please refer to the [DepthAI documentation](https://stg.docs.luxonis.com/software/v3/examples/).
+For more information about the examples, please refer to the [DepthAI documentation](https://docs.luxonis.com/software-v3/depthai/examples/).
 ## Supported platforms
 The examples are now split into three categories:
 * In the root directory of examples, there are the examples that are supported on both RVC2 and RVC4 platforms devices


### PR DESCRIPTION
Fixes some of the README.md links:

- `README.md` docs badge: `https://stg.docs.luxonis.com/software/v3/` -> `https://docs.luxonis.com/software-v3/`
- `README.md` anchor: `#installing` -> `#installation-and-integration`
- `examples/README.md`: `https://stg.docs.luxonis.com/software/v3/examples/` -> `https://docs.luxonis.com/software-v3/depthai/examples/`
- `V2V3PortinGuide.md`: `https://docs.luxonis.com/software/v3/depthai-components/nodes/image_manip/` -> `https://docs.luxonis.com/software-v3/depthai/depthai-components/nodes/image_manip/`